### PR TITLE
Fix session restore and in-app signup flow

### DIFF
--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -3,9 +3,7 @@ use std::ops::Not;
 use makepad_widgets::*;
 use url::Url;
 
-use crate::sliding_sync::{
-    submit_async_request, LoginByPassword, LoginRequest, MatrixRequest, RegisterAccount,
-};
+use crate::sliding_sync::{submit_async_request, LoginByPassword, LoginRequest, MatrixRequest, RegisterAccount};
 
 use super::login_status_modal::{LoginStatusModalAction, LoginStatusModalWidgetExt};
 
@@ -62,7 +60,7 @@ script_mod! {
             show_bg: true,
             draw_bg.color: (COLOR_SECONDARY)
             // draw_bg.color: (COLOR_PRIMARY) // TODO: once Makepad supports `Fill {max: 375}`, change this back to COLOR_PRIMARY
-
+   
             // allow the view to be scrollable but hide the actual scroll bar
             scroll_bars: {
                 scroll_bar_y: {
@@ -169,7 +167,7 @@ script_mod! {
                             LineH { draw_bg.color: #C8C8C8 }
                         }
                     }
-
+                    
 
                     login_button := RobrixIconButton {
                         width: 275,
@@ -261,7 +259,7 @@ script_mod! {
 
                         LineH { draw_bg.color: #C8C8C8 }
                     }
-
+                    
                     mode_toggle_button := RobrixIconButton {
                         width: Fit, height: Fit
                         padding: Inset{left: 15, right: 15, top: 10, bottom: 10}
@@ -288,75 +286,44 @@ script_mod! {
 
 #[derive(Script, ScriptHook, Widget)]
 pub struct LoginScreen {
-    #[source]
-    source: ScriptObjectRef,
-    #[deref]
-    view: View,
+    #[source] source: ScriptObjectRef,
+    #[deref] view: View,
     /// Whether the screen is showing the in-app sign-up flow.
-    #[rust]
-    signup_mode: bool,
+    #[rust] signup_mode: bool,
     /// Boolean to indicate if the SSO login process is still in flight
-    #[rust]
-    sso_pending: bool,
+    #[rust] sso_pending: bool,
     /// The URL to redirect to after logging in with SSO.
-    #[rust]
-    sso_redirect_url: Option<String>,
+    #[rust] sso_redirect_url: Option<String>,
     /// The most recent login failure message shown to the user.
-    #[rust]
-    last_failure_message_shown: Option<String>,
+    #[rust] last_failure_message_shown: Option<String>,
 }
 
 impl LoginScreen {
     fn set_signup_mode(&mut self, cx: &mut Cx, signup_mode: bool) {
         self.signup_mode = signup_mode;
-        self.view
-            .view(cx, ids!(confirm_password_wrapper))
-            .set_visible(cx, signup_mode);
-        self.view
-            .view(cx, ids!(login_only_view))
-            .set_visible(cx, !signup_mode);
-        self.view.label(cx, ids!(title)).set_text(
-            cx,
-            if signup_mode {
-                "Create your Robrix account"
-            } else {
-                "Login to Robrix"
-            },
+        self.view.view(cx, ids!(confirm_password_wrapper)).set_visible(cx, signup_mode);
+        self.view.view(cx, ids!(login_only_view)).set_visible(cx, !signup_mode);
+        self.view.label(cx, ids!(title)).set_text(cx,
+            if signup_mode { "Create your Robrix account" } else { "Login to Robrix" }
         );
-        self.view.button(cx, ids!(login_button)).set_text(
-            cx,
-            if signup_mode {
-                "Create account"
-            } else {
-                "Login"
-            },
+        self.view.button(cx, ids!(login_button)).set_text(cx,
+            if signup_mode { "Create account" } else { "Login" }
         );
-        self.view.label(cx, ids!(account_prompt_label)).set_text(
-            cx,
-            if signup_mode {
-                "Already have an account?"
-            } else {
-                "Don't have an account?"
-            },
+        self.view.label(cx, ids!(account_prompt_label)).set_text(cx,
+            if signup_mode { "Already have an account?" } else { "Don't have an account?" }
         );
-        self.view.button(cx, ids!(mode_toggle_button)).set_text(
-            cx,
-            if signup_mode {
-                "Back to login"
-            } else {
-                "Sign up here"
-            },
+        self.view.button(cx, ids!(mode_toggle_button)).set_text(cx,
+            if signup_mode { "Back to login" } else { "Sign up here" }
         );
 
         if !signup_mode {
-            self.view
-                .text_input(cx, ids!(confirm_password_input))
-                .set_text(cx, "");
+            self.view.text_input(cx, ids!(confirm_password_input)).set_text(cx, "");
         }
 
         self.redraw(cx);
     }
 }
+
 
 impl Widget for LoginScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
@@ -379,9 +346,7 @@ impl MatchEvent for LoginScreen {
         let homeserver_input = self.view.text_input(cx, ids!(homeserver_input));
 
         let login_status_modal = self.view.modal(cx, ids!(login_status_modal));
-        let login_status_modal_inner = self
-            .view
-            .login_status_modal(cx, ids!(login_status_modal_inner));
+        let login_status_modal_inner = self.view.login_status_modal(cx, ids!(login_status_modal_inner));
 
         if mode_toggle_button.clicked(actions) {
             self.set_signup_mode(cx, !self.signup_mode);
@@ -407,21 +372,15 @@ impl MatchEvent for LoginScreen {
                 login_status_modal_inner.button_ref(cx).set_text(cx, "Okay");
             } else if self.signup_mode && password != confirm_password {
                 login_status_modal_inner.set_title(cx, "Passwords do not match");
-                login_status_modal_inner.set_status(
-                    cx,
-                    "Please enter the same password in both password fields.",
-                );
+                login_status_modal_inner.set_status(cx, "Please enter the same password in both password fields.");
                 login_status_modal_inner.button_ref(cx).set_text(cx, "Okay");
             } else {
                 self.last_failure_message_shown = None;
-                login_status_modal_inner.set_title(
-                    cx,
-                    if self.signup_mode {
-                        "Creating account..."
-                    } else {
-                        "Logging in..."
-                    },
-                );
+                login_status_modal_inner.set_title(cx, if self.signup_mode {
+                    "Creating account..."
+                } else {
+                    "Logging in..."
+                });
                 login_status_modal_inner.set_status(
                     cx,
                     if self.signup_mode {
@@ -430,9 +389,7 @@ impl MatchEvent for LoginScreen {
                         "Waiting for a login response..."
                     },
                 );
-                login_status_modal_inner
-                    .button_ref(cx)
-                    .set_text(cx, "Cancel");
+                login_status_modal_inner.button_ref(cx).set_text(cx, "Cancel");
                 submit_async_request(MatrixRequest::Login(if self.signup_mode {
                     LoginRequest::Register(RegisterAccount {
                         user_id,
@@ -450,14 +407,14 @@ impl MatchEvent for LoginScreen {
             login_status_modal.open(cx);
             self.redraw(cx);
         }
-
+        
         let provider_brands = ["apple", "facebook", "github", "gitlab", "google", "twitter"];
         let button_set: &[&[LiveId]] = ids_array!(
-            apple_button,
-            facebook_button,
-            github_button,
-            gitlab_button,
-            google_button,
+            apple_button, 
+            facebook_button, 
+            github_button, 
+            gitlab_button, 
+            google_button, 
             twitter_button
         );
         for action in actions {
@@ -467,17 +424,16 @@ impl MatchEvent for LoginScreen {
 
             // Handle login-related actions received from background async tasks.
             match action.downcast_ref() {
-                Some(LoginAction::CliAutoLogin {
-                    user_id,
-                    homeserver,
-                }) => {
+                Some(LoginAction::CliAutoLogin { user_id, homeserver }) => {
                     self.last_failure_message_shown = None;
                     user_id_input.set_text(cx, user_id);
                     password_input.set_text(cx, "");
                     homeserver_input.set_text(cx, homeserver.as_deref().unwrap_or_default());
                     login_status_modal_inner.set_title(cx, "Logging in via CLI...");
-                    login_status_modal_inner
-                        .set_status(cx, &format!("Auto-logging in as user {user_id}..."));
+                    login_status_modal_inner.set_status(
+                        cx,
+                        &format!("Auto-logging in as user {user_id}...")
+                    );
                     let login_status_modal_button = login_status_modal_inner.button_ref(cx);
                     login_status_modal_button.set_text(cx, "Cancel");
                     login_status_modal_button.set_enabled(cx, false); // Login cancel not yet supported
@@ -510,14 +466,11 @@ impl MatchEvent for LoginScreen {
                         continue;
                     }
                     self.last_failure_message_shown = Some(error.clone());
-                    login_status_modal_inner.set_title(
-                        cx,
-                        if self.signup_mode {
-                            "Account Creation Failed."
-                        } else {
-                            "Login Failed."
-                        },
-                    );
+                    login_status_modal_inner.set_title(cx, if self.signup_mode {
+                        "Account Creation Failed."
+                    } else {
+                        "Login Failed."
+                    });
                     login_status_modal_inner.set_status(cx, error);
                     let login_status_modal_button = login_status_modal_inner.button_ref(cx);
                     login_status_modal_button.set_text(cx, "Okay");
@@ -527,15 +480,9 @@ impl MatchEvent for LoginScreen {
                 }
                 Some(LoginAction::SsoPending(pending)) => {
                     let mask = if *pending { 1.0 } else { 0.0 };
-                    let cursor = if *pending {
-                        MouseCursor::NotAllowed
-                    } else {
-                        MouseCursor::Hand
-                    };
+                    let cursor = if *pending { MouseCursor::NotAllowed } else { MouseCursor::Hand };
                     for view_ref in self.view_set(cx, button_set).iter() {
-                        let Some(mut view_mut) = view_ref.borrow_mut() else {
-                            continue;
-                        };
+                        let Some(mut view_mut) = view_ref.borrow_mut() else { continue };
                         let mut image = view_mut.image(cx, ids!(image));
                         script_apply_eval!(cx, image, {
                             draw_bg.mask: #(mask)
@@ -548,7 +495,7 @@ impl MatchEvent for LoginScreen {
                 Some(LoginAction::SsoSetRedirectUrl(url)) => {
                     self.sso_redirect_url = Some(url.to_string());
                 }
-                _ => {}
+                _ => { }
             }
         }
 
@@ -557,10 +504,7 @@ impl MatchEvent for LoginScreen {
             let login_status_modal_button = login_status_modal_inner.button_ref(cx);
             if login_status_modal_button.clicked(actions) {
                 let request_id = id!(SSO_CANCEL_BUTTON);
-                let request = HttpRequest::new(
-                    format!("{}/?login_token=", sso_redirect_url),
-                    HttpMethod::GET,
-                );
+                let request = HttpRequest::new(format!("{}/?login_token=",sso_redirect_url), HttpMethod::GET);
                 cx.http_request(request_id, request);
                 self.sso_redirect_url = None;
             }
@@ -569,14 +513,15 @@ impl MatchEvent for LoginScreen {
         // Handle any of the SSO login buttons being clicked
         for (view_ref, brand) in self.view_set(cx, button_set).iter().zip(&provider_brands) {
             if view_ref.finger_up(actions).is_some() && !self.sso_pending {
-                submit_async_request(MatrixRequest::SpawnSSOServer {
-                    identity_provider_id: format!("oidc-{}", brand),
+                submit_async_request(MatrixRequest::SpawnSSOServer{
+                    identity_provider_id: format!("oidc-{}",brand),
                     brand: brand.to_string(),
-                    homeserver_url: homeserver_input.text(),
+                    homeserver_url: homeserver_input.text()
                 });
             }
         }
     }
+
 }
 
 /// Actions sent to or from the login screen.
@@ -587,7 +532,10 @@ pub enum LoginAction {
     /// A negative response from the backend Matrix task to the login screen.
     LoginFailure(String),
     /// A login-related status message to display to the user.
-    Status { title: String, status: String },
+    Status {
+        title: String,
+        status: String,
+    },
     /// The given login info was specified on the command line (CLI),
     /// and the login process is underway.
     CliAutoLogin {
@@ -598,9 +546,9 @@ pub enum LoginAction {
     /// informing it that the SSO login process is either still in flight (`true`) or has finished (`false`).
     ///
     /// Note that an inner value of `false` does *not* imply that the login request has
-    /// successfully finished.
+    /// successfully finished. 
     /// The login screen can use this to prevent the user from submitting
-    /// additional SSO login requests while a previous request is in flight.
+    /// additional SSO login requests while a previous request is in flight. 
     SsoPending(bool),
     /// Set the SSO redirect URL in the LoginScreen.
     ///

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -6,11 +6,15 @@ use makepad_widgets::{log, warning, Cx};
 use matrix_sdk::{
     authentication::matrix::MatrixSession,
     ruma::{OwnedUserId, UserId},
-    sliding_sync, Client,
+    sliding_sync,
+    Client,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{app_data_dir, login::login_screen::LoginAction};
+use crate::{
+    app_data_dir,
+    login::login_screen::LoginAction,
+};
 
 /// The data needed to re-build a client.
 #[derive(Clone, Serialize, Deserialize)]
@@ -53,11 +57,11 @@ pub struct FullSessionPersisted {
     pub sync_token: Option<String>,
 
     /// The sliding sync version to use for this client session.
-    ///
+    /// 
     /// This determines the sync protocol used by the Matrix client:
     /// - `Native`: Uses the server's native sliding sync implementation for efficient syncing
     /// - `None`: Falls back to standard Matrix sync (without sliding sync optimizations)
-    ///
+    /// 
     /// The value is restored and applied to the client via `client.set_sliding_sync_version()`
     /// when rebuilding the session from persistent storage.
     #[serde(default)]
@@ -89,7 +93,9 @@ impl From<sliding_sync::Version> for SlidingSyncVersion {
 }
 
 fn user_id_to_file_name(user_id: &UserId) -> String {
-    user_id.as_str().replace(":", "_").replace("@", "")
+    user_id.as_str()
+        .replace(":", "_")
+        .replace("@", "")
 }
 
 /// Returns the path to the persistent state directory for the given user.
@@ -108,12 +114,14 @@ const LATEST_USER_ID_FILE_NAME: &str = "latest_user_id.txt";
 
 /// Returns the user ID of the most recently-logged in user session.
 pub async fn most_recent_user_id() -> Option<OwnedUserId> {
-    tokio::fs::read_to_string(app_data_dir().join(LATEST_USER_ID_FILE_NAME))
-        .await
-        .ok()?
-        .trim()
-        .try_into()
-        .ok()
+    tokio::fs::read_to_string(
+        app_data_dir().join(LATEST_USER_ID_FILE_NAME)
+    )
+    .await
+    .ok()?
+    .trim()
+    .try_into()
+    .ok()
 }
 
 /// Save which user was the most recently logged in.
@@ -121,17 +129,17 @@ async fn save_latest_user_id(user_id: &UserId) -> anyhow::Result<()> {
     tokio::fs::write(
         app_data_dir().join(LATEST_USER_ID_FILE_NAME),
         user_id.as_str(),
-    )
-    .await?;
+    ).await?;
     Ok(())
 }
+
 
 /// Restores the given user's previous session from the filesystem.
 ///
 /// If no User ID is specified, the ID of the most recently-logged in user
 /// is retrieved from the filesystem.
 pub async fn restore_session(
-    user_id: Option<OwnedUserId>,
+    user_id: Option<OwnedUserId>
 ) -> anyhow::Result<(Client, Option<String>)> {
     let user_id = if let Some(user_id) = user_id {
         Some(user_id)
@@ -157,12 +165,8 @@ pub async fn restore_session(
 
     // The session was serialized as JSON in a file.
     let serialized_session = tokio::fs::read_to_string(session_file).await?;
-    let FullSessionPersisted {
-        client_session,
-        user_session,
-        sync_token,
-        sliding_sync_version,
-    } = serde_json::from_str(&serialized_session)?;
+    let FullSessionPersisted { client_session, user_session, sync_token, sliding_sync_version } =
+        serde_json::from_str(&serialized_session)?;
 
     let status_str = format!(
         "Loaded session file for:\n{user_id}\n\nTrying to connect to homeserver...\n{}",
@@ -185,10 +189,7 @@ pub async fn restore_session(
         .await?;
     let sliding_sync_version = sliding_sync_version.into();
     client.set_sliding_sync_version(sliding_sync_version);
-    let status_str = format!(
-        "Authenticating previous login session for {}...",
-        user_session.meta.user_id
-    );
+    let status_str = format!("Authenticating previous login session for {}...", user_session.meta.user_id);
     log!("{status_str}");
     Cx::post_action(LoginAction::Status {
         title: "Authenticating session".into(),
@@ -225,7 +226,7 @@ pub async fn save_session(
         client_session,
         user_session,
         sync_token: None,
-        sliding_sync_version,
+        sliding_sync_version
     })?;
     if let Some(parent) = session_file.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -237,17 +238,16 @@ pub async fn save_session(
 }
 
 /// Remove the LATEST_USER_ID_FILE_NAME file if it exists
-///
+/// 
 /// Returns:
 /// - Ok(true) if file was found and deleted
 /// - Ok(false) if file didn't exist
 /// - Err if deletion failed
 pub async fn delete_latest_user_id() -> anyhow::Result<bool> {
     let last_login_path = app_data_dir().join(LATEST_USER_ID_FILE_NAME);
-
+    
     if last_login_path.exists() {
-        tokio::fs::remove_file(&last_login_path)
-            .await
+        tokio::fs::remove_file(&last_login_path).await
             .map_err(|e| anyhow::anyhow!("Failed to remove latest user file: {e}"))
             .map(|_| true)
     } else {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -8,110 +8,43 @@ use imbl::Vector;
 use makepad_widgets::{error, log, warning, Cx, SignalToUI};
 use matrix_sdk_base::crypto::{DecryptionSettings, TrustRequirement};
 use matrix_sdk::{
-    config::RequestConfig,
-    encryption::EncryptionSettings,
-    event_handler::EventHandlerDropGuard,
-    media::MediaRequestParameters,
-    room::{edit::EditedContent, reply::Reply, IncludeRelations, RelationsOptions, RoomMember},
-    ruma::{
-        api::{
-            Direction,
-            client::{
-                account::register::v3::Request as RegistrationRequest,
-                error::ErrorKind,
-                profile::{AvatarUrl, DisplayName},
-                receipt::create_receipt::v3::ReceiptType,
-                uiaa::{AuthData, AuthType, Dummy},
-            },
-        },
-        events::{
+    config::RequestConfig, encryption::EncryptionSettings, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, RelationsOptions, RoomMember}, ruma::{
+        api::{Direction, client::{
+            account::register::v3::Request as RegistrationRequest,
+            error::ErrorKind,
+            profile::{AvatarUrl, DisplayName},
+            receipt::create_receipt::v3::ReceiptType,
+            uiaa::{AuthData, AuthType, Dummy},
+        }}, events::{
             relation::RelationType,
-            room::{message::RoomMessageEventContent, power_levels::RoomPowerLevels, MediaSource},
-            MessageLikeEventType, StateEventType,
-        },
-        matrix_uri::MatrixId,
-        EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri,
-        OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, uint,
-    },
-    sliding_sync::VersionBuilder,
-    Client, ClientBuildError, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships,
-    RoomState, SessionChange, SuccessorRoom,
+            room::{
+                message::RoomMessageEventContent, power_levels::RoomPowerLevels, MediaSource
+            }, MessageLikeEventType, StateEventType
+        }, matrix_uri::MatrixId, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, uint
+    }, sliding_sync::VersionBuilder, Client, ClientBuildError, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
 };
 use matrix_sdk_ui::{
-    RoomListService, Timeline, encryption_sync_service,
-    room_list_service::{RoomListItem, RoomListLoadingState, SyncIndicator, filters},
-    sync_service::{self, SyncService},
-    timeline::{
-        LatestEventValue, RoomExt, TimelineEventItemId, TimelineFocus, TimelineItem,
-        TimelineReadReceiptTracking, TimelineDetails,
-    },
+    RoomListService, Timeline, encryption_sync_service, room_list_service::{RoomListItem, RoomListLoadingState, SyncIndicator, filters}, sync_service::{self, SyncService}, timeline::{LatestEventValue, RoomExt, TimelineEventItemId, TimelineFocus, TimelineItem, TimelineReadReceiptTracking, TimelineDetails}
 };
 use robius_open::Uri;
 use ruma::{OwnedRoomOrAliasId, RoomId, events::tag::Tags};
 use tokio::{
     runtime::Handle,
-    sync::{
-        broadcast,
-        mpsc::{Sender, UnboundedReceiver, UnboundedSender},
-        watch, Notify,
-    },
-    task::JoinHandle,
-    time::error::Elapsed,
+    sync::{broadcast, mpsc::{Sender, UnboundedReceiver, UnboundedSender}, watch, Notify}, task::JoinHandle, time::error::Elapsed,
 };
 use url::Url;
-use std::{
-    borrow::Cow,
-    cmp::{max, min},
-    future::Future,
-    hash::{BuildHasherDefault, DefaultHasher},
-    iter::Peekable,
-    ops::{Deref, DerefMut, Not},
-    path::Path,
-    sync::{Arc, LazyLock, Mutex},
-    time::Duration,
-};
+use std::{borrow::Cow, cmp::{max, min}, future::Future, hash::{BuildHasherDefault, DefaultHasher}, iter::Peekable, ops::{Deref, DerefMut, Not}, path:: Path, sync::{Arc, LazyLock, Mutex}, time::Duration};
 use std::io;
 use hashbrown::{HashMap, HashSet};
 use crate::{
-    app::AppStateAction,
-    app_data_dir,
-    avatar_cache::AvatarUpdate,
-    event_preview::{
-        BeforeText, TextPreview, text_preview_of_raw_timeline_event, text_preview_of_timeline_item,
-    },
-    home::{
-        add_room::KnockResultAction,
-        invite_screen::{JoinRoomResultAction, LeaveRoomResultAction},
-        link_preview::{LinkPreviewData, LinkPreviewDataNonNumeric, LinkPreviewRateLimitResponse},
-        room_screen::{InviteResultAction, TimelineUpdate},
-        rooms_list::{
-            self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate,
-            enqueue_rooms_list_update,
-        },
-        rooms_list_header::RoomsListHeaderAction,
-        tombstone_footer::SuccessorRoomDetails,
-    },
-    login::login_screen::LoginAction,
-    logout::{
-        logout_confirm_modal::LogoutAction,
-        logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine},
-    },
-    media_cache::{MediaCacheEntry, MediaCacheEntryRef},
-    persistence::{self, ClientSessionPersisted, load_app_state},
-    profile::{
+    app::AppStateAction, app_data_dir, avatar_cache::AvatarUpdate, event_preview::{BeforeText, TextPreview, text_preview_of_raw_timeline_event, text_preview_of_timeline_item}, home::{
+        add_room::KnockResultAction, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::{LinkPreviewData, LinkPreviewDataNonNumeric, LinkPreviewRateLimitResponse}, room_screen::{InviteResultAction, TimelineUpdate}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails
+    }, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state}, profile::{
         user_profile::UserProfile,
         user_profile_cache::{UserProfileUpdate, enqueue_user_profile_update},
-    },
-    room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction},
-    shared::{
-        avatar::AvatarState,
-        html_or_plaintext::MatrixLinkPillState,
-        jump_to_bottom_button::UnreadMessageCount,
-        popup_list::{PopupKind, enqueue_popup_notification},
-    },
-    space_service_sync::space_service_loop,
-    utils::{self, AVATAR_THUMBNAIL_FORMAT, RoomNameId, VecDiff, avatar_from_room_name},
-    verification::add_verification_event_handlers_and_sync_client,
+    }, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{
+        avatar::AvatarState, html_or_plaintext::MatrixLinkPillState, jump_to_bottom_button::UnreadMessageCount, popup_list::{PopupKind, enqueue_popup_notification}
+    }, space_service_sync::space_service_loop, utils::{self, AVATAR_THUMBNAIL_FORMAT, RoomNameId, VecDiff, avatar_from_room_name}, verification::add_verification_event_handlers_and_sync_client
 };
 
 #[derive(Parser, Default)]
@@ -159,8 +92,7 @@ impl From<LoginByPassword> for Cli {
         Self {
             user_id: login.user_id.trim().to_owned(),
             password: login.password,
-            homeserver: login
-                .homeserver
+            homeserver: login.homeserver
                 .map(|homeserver| homeserver.trim().to_owned())
                 .filter(|homeserver| !homeserver.is_empty()),
             proxy: None,
@@ -175,8 +107,7 @@ impl From<RegisterAccount> for Cli {
         Self {
             user_id: registration.user_id.trim().to_owned(),
             password: registration.password,
-            homeserver: registration
-                .homeserver
+            homeserver: registration.homeserver
                 .map(|homeserver| homeserver.trim().to_owned())
                 .filter(|homeserver| !homeserver.is_empty()),
             proxy: None,
@@ -197,8 +128,7 @@ async fn finalize_authenticated_client(
     fallback_user_id: &str,
 ) -> Result<(Client, Option<String>)> {
     if client.matrix_auth().logged_in() {
-        let logged_in_user_id = client
-            .user_id()
+        let logged_in_user_id = client.user_id()
             .map(ToString::to_string)
             .unwrap_or_else(|| fallback_user_id.to_owned());
         log!("Logged in successfully.");
@@ -215,9 +145,7 @@ async fn finalize_authenticated_client(
             "Authentication succeeded for {fallback_user_id}, but the homeserver did not return a login session."
         );
         enqueue_popup_notification(err_msg.clone(), PopupKind::Error, None);
-        enqueue_rooms_list_update(RoomsListUpdate::Status {
-            status: err_msg.clone(),
-        });
+        enqueue_rooms_list_update(RoomsListUpdate::Status { status: err_msg.clone() });
         bail!(err_msg);
     }
 }
@@ -233,8 +161,7 @@ fn registration_localpart(user_id: &str) -> Result<String> {
     }
 
     let localpart = trimmed.trim_start_matches('@');
-    if localpart.is_empty() || localpart.contains(':') || localpart.chars().any(char::is_whitespace)
-    {
+    if localpart.is_empty() || localpart.contains(':') || localpart.chars().any(char::is_whitespace) {
         bail!("Please enter a valid username or full Matrix user ID.");
     }
 
@@ -341,14 +268,9 @@ async fn reset_runtime_state_for_relogin() {
     ALL_JOINED_ROOMS.lock().unwrap().clear();
 
     let on_clear_appstate = Arc::new(Notify::new());
-    Cx::post_action(LogoutAction::ClearAppState {
-        on_clear_appstate: on_clear_appstate.clone(),
-    });
+    Cx::post_action(LogoutAction::ClearAppState { on_clear_appstate: on_clear_appstate.clone() });
 
-    if tokio::time::timeout(Duration::from_secs(5), on_clear_appstate.notified())
-        .await
-        .is_err()
-    {
+    if tokio::time::timeout(Duration::from_secs(5), on_clear_appstate.notified()).await.is_err() {
         warning!("Timed out waiting for UI-side app state cleanup during re-login reset");
     }
 }
@@ -359,6 +281,7 @@ fn is_invalid_token_http_error(error: &matrix_sdk::HttpError) -> bool {
         Some(ErrorKind::UnknownToken { .. } | ErrorKind::MissingToken)
     )
 }
+
 
 /// Build a new client.
 async fn build_client(
@@ -382,13 +305,11 @@ async fn build_client(
     };
 
     let inferred_homeserver = infer_homeserver_from_user_id(&cli.user_id);
-    let homeserver_url = cli
-        .homeserver
-        .as_deref()
+    let homeserver_url = cli.homeserver.as_deref()
         .filter(|homeserver| !homeserver.trim().is_empty())
         .or(inferred_homeserver.as_deref())
         .unwrap_or("https://matrix-client.matrix.org/");
-    // .unwrap_or("https://matrix.org/");
+        // .unwrap_or("https://matrix.org/");
 
     let mut builder = Client::builder()
         .server_name_or_homeserver_url(homeserver_url)
@@ -416,11 +337,13 @@ async fn build_client(
 
     // Use a 60 second timeout for all requests to the homeserver.
     // Yes, this is a long timeout, but the standard matrix homeserver is often very slow.
-    builder =
-        builder.request_config(RequestConfig::new().timeout(std::time::Duration::from_secs(60)));
+    builder = builder.request_config(
+        RequestConfig::new()
+            .timeout(std::time::Duration::from_secs(60))
+    );
 
     let client = builder.build().await?;
-    let homeserver_url = client.homeserver().to_string();
+    let homeserver_url =  client.homeserver().to_string();
     Ok((
         client,
         ClientSessionPersisted {
@@ -436,7 +359,10 @@ async fn build_client(
 /// This function is used by the login screen to log in to the Matrix server.
 ///
 /// Upon success, this function returns the logged-in client and an optional sync token.
-async fn login(cli: &Cli, login_request: LoginRequest) -> Result<(Client, Option<String>)> {
+async fn login(
+    cli: &Cli,
+    login_request: LoginRequest,
+) -> Result<(Client, Option<String>)> {
     match login_request {
         LoginRequest::LoginByCli | LoginRequest::LoginByPassword(_) => {
             let cli = if let LoginRequest::LoginByPassword(login_by_password) = login_request {
@@ -459,9 +385,7 @@ async fn login(cli: &Cli, login_request: LoginRequest) -> Result<(Client, Option
             if !client.matrix_auth().logged_in() {
                 let err_msg = format!("Failed to login as {}: {:?}", cli.user_id, login_result);
                 enqueue_popup_notification(err_msg.clone(), PopupKind::Error, None);
-                enqueue_rooms_list_update(RoomsListUpdate::Status {
-                    status: err_msg.clone(),
-                });
+                enqueue_rooms_list_update(RoomsListUpdate::Status { status: err_msg.clone() });
                 bail!(err_msg);
             }
             finalize_authenticated_client(client, client_session, &cli.user_id).await
@@ -517,9 +441,7 @@ async fn login(cli: &Cli, login_request: LoginRequest) -> Result<(Client, Option
                     register_result.user_id,
                 );
                 enqueue_popup_notification(err_msg.clone(), PopupKind::Error, None);
-                enqueue_rooms_list_update(RoomsListUpdate::Status {
-                    status: err_msg.clone(),
-                });
+                enqueue_rooms_list_update(RoomsListUpdate::Status { status: err_msg.clone() });
                 bail!(err_msg);
             }
 
@@ -538,6 +460,7 @@ async fn login(cli: &Cli, login_request: LoginRequest) -> Result<(Client, Option
         }
     }
 }
+
 
 /// Which direction to paginate in.
 ///
@@ -607,6 +530,7 @@ pub type OnLinkPreviewFetchedFn = fn(
     Option<crossbeam_channel::Sender<TimelineUpdate>>,
 );
 
+
 /// Actions emitted in response to a [`MatrixRequest::GenerateMatrixLink`].
 #[derive(Clone, Debug)]
 pub enum MatrixLinkAction {
@@ -637,7 +561,9 @@ pub enum DirectMessageRoomAction {
         room_name_id: RoomNameId,
     },
     /// A direct message room didn't exist, and we didn't attempt to create a new one.
-    DidNotExist { user_profile: UserProfile },
+    DidNotExist {
+        user_profile: UserProfile,
+    },
     /// A direct message room didn't exist, but we successfully created a new one.
     NewlyCreated {
         user_profile: UserProfile,
@@ -672,10 +598,7 @@ impl TimelineKind {
     pub fn thread_root_event_id(&self) -> Option<&OwnedEventId> {
         match self {
             TimelineKind::MainRoom { .. } => None,
-            TimelineKind::Thread {
-                thread_root_event_id,
-                ..
-            } => Some(thread_root_event_id),
+            TimelineKind::Thread { thread_root_event_id, .. } => Some(thread_root_event_id),
         }
     }
 }
@@ -683,10 +606,7 @@ impl std::fmt::Display for TimelineKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TimelineKind::MainRoom { room_id } => write!(f, "MainRoom({})", room_id),
-            TimelineKind::Thread {
-                room_id,
-                thread_root_event_id,
-            } => {
+            TimelineKind::Thread { room_id, thread_root_event_id } => {
                 write!(f, "Thread({}, {})", room_id, thread_root_event_id)
             }
         }
@@ -699,7 +619,9 @@ pub enum MatrixRequest {
     /// Request from the login screen to log in with the given credentials.
     Login(LoginRequest),
     /// Request to logout.
-    Logout { is_desktop: bool },
+    Logout {
+        is_desktop: bool,
+    },
     /// Request to paginate the older (or newer) events of a room or thread timeline.
     PaginateTimeline {
         timeline_kind: TimelineKind,
@@ -731,7 +653,9 @@ pub enum MatrixRequest {
     ///
     /// Even though it operates on a room itself, this accepts a `TimelineKind`
     /// in order to be able to send the fetched room member list to a specific timeline UI.
-    SyncRoomMemberList { timeline_kind: TimelineKind },
+    SyncRoomMemberList {
+        timeline_kind: TimelineKind,
+    },
     /// Request to create a thread timeline focused on the given thread root event in the given room.
     CreateThreadTimeline {
         room_id: OwnedRoomId,
@@ -750,9 +674,13 @@ pub enum MatrixRequest {
         user_id: OwnedUserId,
     },
     /// Request to join the given room.
-    JoinRoom { room_id: OwnedRoomId },
+    JoinRoom {
+        room_id: OwnedRoomId,
+    },
     /// Request to leave the given room.
-    LeaveRoom { room_id: OwnedRoomId },
+    LeaveRoom {
+        room_id: OwnedRoomId,
+    },
     /// Request to get the actual list of members in a room.
     ///
     /// This returns the list of members that can be displayed in the UI.
@@ -775,7 +703,9 @@ pub enum MatrixRequest {
         via: Vec<OwnedServerName>,
     },
     /// Request to fetch the full details (the room preview) of a tombstoned room.
-    GetSuccessorRoomDetails { tombstoned_room_id: OwnedRoomId },
+    GetSuccessorRoomDetails {
+        tombstoned_room_id: OwnedRoomId,
+    },
     /// Request to create or open a direct message room with the given user.
     ///
     /// If there is no existing DM room with the given user, this will create a new DM room
@@ -800,7 +730,9 @@ pub enum MatrixRequest {
         local_only: bool,
     },
     /// Request to fetch the number of unread messages in the given room.
-    GetNumberUnreadMessages { timeline_kind: TimelineKind },
+    GetNumberUnreadMessages {
+        timeline_kind: TimelineKind,
+    },
     /// Request to set the unread flag for the given room.
     SetUnreadFlag {
         room_id: OwnedRoomId,
@@ -885,12 +817,15 @@ pub enum MatrixRequest {
     /// This request does not return a response or notify the UI thread, and
     /// furthermore, there is no need to send a follow-up request to stop typing
     /// (though you certainly can do so).
-    SendTypingNotice { room_id: OwnedRoomId, typing: bool },
+    SendTypingNotice {
+        room_id: OwnedRoomId,
+        typing: bool,
+    },
     /// Spawn an async task to login to the given Matrix homeserver using the given SSO identity provider ID.
     ///
     /// While an SSO request is in flight, the login screen will temporarily prevent the user
     /// from submitting another redundant request, until this request has succeeded or failed.
-    SpawnSSOServer {
+    SpawnSSOServer{
         brand: String,
         homeserver_url: String,
         identity_provider_id: String,
@@ -935,7 +870,9 @@ pub enum MatrixRequest {
     ///
     /// Even though it operates on a room itself, this accepts a `TimelineKind`
     /// in order to be able to send the fetched room member list to a specific timeline UI.
-    GetRoomPowerLevels { timeline_kind: TimelineKind },
+    GetRoomPowerLevels {
+        timeline_kind: TimelineKind,
+    },
     /// Toggles the given reaction to the given event in the given room.
     ToggleReaction {
         timeline_kind: TimelineKind,
@@ -961,7 +898,7 @@ pub enum MatrixRequest {
     /// The MatrixLinkPillInfo::Loaded variant is sent back to the main UI thread via.
     GetMatrixRoomLinkPillInfo {
         matrix_id: MatrixId,
-        via: Vec<OwnedServerName>,
+        via: Vec<OwnedServerName>
     },
     /// Request to fetch URL preview from the Matrix homeserver.
     GetUrlPreview {
@@ -975,19 +912,19 @@ pub enum MatrixRequest {
 /// Submits a request to the worker thread to be executed asynchronously.
 pub fn submit_async_request(req: MatrixRequest) {
     if let Some(sender) = REQUEST_SENDER.lock().unwrap().as_ref() {
-        sender
-            .send(req)
+        sender.send(req)
             .expect("BUG: matrix worker task receiver has died!");
     }
 }
 
 /// Details of a login request that get submitted within [`MatrixRequest::Login`].
-pub enum LoginRequest {
+pub enum LoginRequest{
     LoginByPassword(LoginByPassword),
     Register(RegisterAccount),
     LoginBySSOSuccess(Client, ClientSessionPersisted),
     LoginByCli,
     HomeserverLoginTypesQuery(String),
+
 }
 /// Information needed to log in to a Matrix homeserver.
 pub struct LoginByPassword {
@@ -1004,6 +941,7 @@ pub struct RegisterAccount {
     pub homeserver: Option<String>,
 }
 
+
 /// The entry point for the worker task that runs Matrix-related operations.
 ///
 /// All this task does is wait for [`MatrixRequests`] from the main UI thread
@@ -1014,8 +952,7 @@ async fn matrix_worker_task(
 ) -> Result<()> {
     log!("Started matrix_worker_task.");
     // The async tasks that are spawned to subscribe to changes in our own user's read receipts for each timeline.
-    let mut subscribers_own_user_read_receipts: HashMap<TimelineKind, JoinHandle<()>> =
-        HashMap::new();
+    let mut subscribers_own_user_read_receipts: HashMap<TimelineKind, JoinHandle<()>> = HashMap::new();
     // The async tasks that are spawned to subscribe to changes in the pinned events for each room.
     let mut subscribers_pinned_events: HashMap<OwnedRoomId, JoinHandle<()>> = HashMap::new();
 
@@ -1025,7 +962,7 @@ async fn matrix_worker_task(
                 if let Err(e) = login_sender.send(login_request).await {
                     error!("Error sending login request to login_sender: {e:?}");
                     Cx::post_action(LoginAction::LoginFailure(String::from(
-                        "BUG: failed to send login request to login worker task.",
+                        "BUG: failed to send login request to login worker task."
                     )));
                 }
             }
@@ -1038,7 +975,7 @@ async fn matrix_worker_task(
                     match logout_with_state_machine(is_desktop).await {
                         Ok(()) => {
                             log!("Logout completed successfully via state machine");
-                        }
+                        },
                         Err(e) => {
                             error!("Logout failed: {e:?}");
                         }
@@ -1046,11 +983,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::PaginateTimeline {
-                timeline_kind,
-                num_events,
-                direction,
-            } => {
+            MatrixRequest::PaginateTimeline {timeline_kind, num_events, direction} => {
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
                     log!("Skipping pagination request for unknown {timeline_kind}");
                     continue;
@@ -1092,11 +1025,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::EditMessage {
-                timeline_kind,
-                timeline_event_item_id,
-                edited_content,
-            } => {
+            MatrixRequest::EditMessage { timeline_kind, timeline_event_item_id, edited_content } => {
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found for edit request");
                     continue;
@@ -1118,10 +1047,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::FetchDetailsForEvent {
-                timeline_kind,
-                event_id,
-            } => {
+            MatrixRequest::FetchDetailsForEvent { timeline_kind, event_id } => {
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found for fetch details for event request");
                     continue;
@@ -1138,10 +1064,7 @@ async fn matrix_worker_task(
                             // error!("Error fetching details for event {event_id} in {timeline_kind}: {_e:?}");
                         }
                     }
-                    if sender
-                        .send(TimelineUpdate::EventDetailsFetched { event_id, result })
-                        .is_err()
-                    {
+                    if sender.send(TimelineUpdate::EventDetailsFetched { event_id, result }).is_err() {
                         error!("Failed to send fetched event details to UI for {timeline_kind}");
                     }
                     SignalToUI::set_ui_signal();
@@ -1195,27 +1118,17 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::CreateThreadTimeline {
-                room_id,
-                thread_root_event_id,
-            } => {
+            MatrixRequest::CreateThreadTimeline { room_id, thread_root_event_id } => {
                 let main_room_timeline = {
                     let mut all_joined_rooms = ALL_JOINED_ROOMS.lock().unwrap();
                     let Some(room_info) = all_joined_rooms.get_mut(&room_id) else {
-                        error!(
-                            "BUG: room info not found for create thread timeline request, room {room_id}"
-                        );
+                        error!("BUG: room info not found for create thread timeline request, room {room_id}");
                         continue;
                     };
-                    if room_info
-                        .thread_timelines
-                        .contains_key(&thread_root_event_id)
-                    {
+                    if room_info.thread_timelines.contains_key(&thread_root_event_id) {
                         continue;
                     }
-                    let newly_pending = room_info
-                        .pending_thread_timelines
-                        .insert(thread_root_event_id.clone());
+                    let newly_pending = room_info.pending_thread_timelines.insert(thread_root_event_id.clone());
                     if !newly_pending {
                         continue;
                     }
@@ -1287,18 +1200,11 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::Knock {
-                room_or_alias_id,
-                reason,
-                server_names,
-            } => {
+            MatrixRequest::Knock { room_or_alias_id, reason, server_names } => {
                 let Some(client) = get_client() else { continue };
                 let _knock_room_task = Handle::current().spawn(async move {
                     log!("Sending request to knock on room {room_or_alias_id}...");
-                    match client
-                        .knock(room_or_alias_id.clone(), reason, server_names)
-                        .await
-                    {
+                    match client.knock(room_or_alias_id.clone(), reason, server_names).await {
                         Ok(room) => {
                             let _ = room.display_name().await; // populate this room's display name cache
                             Cx::post_action(KnockResultAction::Knocked {
@@ -1322,21 +1228,23 @@ async fn matrix_worker_task(
                     if let Some(room) = client.get_room(&room_id) {
                         log!("Sending request to invite user {user_id} to room {room_id}...");
                         match room.invite_user_by_id(&user_id).await {
-                            Ok(_) => Cx::post_action(InviteResultAction::Sent { room_id, user_id }),
+                            Ok(_) => Cx::post_action(InviteResultAction::Sent {
+                                room_id,
+                                user_id,
+                            }),
                             Err(error) => Cx::post_action(InviteResultAction::Failed {
                                 room_id,
                                 user_id,
                                 error,
                             }),
                         }
-                    } else {
+                    }
+                    else {
                         error!("Room/Space not found for invite user request {room_id}, {user_id}");
                         Cx::post_action(InviteResultAction::Failed {
                             room_id,
                             user_id,
-                            error: matrix_sdk::Error::UnknownError(
-                                "Room/Space not found in client's known list.".into(),
-                            ),
+                            error: matrix_sdk::Error::UnknownError("Room/Space not found in client's known list.".into()),
                         })
                     }
                 });
@@ -1357,7 +1265,8 @@ async fn matrix_worker_task(
                                 JoinRoomResultAction::Failed { room_id, error: e }
                             }
                         }
-                    } else {
+                    }
+                    else {
                         match client.join_room_by_id(&room_id).await {
                             Ok(_room) => {
                                 log!("Successfully joined new unknown room {room_id}.");
@@ -1392,20 +1301,14 @@ async fn matrix_worker_task(
                         error!("BUG: client could not get room with ID {room_id}");
                         LeaveRoomResultAction::Failed {
                             room_id,
-                            error: matrix_sdk::Error::UnknownError(
-                                "Client couldn't locate room to leave it.".into(),
-                            ),
+                            error: matrix_sdk::Error::UnknownError("Client couldn't locate room to leave it.".into()),
                         }
                     };
                     Cx::post_action(result_action);
                 });
             }
 
-            MatrixRequest::GetRoomMembers {
-                timeline_kind,
-                memberships,
-                local_only,
-            } => {
+            MatrixRequest::GetRoomMembers { timeline_kind, memberships, local_only } => {
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found for get room members request");
                     continue;
@@ -1414,9 +1317,7 @@ async fn matrix_worker_task(
                 let _get_members_task = Handle::current().spawn(async move {
                     let send_update = |members: Vec<matrix_sdk::room::RoomMember>, source: &str| {
                         log!("{} {} members for {timeline_kind}", source, members.len());
-                        sender
-                            .send(TimelineUpdate::RoomMembersListFetched { members })
-                            .unwrap();
+                        sender.send(TimelineUpdate::RoomMembersListFetched { members }).unwrap();
                         SignalToUI::set_ui_signal();
                     };
 
@@ -1433,10 +1334,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::GetRoomPreview {
-                room_or_alias_id,
-                via,
-            } => {
+            MatrixRequest::GetRoomPreview { room_or_alias_id, via } => {
                 let Some(client) = get_client() else { continue };
                 let _fetch_task = Handle::current().spawn(async move {
                     let res = fetch_room_preview_with_avatar(&client, &room_or_alias_id, via).await;
@@ -1449,9 +1347,7 @@ async fn matrix_worker_task(
                 let (sender, successor_room) = {
                     let all_joined_rooms = ALL_JOINED_ROOMS.lock().unwrap();
                     let Some(room_info) = all_joined_rooms.get(&tombstoned_room_id) else {
-                        error!(
-                            "BUG: tombstoned room {tombstoned_room_id} info not found for get successor room details request"
-                        );
+                        error!("BUG: tombstoned room {tombstoned_room_id} info not found for get successor room details request");
                         continue;
                     };
                     (
@@ -1467,10 +1363,7 @@ async fn matrix_worker_task(
                 );
             }
 
-            MatrixRequest::OpenOrCreateDirectMessage {
-                user_profile,
-                allow_create,
-            } => {
+            MatrixRequest::OpenOrCreateDirectMessage { user_profile, allow_create } => {
                 let Some(client) = get_client() else { continue };
                 let _create_dm_task = Handle::current().spawn(async move {
                     if let Some(room) = client.get_dm_room(&user_profile.user_id) {
@@ -1493,7 +1386,7 @@ async fn matrix_worker_task(
                                 user_profile,
                                 room_name_id: RoomNameId::from_room(&room).await,
                             });
-                        }
+                        },
                         Err(error) => {
                             error!("Failed to create DM with {user_profile:?}: {error}");
                             Cx::post_action(DirectMessageRoomAction::FailedToCreate {
@@ -1505,11 +1398,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::GetUserProfile {
-                user_id,
-                room_id,
-                local_only,
-            } => {
+            MatrixRequest::GetUserProfile { user_id, room_id, local_only } => {
                 let Some(client) = get_client() else { continue };
                 let _fetch_task = Handle::current().spawn(async move {
                     // log!("Sending get user profile request: user: {user_id}, \
@@ -1603,10 +1492,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::SetUnreadFlag {
-                room_id,
-                mark_as_unread,
-            } => {
+            MatrixRequest::SetUnreadFlag { room_id, mark_as_unread } => {
                 let Some(main_timeline) = get_room_timeline(&room_id) else {
                     log!("BUG: skipping set unread flag request for not-yet-known room {room_id}");
                     continue;
@@ -1615,64 +1501,35 @@ async fn matrix_worker_task(
                     let result = main_timeline.room().set_unread_flag(mark_as_unread).await;
                     match result {
                         Ok(_) => log!("Set unread flag to {} for room {}", mark_as_unread, room_id),
-                        Err(e) => error!(
-                            "Failed to set unread flag to {} for room {}: {:?}",
-                            mark_as_unread, room_id, e
-                        ),
+                        Err(e) => error!("Failed to set unread flag to {} for room {}: {:?}", mark_as_unread, room_id, e),
                     }
                 });
             }
 
-            MatrixRequest::SetIsFavorite {
-                room_id,
-                is_favorite,
-            } => {
+            MatrixRequest::SetIsFavorite { room_id, is_favorite } => {
                 let Some(main_timeline) = get_room_timeline(&room_id) else {
-                    log!(
-                        "BUG: skipping set favorite flag request for not-yet-known room {room_id}"
-                    );
+                    log!("BUG: skipping set favorite flag request for not-yet-known room {room_id}");
                     continue;
                 };
                 let _set_favorite_task = Handle::current().spawn(async move {
-                    let result = main_timeline
-                        .room()
-                        .set_is_favourite(is_favorite, None)
-                        .await;
+                    let result = main_timeline.room().set_is_favourite(is_favorite, None).await;
                     match result {
                         Ok(_) => log!("Set favorite to {} for room {}", is_favorite, room_id),
-                        Err(e) => error!(
-                            "Failed to set favorite to {} for room {}: {:?}",
-                            is_favorite, room_id, e
-                        ),
+                        Err(e) => error!("Failed to set favorite to {} for room {}: {:?}", is_favorite, room_id, e),
                     }
                 });
             }
 
-            MatrixRequest::SetIsLowPriority {
-                room_id,
-                is_low_priority,
-            } => {
+            MatrixRequest::SetIsLowPriority { room_id, is_low_priority } => {
                 let Some(main_timeline) = get_room_timeline(&room_id) else {
-                    log!(
-                        "BUG: skipping set low priority flag request for not-yet-known room {room_id}"
-                    );
+                    log!("BUG: skipping set low priority flag request for not-yet-known room {room_id}");
                     continue;
                 };
                 let _set_lp_task = Handle::current().spawn(async move {
-                    let result = main_timeline
-                        .room()
-                        .set_is_low_priority(is_low_priority, None)
-                        .await;
+                    let result = main_timeline.room().set_is_low_priority(is_low_priority, None).await;
                     match result {
-                        Ok(_) => log!(
-                            "Set low priority to {} for room {}",
-                            is_low_priority,
-                            room_id
-                        ),
-                        Err(e) => error!(
-                            "Failed to set low priority to {} for room {}: {:?}",
-                            is_low_priority, room_id, e
-                        ),
+                        Ok(_) => log!("Set low priority to {} for room {}", is_low_priority, room_id),
+                        Err(e) => error!("Failed to set low priority to {} for room {}: {:?}", is_low_priority, room_id, e),
                     }
                 });
             }
@@ -1681,24 +1538,15 @@ async fn matrix_worker_task(
                 let Some(client) = get_client() else { continue };
                 let _set_avatar_task = Handle::current().spawn(async move {
                     let is_removing = avatar_url.is_none();
-                    log!(
-                        "Sending request to {} avatar...",
-                        if is_removing { "remove" } else { "set" }
-                    );
+                    log!("Sending request to {} avatar...", if is_removing { "remove" } else { "set" });
                     let result = client.account().set_avatar_url(avatar_url.as_deref()).await;
                     match result {
                         Ok(_) => {
-                            log!(
-                                "Successfully {} avatar.",
-                                if is_removing { "removed" } else { "set" }
-                            );
+                            log!("Successfully {} avatar.", if is_removing { "removed" } else { "set" });
                             Cx::post_action(AccountDataAction::AvatarChanged(avatar_url));
                         }
                         Err(e) => {
-                            let err_msg = format!(
-                                "Failed to {} avatar: {e}",
-                                if is_removing { "remove" } else { "set" }
-                            );
+                            let err_msg = format!("Failed to {} avatar: {e}", if is_removing { "remove" } else { "set" });
                             Cx::post_action(AccountDataAction::AvatarChangeFailed(err_msg));
                         }
                     }
@@ -1709,87 +1557,57 @@ async fn matrix_worker_task(
                 let Some(client) = get_client() else { continue };
                 let _set_display_name_task = Handle::current().spawn(async move {
                     let is_removing = new_display_name.is_none();
-                    log!(
-                        "Sending request to {} display name{}...",
+                    log!("Sending request to {} display name{}...",
                         if is_removing { "remove" } else { "set" },
-                        new_display_name
-                            .as_ref()
-                            .map(|n| format!(" to '{n}'"))
-                            .unwrap_or_default()
+                        new_display_name.as_ref().map(|n| format!(" to '{n}'")).unwrap_or_default()
                     );
-                    let result = client
-                        .account()
-                        .set_display_name(new_display_name.as_deref())
-                        .await;
+                    let result = client.account().set_display_name(new_display_name.as_deref()).await;
                     match result {
                         Ok(_) => {
-                            log!(
-                                "Successfully {} display name.",
-                                if is_removing { "removed" } else { "set" }
-                            );
-                            Cx::post_action(AccountDataAction::DisplayNameChanged(
-                                new_display_name,
-                            ));
+                            log!("Successfully {} display name.", if is_removing { "removed" } else { "set" });
+                            Cx::post_action(AccountDataAction::DisplayNameChanged(new_display_name));
                         }
                         Err(e) => {
-                            let err_msg = format!(
-                                "Failed to {} display name: {e}",
-                                if is_removing { "remove" } else { "set" }
-                            );
+                            let err_msg = format!("Failed to {} display name: {e}", if is_removing { "remove" } else { "set" });
                             Cx::post_action(AccountDataAction::DisplayNameChangeFailed(err_msg));
                         }
                     }
                 });
             }
 
-            MatrixRequest::GenerateMatrixLink {
-                room_id,
-                event_id,
-                use_matrix_scheme,
-                join_on_click,
-            } => {
+            MatrixRequest::GenerateMatrixLink { room_id, event_id, use_matrix_scheme, join_on_click } => {
                 let Some(client) = get_client() else { continue };
                 let _gen_link_task = Handle::current().spawn(async move {
                     if let Some(room) = client.get_room(&room_id) {
                         let result = if use_matrix_scheme {
                             if let Some(event_id) = event_id {
-                                room.matrix_event_permalink(event_id)
-                                    .await
+                                room.matrix_event_permalink(event_id).await
                                     .map(MatrixLinkAction::MatrixUri)
                             } else {
-                                room.matrix_permalink(join_on_click)
-                                    .await
+                                room.matrix_permalink(join_on_click).await
                                     .map(MatrixLinkAction::MatrixUri)
                             }
                         } else {
                             if let Some(event_id) = event_id {
-                                room.matrix_to_event_permalink(event_id)
-                                    .await
+                                room.matrix_to_event_permalink(event_id).await
                                     .map(MatrixLinkAction::MatrixToUri)
                             } else {
-                                room.matrix_to_permalink()
-                                    .await
+                                room.matrix_to_permalink().await
                                     .map(MatrixLinkAction::MatrixToUri)
                             }
                         };
-
+    
                         match result {
                             Ok(action) => Cx::post_action(action),
                             Err(e) => Cx::post_action(MatrixLinkAction::Error(e.to_string())),
                         }
                     } else {
-                        Cx::post_action(MatrixLinkAction::Error(format!(
-                            "Room {room_id} not found"
-                        )));
+                         Cx::post_action(MatrixLinkAction::Error(format!("Room {room_id} not found")));
                     }
                 });
             }
 
-            MatrixRequest::IgnoreUser {
-                ignore,
-                room_member,
-                room_id,
-            } => {
+            MatrixRequest::IgnoreUser { ignore, room_member, room_id } => {
                 let Some(client) = get_client() else { continue };
                 let _ignore_task = Handle::current().spawn(async move {
                     let user_id = room_member.user_id();
@@ -1844,9 +1662,7 @@ async fn matrix_worker_task(
 
             MatrixRequest::SendTypingNotice { room_id, typing } => {
                 let Some(main_room_timeline) = get_room_timeline(&room_id) else {
-                    log!(
-                        "BUG: skipping send typing notice request for not-yet-known room {room_id}"
-                    );
+                    log!("BUG: skipping send typing notice request for not-yet-known room {room_id}");
                     continue;
                 };
                 let _typing_task = Handle::current().spawn(async move {
@@ -1860,21 +1676,16 @@ async fn matrix_worker_task(
                 let (main_timeline, timeline_update_sender, mut typing_notice_receiver) = {
                     let mut all_joined_rooms = ALL_JOINED_ROOMS.lock().unwrap();
                     let Some(jrd) = all_joined_rooms.get_mut(&room_id) else {
-                        log!(
-                            "BUG: room info not found for subscribe to typing notices request, room {room_id}"
-                        );
+                        log!("BUG: room info not found for subscribe to typing notices request, room {room_id}");
                         continue;
                     };
                     let (main_timeline, receiver) = if subscribe {
                         if jrd.typing_notice_subscriber.is_some() {
-                            warning!(
-                                "Note: room {room_id} is already subscribed to typing notices."
-                            );
+                            warning!("Note: room {room_id} is already subscribed to typing notices.");
                             continue;
                         } else {
                             let main_timeline = jrd.main_timeline.timeline.clone();
-                            let (drop_guard, receiver) =
-                                main_timeline.room().subscribe_to_typing_notifications();
+                            let (drop_guard, receiver) = main_timeline.room().subscribe_to_typing_notifications();
                             jrd.typing_notice_subscriber = Some(drop_guard);
                             (main_timeline, receiver)
                         }
@@ -1883,11 +1694,7 @@ async fn matrix_worker_task(
                         continue;
                     };
                     // Here: we don't have an existing subscriber running, so we fall through and start one.
-                    (
-                        main_timeline,
-                        jrd.main_timeline.timeline_update_sender.clone(),
-                        receiver,
-                    )
+                    (main_timeline, jrd.main_timeline.timeline_update_sender.clone(), receiver)
                 };
 
                 let _typing_notices_task = Handle::current().spawn(async move {
@@ -1914,22 +1721,15 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::SubscribeToOwnUserReadReceiptsChanged {
-                timeline_kind,
-                subscribe,
-            } => {
+            MatrixRequest::SubscribeToOwnUserReadReceiptsChanged { timeline_kind, subscribe } => {
                 if !subscribe {
-                    if let Some(task_handler) =
-                        subscribers_own_user_read_receipts.remove(&timeline_kind)
-                    {
+                    if let Some(task_handler) = subscribers_own_user_read_receipts.remove(&timeline_kind) {
                         task_handler.abort();
                     }
                     continue;
                 }
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
-                    log!(
-                        "BUG: skipping subscribe to own user read receipts changed request for {timeline_kind}"
-                    );
+                    log!("BUG: skipping subscribe to own user read receipts changed request for {timeline_kind}");
                     continue;
                 };
 
@@ -1971,8 +1771,7 @@ async fn matrix_worker_task(
                         }
                     }
                 });
-                subscribers_own_user_read_receipts
-                    .insert(timeline_kind_clone, subscribe_own_read_receipt_task);
+                subscribers_own_user_read_receipts.insert(timeline_kind_clone, subscribe_own_read_receipt_task);
             }
 
             MatrixRequest::SubscribeToPinnedEvents { room_id, subscribe } => {
@@ -1982,13 +1781,9 @@ async fn matrix_worker_task(
                     }
                     continue;
                 }
-                let kind = TimelineKind::MainRoom {
-                    room_id: room_id.clone(),
-                };
+                let kind = TimelineKind::MainRoom { room_id: room_id.clone() };
                 let Some((main_timeline, sender)) = get_timeline_and_sender(&kind) else {
-                    log!(
-                        "BUG: skipping subscribe to pinned events request for unknown room {room_id}"
-                    );
+                    log!("BUG: skipping subscribe to pinned events request for unknown room {room_id}");
                     continue;
                 };
                 let subscribe_pinned_events_task = Handle::current().spawn(async move {
@@ -2010,18 +1805,8 @@ async fn matrix_worker_task(
                 subscribers_pinned_events.insert(room_id, subscribe_pinned_events_task);
             }
 
-            MatrixRequest::SpawnSSOServer {
-                brand,
-                homeserver_url,
-                identity_provider_id,
-            } => {
-                spawn_sso_server(
-                    brand,
-                    homeserver_url,
-                    identity_provider_id,
-                    login_sender.clone(),
-                )
-                .await;
+            MatrixRequest::SpawnSSOServer { brand, homeserver_url, identity_provider_id} => {
+                spawn_sso_server(brand, homeserver_url, identity_provider_id, login_sender.clone()).await;
             }
 
             MatrixRequest::ResolveRoomAlias(room_alias) => {
@@ -2034,10 +1819,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::FetchAvatar {
-                mxc_uri,
-                on_fetched,
-            } => {
+            MatrixRequest::FetchAvatar { mxc_uri, on_fetched } => {
                 let Some(client) = get_client() else { continue };
                 Handle::current().spawn(async move {
                     // log!("Sending fetch avatar request for {mxc_uri:?}...");
@@ -2047,21 +1829,13 @@ async fn matrix_worker_task(
                     };
                     let res = client.media().get_media_content(&media_request, true).await;
                     // log!("Fetched avatar for {mxc_uri:?}, succeeded? {}", res.is_ok());
-                    on_fetched(AvatarUpdate {
-                        mxc_uri,
-                        avatar_data: res.map(|v| v.into()),
-                    });
+                    on_fetched(AvatarUpdate { mxc_uri, avatar_data: res.map(|v| v.into()) });
                 });
             }
 
-            MatrixRequest::FetchMedia {
-                media_request,
-                on_fetched,
-                destination,
-                update_sender,
-            } => {
+            MatrixRequest::FetchMedia { media_request, on_fetched, destination, update_sender } => {
                 let Some(client) = get_client() else { continue };
-
+                
                 let _fetch_task = Handle::current().spawn(async move {
                     // log!("Sending fetch media request for {media_request:?}...");
                     let res = client.media().get_media_content(&media_request, true).await;
@@ -2166,11 +1940,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::ReadReceipt {
-                timeline_kind,
-                event_id,
-                receipt_type,
-            } => {
+            MatrixRequest::ReadReceipt { timeline_kind, event_id, receipt_type } => {
                 let Some(timeline) = get_timeline(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found when sending read receipt, {event_id}");
                     continue;
@@ -2191,7 +1961,7 @@ async fn matrix_worker_task(
                         });
                     }
                 });
-            }
+            },
 
             MatrixRequest::GetRoomPowerLevels { timeline_kind } => {
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
@@ -2199,21 +1969,15 @@ async fn matrix_worker_task(
                     continue;
                 };
 
-                let Some(user_id) = current_user_id() else {
-                    continue;
-                };
+                let Some(user_id) = current_user_id() else { continue };
 
                 let _power_levels_task = Handle::current().spawn(async move {
                     match timeline.room().power_levels().await {
                         Ok(power_levels) => {
                             log!("Successfully fetched power levels for {timeline_kind}.");
-                            if sender
-                                .send(TimelineUpdate::UserPowerLevels(UserPowerLevels::from(
-                                    &power_levels,
-                                    &user_id,
-                                )))
-                                .is_err()
-                            {
+                            if sender.send(TimelineUpdate::UserPowerLevels(
+                                UserPowerLevels::from(&power_levels, &user_id),
+                            )).is_err() {
                                 error!("Failed to send room power levels to UI.")
                             }
                             SignalToUI::set_ui_signal();
@@ -2223,13 +1987,9 @@ async fn matrix_worker_task(
                         }
                     }
                 });
-            }
+            },
 
-            MatrixRequest::ToggleReaction {
-                timeline_kind,
-                timeline_event_id,
-                reaction,
-            } => {
+            MatrixRequest::ToggleReaction { timeline_kind, timeline_event_id, reaction } => {
                 let Some(timeline) = get_timeline(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found for toggle reaction request");
                     continue;
@@ -2237,26 +1997,17 @@ async fn matrix_worker_task(
 
                 let _toggle_reaction_task = Handle::current().spawn(async move {
                     log!("Sending toggle reaction {reaction:?} to {timeline_kind}: ...");
-                    match timeline
-                        .toggle_reaction(&timeline_event_id, &reaction)
-                        .await
-                    {
+                    match timeline.toggle_reaction(&timeline_event_id, &reaction).await {
                         Ok(_send_handle) => {
                             log!("Sent toggle reaction {reaction:?} to {timeline_kind}.");
                             SignalToUI::set_ui_signal();
-                        }
-                        Err(_e) => error!(
-                            "Failed to send toggle reaction to {timeline_kind}; error: {_e:?}"
-                        ),
+                        },
+                        Err(_e) => error!("Failed to send toggle reaction to {timeline_kind}; error: {_e:?}"),
                     }
                 });
-            }
+            },
 
-            MatrixRequest::RedactMessage {
-                timeline_kind,
-                timeline_event_id,
-                reason,
-            } => {
+            MatrixRequest::RedactMessage { timeline_kind, timeline_event_id, reason } => {
                 let Some(timeline) = get_timeline(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found for redact message request");
                     continue;
@@ -2275,13 +2026,9 @@ async fn matrix_worker_task(
                         }
                     }
                 });
-            }
+            },
 
-            MatrixRequest::PinEvent {
-                timeline_kind,
-                event_id,
-                pin,
-            } => {
+            MatrixRequest::PinEvent { timeline_kind, event_id, pin } => {
                 let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
                     log!("BUG: {timeline_kind} not found for pin event request");
                     continue;
@@ -2293,11 +2040,7 @@ async fn matrix_worker_task(
                     } else {
                         timeline.unpin_event(&event_id).await
                     };
-                    match sender.send(TimelineUpdate::PinResult {
-                        event_id,
-                        pin,
-                        result,
-                    }) {
+                    match sender.send(TimelineUpdate::PinResult { event_id, pin, result }) {
                         Ok(_) => SignalToUI::set_ui_signal(),
                         Err(_) => log!("Failed to send UI update for pin event."),
                     }
@@ -2331,12 +2074,7 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::GetUrlPreview {
-                url,
-                on_fetched,
-                destination,
-                update_sender,
-            } => {
+            MatrixRequest::GetUrlPreview { url, on_fetched, destination, update_sender } => {
                 // const MAX_LOG_RESPONSE_BODY_LENGTH: usize = 1000;
                 // log!("Starting URL preview fetch for: {}", url);
                 let _fetch_url_preview_task = Handle::current().spawn(async move {
@@ -2346,19 +2084,17 @@ async fn matrix_worker_task(
                             // error!("Matrix client not available for URL preview: {}", url);
                             UrlPreviewError::ClientNotAvailable
                         })?;
-
+                        
                         let token = client.access_token().ok_or_else(|| {
                             // error!("Access token not available for URL preview: {}", url);
                             UrlPreviewError::AccessTokenNotAvailable
                         })?;
                         // Official Doc: https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientv1mediapreview_url
                         // Element desktop is using /_matrix/media/v3/preview_url
-                        let endpoint_url = client
-                            .homeserver()
-                            .join("/_matrix/client/v1/media/preview_url")
+                        let endpoint_url = client.homeserver().join("/_matrix/client/v1/media/preview_url")
                             .map_err(UrlPreviewError::UrlParse)?;
                         // log!("Fetching URL preview from endpoint: {} for URL: {}", endpoint_url, url);
-
+                        
                         let response = client
                             .http_client()
                             .get(endpoint_url.clone())
@@ -2371,20 +2107,20 @@ async fn matrix_worker_task(
                                 // error!("HTTP request failed for URL preview {}: {}", url, e);
                                 UrlPreviewError::Request(e)
                             })?;
-
+                        
                         let status = response.status();
                         // log!("URL preview response status for {}: {}", url, status);
-
+                        
                         if !status.is_success() && status.as_u16() != 429 {
                             // error!("URL preview request failed with status {} for URL: {}", status, url);
                             return Err(UrlPreviewError::HttpStatus(status.as_u16()));
                         }
-
+                        
                         let text = response.text().await.map_err(|e| {
                             // error!("Failed to read response text for URL preview {}: {}", url, e);
                             UrlPreviewError::Request(e)
                         })?;
-
+                        
                         // log!("URL preview response body length for {}: {} bytes", url, text.len());
                         // if text.len() > MAX_LOG_RESPONSE_BODY_LENGTH {
                         //     log!("URL preview response body preview for {}: {}...", url, &text[..MAX_LOG_RESPONSE_BODY_LENGTH]);
@@ -2393,25 +2129,22 @@ async fn matrix_worker_task(
                         // }
                         // This request is rate limited, retry after a duration we get from the server.
                         if status.as_u16() == 429 {
-                            let link_preview_429_res =
-                                serde_json::from_str::<LinkPreviewRateLimitResponse>(&text)
-                                    .map_err(|e| {
-                                        // error!("Failed to parse as LinkPreviewRateLimitResponse for URL preview {}: {}", url, e);
-                                        UrlPreviewError::Json(e)
-                                    });
+                            let link_preview_429_res = serde_json::from_str::<LinkPreviewRateLimitResponse>(&text)
+                                .map_err(|e| {
+                                    // error!("Failed to parse as LinkPreviewRateLimitResponse for URL preview {}: {}", url, e);
+                                    UrlPreviewError::Json(e)
+                            });
                             match link_preview_429_res {
                                 Ok(link_preview_429_res) => {
                                     if let Some(retry_after) = link_preview_429_res.retry_after_ms {
-                                        tokio::time::sleep(Duration::from_millis(
-                                            retry_after.into(),
-                                        ))
-                                        .await;
-                                        submit_async_request(MatrixRequest::GetUrlPreview {
+                                        tokio::time::sleep(Duration::from_millis(retry_after.into())).await;
+                                        submit_async_request(MatrixRequest::GetUrlPreview{
                                             url: url.clone(),
                                             on_fetched,
                                             destination: destination.clone(),
                                             update_sender: update_sender.clone(),
                                         });
+                                        
                                     }
                                 }
                                 Err(_e) => {
@@ -2431,12 +2164,11 @@ async fn matrix_worker_task(
                                 // error!("Response body that failed to parse: {}", text);
                                 UrlPreviewError::Json(e)
                             })
-                    }
-                    .await;
+                    }.await;
 
                     // match &result {
                     //     Ok(preview_data) => {
-                    //         log!("Successfully fetched URL preview for {}: title: {:?}, site_name: {:?}",
+                    //         log!("Successfully fetched URL preview for {}: title: {:?}, site_name: {:?}", 
                     //              url, preview_data.title, preview_data.site_name);
                     //     }
                     //     Err(e) => {
@@ -2455,6 +2187,7 @@ async fn matrix_worker_task(
     bail!("matrix_worker_task task ended unexpectedly")
 }
 
+
 /// The single global Tokio runtime that is used by all async tasks.
 static TOKIO_RUNTIME: Mutex<Option<tokio::runtime::Runtime>> = Mutex::new(None);
 
@@ -2467,8 +2200,7 @@ static REQUEST_SENDER: Mutex<Option<UnboundedSender<MatrixRequest>>> = Mutex::ne
 static DEFAULT_SSO_CLIENT: Mutex<Option<(Client, ClientSessionPersisted)>> = Mutex::new(None);
 
 /// Used to notify the SSO login task that the async creation of the `DEFAULT_SSO_CLIENT` has finished.
-static DEFAULT_SSO_CLIENT_NOTIFIER: LazyLock<Arc<Notify>> =
-    LazyLock::new(|| Arc::new(Notify::new()));
+static DEFAULT_SSO_CLIENT_NOTIFIER: LazyLock<Arc<Notify>> = LazyLock::new(|| Arc::new(Notify::new()));
 
 /// Blocks the current thread until the given future completes.
 ///
@@ -2479,21 +2211,19 @@ pub fn block_on_async_with_timeout<T>(
     timeout: Option<Duration>,
     async_future: impl Future<Output = T>,
 ) -> Result<T, Elapsed> {
-    let rt = TOKIO_RUNTIME
-        .lock()
-        .unwrap()
-        .get_or_insert_with(|| {
-            tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
-        })
-        .handle()
-        .clone();
+    let rt = TOKIO_RUNTIME.lock().unwrap().get_or_insert_with(||
+        tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
+    ).handle().clone();
 
     if let Some(timeout) = timeout {
-        rt.block_on(async { tokio::time::timeout(timeout, async_future).await })
+        rt.block_on(async {
+            tokio::time::timeout(timeout, async_future).await
+        })
     } else {
         Ok(rt.block_on(async_future))
     }
 }
+
 
 /// The primary initialization routine for starting the Matrix client sync
 /// and the async tokio runtime.
@@ -2501,23 +2231,16 @@ pub fn block_on_async_with_timeout<T>(
 /// Returns a handle to the Tokio runtime that is used to run async background tasks.
 pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
     // Create a Tokio runtime, and save it in a static variable to ensure it isn't dropped.
-    let rt_handle = TOKIO_RUNTIME
-        .lock()
-        .unwrap()
-        .get_or_insert_with(|| {
-            tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
-        })
-        .handle()
-        .clone();
+    let rt_handle = TOKIO_RUNTIME.lock().unwrap().get_or_insert_with(|| {
+        tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
+    }).handle().clone();
 
     // Proactively build a Matrix Client in the background so that the SSO Server
     // can have a quicker start if needed (as it's rather slow to build this client).
     rt_handle.spawn(async move {
         match build_client(&Cli::default(), app_data_dir()).await {
             Ok(client_and_session) => {
-                DEFAULT_SSO_CLIENT
-                    .lock()
-                    .unwrap()
+                DEFAULT_SSO_CLIENT.lock().unwrap()
                     .get_or_insert(client_and_session);
             }
             Err(e) => error!("Error: could not create DEFAULT_SSO_CLIENT object: {e}"),
@@ -2533,6 +2256,7 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
 
     Ok(rt_handle)
 }
+
 
 /// A tokio::watch channel sender for sending requests from the RoomScreen UI widget
 /// to the corresponding background async task for that room (its `timeline_subscriber_handler`).
@@ -2600,13 +2324,13 @@ impl Drop for JoinedRoomDetails {
     }
 }
 
+
 /// A const-compatible hasher, used for `static` items containing `HashMap`s or `HashSet`s.
 type ConstHasher = BuildHasherDefault<DefaultHasher>;
 
 /// Information about all joined rooms that our client currently know about.
 /// We use a `HashMap` for O(1) lookups, as this is accessed frequently (e.g. every timeline update).
-static ALL_JOINED_ROOMS: Mutex<HashMap<OwnedRoomId, JoinedRoomDetails, ConstHasher>> =
-    Mutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
+static ALL_JOINED_ROOMS: Mutex<HashMap<OwnedRoomId, JoinedRoomDetails, ConstHasher>> = Mutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
 /// Returns the timeline and timeline update sender for the given joined room/thread timeline.
 fn get_per_timeline_details<'a>(
@@ -2616,10 +2340,7 @@ fn get_per_timeline_details<'a>(
     let room_info = all_joined_rooms.get_mut(kind.room_id())?;
     match kind {
         TimelineKind::MainRoom { .. } => Some(&mut room_info.main_timeline),
-        TimelineKind::Thread {
-            thread_root_event_id,
-            ..
-        } => room_info.thread_timelines.get_mut(thread_root_event_id),
+        TimelineKind::Thread { thread_root_event_id, .. } => room_info.thread_timelines.get_mut(thread_root_event_id),
     }
 }
 
@@ -2630,22 +2351,14 @@ fn get_timeline(kind: &TimelineKind) -> Option<Arc<Timeline>> {
 }
 
 /// Obtains the lock on `ALL_JOINED_ROOMS` and returns the timeline and timeline update sender for the given timeline kind.
-fn get_timeline_and_sender(
-    kind: &TimelineKind,
-) -> Option<(Arc<Timeline>, crossbeam_channel::Sender<TimelineUpdate>)> {
-    get_per_timeline_details(ALL_JOINED_ROOMS.lock().unwrap().deref_mut(), kind).map(|details| {
-        (
-            details.timeline.clone(),
-            details.timeline_update_sender.clone(),
-        )
-    })
+fn get_timeline_and_sender(kind: &TimelineKind) -> Option<(Arc<Timeline>, crossbeam_channel::Sender<TimelineUpdate>)> {
+    get_per_timeline_details(ALL_JOINED_ROOMS.lock().unwrap().deref_mut(), kind)
+        .map(|details| (details.timeline.clone(), details.timeline_update_sender.clone()))
 }
 
 /// Obtains the lock on `ALL_JOINED_ROOMS` and returns the main timeline for the given room.
 fn get_room_timeline(room_id: &RoomId) -> Option<Arc<Timeline>> {
-    ALL_JOINED_ROOMS
-        .lock()
-        .unwrap()
+    ALL_JOINED_ROOMS.lock().unwrap()
         .get(room_id)
         .map(|jrd| jrd.main_timeline.timeline.clone())
 }
@@ -2659,15 +2372,14 @@ pub fn get_client() -> Option<Client> {
 
 /// Returns the user ID of the currently logged-in user, if any.
 pub fn current_user_id() -> Option<OwnedUserId> {
-    CLIENT
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|c| c.session_meta().map(|m| m.user_id.clone()))
+    CLIENT.lock().unwrap().as_ref().and_then(|c|
+        c.session_meta().map(|m| m.user_id.clone())
+    )
 }
 
 /// The singleton sync service.
 static SYNC_SERVICE: Mutex<Option<Arc<SyncService>>> = Mutex::new(None);
+
 
 /// Get a reference to the current sync service, if available.
 pub fn get_sync_service() -> Option<Arc<SyncService>> {
@@ -2677,8 +2389,7 @@ pub fn get_sync_service() -> Option<Arc<SyncService>> {
 /// The list of users that the current user has chosen to ignore.
 /// Ideally we shouldn't have to maintain this list ourselves,
 /// but the Matrix SDK doesn't currently properly maintain the list of ignored users.
-static IGNORED_USERS: Mutex<HashSet<OwnedUserId, ConstHasher>> =
-    Mutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
+static IGNORED_USERS: Mutex<HashSet<OwnedUserId, ConstHasher>> = Mutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
 
 /// Returns a deep clone of the current list of ignored users.
 pub fn get_ignored_users() -> HashSet<OwnedUserId, ConstHasher> {
@@ -2689,6 +2400,7 @@ pub fn get_ignored_users() -> HashSet<OwnedUserId, ConstHasher> {
 pub fn is_user_ignored(user_id: &UserId) -> bool {
     IGNORED_USERS.lock().unwrap().contains(user_id)
 }
+
 
 /// Returns three channel endpoints related to the timeline for the given joined room or thread.
 ///
@@ -2703,10 +2415,7 @@ pub fn take_timeline_endpoints(kind: &TimelineKind) -> Option<TimelineEndpoints>
     let jrd = all_joined_rooms.get_mut(kind.room_id())?;
     let details = match kind {
         TimelineKind::MainRoom { .. } => &mut jrd.main_timeline,
-        TimelineKind::Thread {
-            thread_root_event_id,
-            ..
-        } => jrd.thread_timelines.get_mut(thread_root_event_id)?,
+        TimelineKind::Thread { thread_root_event_id, .. } => jrd.thread_timelines.get_mut(thread_root_event_id)?,
     };
     let (update_receiver, request_sender) = details.timeline_singleton_endpoints.take()?;
     Some(TimelineEndpoints {
@@ -2719,17 +2428,24 @@ pub fn take_timeline_endpoints(kind: &TimelineKind) -> Option<TimelineEndpoints>
 
 const DEFAULT_HOMESERVER: &str = "matrix.org";
 
-fn username_to_full_user_id(username: &str, homeserver: Option<&str>) -> Option<OwnedUserId> {
-    username.try_into().ok().or_else(|| {
-        let homeserver_url = homeserver.unwrap_or(DEFAULT_HOMESERVER);
-        let user_id_str = if username.starts_with("@") {
-            format!("{}:{}", username, homeserver_url)
-        } else {
-            format!("@{}:{}", username, homeserver_url)
-        };
-        user_id_str.as_str().try_into().ok()
-    })
+fn username_to_full_user_id(
+    username: &str,
+    homeserver: Option<&str>,
+) -> Option<OwnedUserId> {
+    username
+        .try_into()
+        .ok()
+        .or_else(|| {
+            let homeserver_url = homeserver.unwrap_or(DEFAULT_HOMESERVER);
+            let user_id_str = if username.starts_with("@") {
+                format!("{}:{}", username, homeserver_url)
+            } else {
+                format!("@{}:{}", username, homeserver_url)
+            };
+            user_id_str.as_str().try_into().ok()
+        })
 }
+
 
 /// Info we store about a room received by the room list service.
 ///
@@ -2758,14 +2474,18 @@ struct RoomListServiceRoomInfo {
 impl RoomListServiceRoomInfo {
     async fn from_room(room: matrix_sdk::Room, current_user_id: &Option<OwnedUserId>) -> Self {
         // Parallelize fetching of independent room data.
-        let (is_direct, tags, display_name, user_power_levels) =
-            tokio::join!(room.is_direct(), room.tags(), room.display_name(), async {
+        let (is_direct, tags, display_name, user_power_levels) = tokio::join!(
+            room.is_direct(),
+            room.tags(),
+            room.display_name(),
+            async {
                 if let Some(user_id) = current_user_id {
                     UserPowerLevels::from_room(&room, user_id.deref()).await
                 } else {
                     None
                 }
-            });
+            }
+        );
 
         Self {
             room_id: room.room_id().to_owned(),
@@ -2807,26 +2527,26 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
     let most_recent_user_id = persistence::most_recent_user_id().await;
     log!("Most recent user ID: {most_recent_user_id:?}");
     let cli_parse_result = Cli::try_parse();
-    let cli_has_valid_username_password = cli_parse_result
-        .as_ref()
+    let cli_has_valid_username_password = cli_parse_result.as_ref()
         .is_ok_and(|cli| !cli.user_id.is_empty() && !cli.password.is_empty());
-    log!(
-        "CLI parsing succeeded? {}. CLI has valid UN+PW? {}",
+    log!("CLI parsing succeeded? {}. CLI has valid UN+PW? {}",
         cli_parse_result.as_ref().is_ok(),
         cli_has_valid_username_password,
     );
-    let wait_for_login = !cli_has_valid_username_password
-        && (most_recent_user_id.is_none()
-            || std::env::args().any(|arg| arg == "--login-screen" || arg == "--force-login"));
+    let wait_for_login = !cli_has_valid_username_password && (
+        most_recent_user_id.is_none()
+            || std::env::args().any(|arg| arg == "--login-screen" || arg == "--force-login")
+    );
     log!("Waiting for login? {}", wait_for_login);
 
     let new_login_opt: Option<(Client, Option<String>, bool)> = if !wait_for_login {
-        let specified_username = cli_parse_result
-            .as_ref()
-            .ok()
-            .and_then(|cli| username_to_full_user_id(&cli.user_id, cli.homeserver.as_deref()));
-        log!(
-            "Trying to restore session for user: {:?}",
+        let specified_username = cli_parse_result.as_ref().ok().and_then(|cli|
+            username_to_full_user_id(
+                &cli.user_id,
+                cli.homeserver.as_deref(),
+            )
+        );
+        log!("Trying to restore session for user: {:?}",
             specified_username.as_ref().or(most_recent_user_id.as_ref())
         );
         match persistence::restore_session(specified_username.clone()).await {
@@ -2843,10 +2563,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                 Cx::post_action(LoginAction::LoginFailure(status_err.to_string()));
 
                 if let Ok(cli) = &cli_parse_result {
-                    log!(
-                        "Attempting auto-login from CLI arguments as user '{}'...",
-                        cli.user_id
-                    );
+                    log!("Attempting auto-login from CLI arguments as user '{}'...", cli.user_id);
                     Cx::post_action(LoginAction::CliAutoLogin {
                         user_id: cli.user_id.clone(),
                         homeserver: cli.homeserver.clone(),
@@ -2855,9 +2572,9 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                         Ok((client, sync_token)) => Some((client, sync_token, false)),
                         Err(e) => {
                             error!("CLI-based login failed: {e:?}");
-                            Cx::post_action(LoginAction::LoginFailure(format!(
-                                "Could not login with CLI-provided arguments.\n\nPlease login manually.\n\nError: {e}"
-                            )));
+                            Cx::post_action(LoginAction::LoginFailure(
+                                format!("Could not login with CLI-provided arguments.\n\nPlease login manually.\n\nError: {e}")
+                            ));
                             enqueue_rooms_list_update(RoomsListUpdate::Status {
                                 status: format!("Login failed: {e:?}"),
                             });
@@ -2882,30 +2599,34 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
         let (client, sync_service, logged_in_user_id) = 'login_loop: loop {
             let (client, _sync_token, validate_session) = match initial_client_opt.take() {
                 Some(login) => login,
-                None => loop {
-                    log!("Waiting for login request...");
-                    match login_receiver.recv().await {
-                        Some(login_request) => match login(&cli, login_request).await {
-                            Ok((client, sync_token)) => break (client, sync_token, false),
-                            Err(e) => {
-                                error!("Login failed: {e:?}");
-                                Cx::post_action(LoginAction::LoginFailure(format!("{e}")));
+                None => {
+                    loop {
+                        log!("Waiting for login request...");
+                        match login_receiver.recv().await {
+                            Some(login_request) => {
+                                match login(&cli, login_request).await {
+                                    Ok((client, sync_token)) => break (client, sync_token, false),
+                                    Err(e) => {
+                                        error!("Login failed: {e:?}");
+                                        Cx::post_action(LoginAction::LoginFailure(format!("{e}")));
+                                        enqueue_rooms_list_update(RoomsListUpdate::Status {
+                                            status: format!("Login failed: {e}"),
+                                        });
+                                    }
+                                }
+                            },
+                            None => {
+                                error!("BUG: login_receiver hung up unexpectedly");
+                                let err = String::from("Please restart Robrix.\n\nUnable to listen for login requests.");
+                                Cx::post_action(LoginAction::LoginFailure(err.clone()));
                                 enqueue_rooms_list_update(RoomsListUpdate::Status {
-                                    status: format!("Login failed: {e}"),
+                                    status: err,
                                 });
+                                return;
                             }
-                        },
-                        None => {
-                            error!("BUG: login_receiver hung up unexpectedly");
-                            let err = String::from(
-                                "Please restart Robrix.\n\nUnable to listen for login requests.",
-                            );
-                            Cx::post_action(LoginAction::LoginFailure(err.clone()));
-                            enqueue_rooms_list_update(RoomsListUpdate::Status { status: err });
-                            return;
                         }
                     }
-                },
+                }
             };
 
             if validate_session {
@@ -2913,8 +2634,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                     Ok(_) => {}
                     Err(e) if is_invalid_token_http_error(&e) => {
                         clear_persisted_session(client.user_id()).await;
-                        let err_msg =
-                            "Your login token is no longer valid.\n\nPlease log in again.";
+                        let err_msg = "Your login token is no longer valid.\n\nPlease log in again.";
                         Cx::post_action(LoginAction::LoginFailure(err_msg.to_string()));
                         enqueue_rooms_list_update(RoomsListUpdate::Status {
                             status: err_msg.to_string(),
@@ -2922,9 +2642,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                         continue 'login_loop;
                     }
                     Err(e) => {
-                        warning!(
-                            "Session validation via whoami failed, but the error was not an invalid token; continuing startup: {e}"
-                        );
+                        warning!("Session validation via whoami failed, but the error was not an invalid token; continuing startup: {e}");
                     }
                 }
             }
@@ -2934,8 +2652,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                 let _ = client_opt.take();
             }
 
-            let logged_in_user_id: OwnedUserId = client
-                .user_id()
+            let logged_in_user_id: OwnedUserId = client.user_id()
                 .expect("BUG: Client::user_id() returned None after successful login!")
                 .to_owned();
             let status = format!("Logged in as {}.\n → Loading rooms...", logged_in_user_id);
@@ -2943,9 +2660,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
 
             // Store this active client in our global Client state so that other tasks can access it.
             if let Some(_existing) = CLIENT.lock().unwrap().replace(client.clone()) {
-                error!(
-                    "BUG: unexpectedly replaced an existing client when initializing the matrix client."
-                );
+                error!("BUG: unexpectedly replaced an existing client when initializing the matrix client.");
             }
 
             // Listen for changes to our verification status and incoming verification requests.
@@ -2969,9 +2684,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                     let err_msg = if is_invalid_token_error(&e) {
                         "Your login token is no longer valid.\n\nPlease log in again.".to_string()
                     } else {
-                        format!(
-                            "Please restart Robrix.\n\nFailed to create Matrix sync service: {e}."
-                        )
+                        format!("Please restart Robrix.\n\nFailed to create Matrix sync service: {e}.")
                     };
                     if is_invalid_token_error(&e) {
                         clear_persisted_session(client.user_id()).await;
@@ -3009,9 +2722,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
         let room_list_service = sync_service.room_list_service();
 
         if let Some(_existing) = SYNC_SERVICE.lock().unwrap().replace(Arc::new(sync_service)) {
-            error!(
-                "BUG: unexpectedly replaced an existing sync service when initializing the matrix client."
-            );
+            error!("BUG: unexpectedly replaced an existing sync service when initializing the matrix client.");
         }
 
         let mut room_list_service_task = rt.spawn(room_list_service_loop(room_list_service));
@@ -3128,6 +2839,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
     }
 }
 
+
 /// The main async task that listens for changes to all rooms.
 async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Result<()> {
     let all_rooms_list = room_list_service.all_rooms().await?;
@@ -3141,13 +2853,13 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
     // 1. not spaces (those are handled by the SpaceService),
     // 2. not left (clients don't typically show rooms that the user has already left),
     // 3. not outdated (don't show tombstoned rooms whose successor is already joined).
-    room_list_dynamic_entries_controller.set_filter(Box::new(filters::new_filter_all(vec![
-        Box::new(filters::new_filter_not(Box::new(
-            filters::new_filter_space(),
-        ))),
-        Box::new(filters::new_filter_non_left()),
-        Box::new(filters::new_filter_deduplicate_versions()),
-    ])));
+    room_list_dynamic_entries_controller.set_filter(Box::new(
+        filters::new_filter_all(vec![
+            Box::new(filters::new_filter_not(Box::new(filters::new_filter_space()))),
+            Box::new(filters::new_filter_non_left()),
+            Box::new(filters::new_filter_deduplicate_versions()),
+        ])
+    ));
 
     let mut all_known_rooms: Vector<RoomListServiceRoomInfo> = Vector::new();
     let current_user_id = current_user_id();
@@ -3163,13 +2875,7 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                     // Append and Reset are identical, except for Reset first clears all rooms.
                     let _num_new_rooms = new_rooms.len();
                     if is_reset {
-                        if LOG_ROOM_LIST_DIFFS {
-                            log!(
-                                "room_list: diff Reset, old length {}, new length {}",
-                                all_known_rooms.len(),
-                                new_rooms.len()
-                            );
-                        }
+                        if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Reset, old length {}, new length {}", all_known_rooms.len(), new_rooms.len()); }
                         // Iterate manually so we can know which rooms are being removed.
                         while let Some(room) = all_known_rooms.pop_back() {
                             remove_room(&room);
@@ -3180,35 +2886,20 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                         enqueue_rooms_list_update(RoomsListUpdate::ClearRooms);
                         enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Clear));
                     } else {
-                        if LOG_ROOM_LIST_DIFFS {
-                            log!(
-                                "room_list: diff Append, old length {}, adding {} new items",
-                                all_known_rooms.len(),
-                                _num_new_rooms
-                            );
-                        }
+                        if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Append, old length {}, adding {} new items", all_known_rooms.len(), _num_new_rooms); }
                     }
 
                     // Parallelize creating each room's RoomListServiceRoomInfo and adding that new room.
                     // We combine `from_room` and `add_new_room` into a single async task per room.
-                    let new_room_infos: Vec<RoomListServiceRoomInfo> =
-                        join_all(new_rooms.into_iter().map(|room| async {
-                            let room_info = RoomListServiceRoomInfo::from_room(
-                                room.into_inner(),
-                                &current_user_id,
-                            )
-                            .await;
-                            if let Err(e) =
-                                add_new_room(&room_info, &room_list_service, false).await
-                            {
-                                error!(
-                                    "Failed to add new room: {:?} ({}); error: {:?}",
-                                    room_info.display_name, room_info.room_id, e
-                                );
+                    let new_room_infos: Vec<RoomListServiceRoomInfo> = join_all(
+                        new_rooms.into_iter().map(|room| async {
+                            let room_info = RoomListServiceRoomInfo::from_room(room.into_inner(), &current_user_id).await;
+                            if let Err(e) = add_new_room(&room_info, &room_list_service, false).await {
+                                error!("Failed to add new room: {:?} ({}); error: {:?}", room_info.display_name, room_info.room_id, e);
                             }
                             room_info
-                        }))
-                        .await;
+                        })
+                    ).await;
 
                     // Send room order update with the new room IDs
                     let (room_id_refs, room_ids) = {
@@ -3222,57 +2913,43 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                     };
                     if !room_ids.is_empty() {
                         enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                            VecDiff::Append { values: room_ids },
+                            VecDiff::Append { values: room_ids }
                         ));
                         room_list_service.subscribe_to_rooms(&room_id_refs).await;
                         all_known_rooms.extend(new_room_infos);
                     }
                 }
                 VectorDiff::Clear => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff Clear");
-                    }
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Clear"); }
                     all_known_rooms.clear();
                     ALL_JOINED_ROOMS.lock().unwrap().clear();
                     enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Clear));
                     enqueue_rooms_list_update(RoomsListUpdate::ClearRooms);
                 }
                 VectorDiff::PushFront { value: new_room } => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff PushFront");
-                    }
-                    let new_room =
-                        RoomListServiceRoomInfo::from_room(new_room.into_inner(), &current_user_id)
-                            .await;
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff PushFront"); }
+                    let new_room = RoomListServiceRoomInfo::from_room(new_room.into_inner(), &current_user_id).await;
                     let room_id = new_room.room_id.clone();
                     add_new_room(&new_room, &room_list_service, true).await?;
                     enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                        VecDiff::PushFront { value: room_id },
+                        VecDiff::PushFront { value: room_id }
                     ));
                     all_known_rooms.push_front(new_room);
                 }
                 VectorDiff::PushBack { value: new_room } => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff PushBack");
-                    }
-                    let new_room =
-                        RoomListServiceRoomInfo::from_room(new_room.into_inner(), &current_user_id)
-                            .await;
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff PushBack"); }
+                    let new_room = RoomListServiceRoomInfo::from_room(new_room.into_inner(), &current_user_id).await;
                     let room_id = new_room.room_id.clone();
                     add_new_room(&new_room, &room_list_service, true).await?;
                     enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                        VecDiff::PushBack { value: room_id },
+                        VecDiff::PushBack { value: room_id }
                     ));
                     all_known_rooms.push_back(new_room);
                 }
                 remove_diff @ VectorDiff::PopFront => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff PopFront");
-                    }
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff PopFront"); }
                     if let Some(room) = all_known_rooms.pop_front() {
-                        enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                            VecDiff::PopFront,
-                        ));
+                        enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::PopFront));
                         optimize_remove_then_add_into_update(
                             remove_diff,
                             &room,
@@ -3280,18 +2957,13 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                             &mut all_known_rooms,
                             &room_list_service,
                             &current_user_id,
-                        )
-                        .await?;
+                        ).await?;
                     }
                 }
                 remove_diff @ VectorDiff::PopBack => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff PopBack");
-                    }
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff PopBack"); }
                     if let Some(room) = all_known_rooms.pop_back() {
-                        enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                            VecDiff::PopBack,
-                        ));
+                        enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::PopBack));
                         optimize_remove_then_add_into_update(
                             remove_diff,
                             &room,
@@ -3299,61 +2971,38 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                             &mut all_known_rooms,
                             &room_list_service,
                             &current_user_id,
-                        )
-                        .await?;
+                        ).await?;
                     }
                 }
-                VectorDiff::Insert {
-                    index,
-                    value: new_room,
-                } => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff Insert at {index}");
-                    }
-                    let new_room =
-                        RoomListServiceRoomInfo::from_room(new_room.into_inner(), &current_user_id)
-                            .await;
+                VectorDiff::Insert { index, value: new_room } => {
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Insert at {index}"); }
+                    let new_room = RoomListServiceRoomInfo::from_room(new_room.into_inner(), &current_user_id).await;
                     let room_id = new_room.room_id.clone();
                     add_new_room(&new_room, &room_list_service, true).await?;
-                    enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Insert {
-                        index,
-                        value: room_id,
-                    }));
+                    enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
+                        VecDiff::Insert { index, value: room_id }
+                    ));
                     all_known_rooms.insert(index, new_room);
                 }
-                VectorDiff::Set {
-                    index,
-                    value: changed_room,
-                } => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff Set at {index}");
-                    }
-                    let changed_room = RoomListServiceRoomInfo::from_room(
-                        changed_room.into_inner(),
-                        &current_user_id,
-                    )
-                    .await;
+                VectorDiff::Set { index, value: changed_room } => {
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Set at {index}"); }
+                    let changed_room = RoomListServiceRoomInfo::from_room(changed_room.into_inner(), &current_user_id).await;
                     if let Some(old_room) = all_known_rooms.get(index) {
                         update_room(old_room, &changed_room, &room_list_service).await?;
                     } else {
                         error!("BUG: room list diff: Set index {index} was out of bounds.");
                     }
                     // Send order update (room ID at this index may have changed)
-                    enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Set {
-                        index,
-                        value: changed_room.room_id.clone(),
-                    }));
+                    enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
+                        VecDiff::Set { index, value: changed_room.room_id.clone() }
+                    ));
                     all_known_rooms.set(index, changed_room);
                 }
                 remove_diff @ VectorDiff::Remove { index } => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff Remove at {index}");
-                    }
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Remove at {index}"); }
                     if index < all_known_rooms.len() {
                         let room = all_known_rooms.remove(index);
-                        enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                            VecDiff::Remove { index },
-                        ));
+                        enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Remove { index }));
                         optimize_remove_then_add_into_update(
                             remove_diff,
                             &room,
@@ -3361,19 +3010,13 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                             &mut all_known_rooms,
                             &room_list_service,
                             &current_user_id,
-                        )
-                        .await?;
+                        ).await?;
                     } else {
-                        error!(
-                            "BUG: room_list: diff Remove index {index} out of bounds, len {}",
-                            all_known_rooms.len()
-                        );
+                        error!("BUG: room_list: diff Remove index {index} out of bounds, len {}", all_known_rooms.len());
                     }
                 }
                 VectorDiff::Truncate { length } => {
-                    if LOG_ROOM_LIST_DIFFS {
-                        log!("room_list: diff Truncate to {length}");
-                    }
+                    if LOG_ROOM_LIST_DIFFS { log!("room_list: diff Truncate to {length}"); }
                     // Iterate manually so we can know which rooms are being removed.
                     while all_known_rooms.len() > length {
                         if let Some(room) = all_known_rooms.pop_back() {
@@ -3382,7 +3025,7 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
                     }
                     all_known_rooms.truncate(length); // sanity check
                     enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
-                        VecDiff::Truncate { length },
+                        VecDiff::Truncate { length }
                     ));
                 }
             }
@@ -3391,6 +3034,7 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
 
     bail!("room list service sync loop ended unexpectedly")
 }
+
 
 /// Attempts to optimize a common RoomListService operation of remove + add.
 ///
@@ -3411,58 +3055,48 @@ async fn optimize_remove_then_add_into_update(
 ) -> Result<()> {
     let next_diff_was_handled: bool;
     match peekable_diffs.peek() {
-        Some(VectorDiff::Insert {
-            index: insert_index,
-            value: new_room,
-        }) if room.room_id == new_room.room_id() => {
+        Some(VectorDiff::Insert { index: insert_index, value: new_room })
+            if room.room_id == new_room.room_id() =>
+        {
             if LOG_ROOM_LIST_DIFFS {
-                log!(
-                    "Optimizing {remove_diff:?} + Insert({insert_index}) into Update for room {}",
-                    room.room_id
-                );
+                log!("Optimizing {remove_diff:?} + Insert({insert_index}) into Update for room {}", room.room_id);
             }
-            let new_room =
-                RoomListServiceRoomInfo::from_room_ref(new_room.deref(), current_user_id).await;
+            let new_room = RoomListServiceRoomInfo::from_room_ref(new_room.deref(), current_user_id).await;
             update_room(room, &new_room, room_list_service).await?;
             // Send order update for the insert
-            enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Insert {
-                index: *insert_index,
-                value: new_room.room_id.clone(),
-            }));
+            enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
+                VecDiff::Insert { index: *insert_index, value: new_room.room_id.clone() }
+            ));
             all_known_rooms.insert(*insert_index, new_room);
             next_diff_was_handled = true;
         }
-        Some(VectorDiff::PushFront { value: new_room }) if room.room_id == new_room.room_id() => {
+        Some(VectorDiff::PushFront { value: new_room })
+            if room.room_id == new_room.room_id() =>
+        {
             if LOG_ROOM_LIST_DIFFS {
-                log!(
-                    "Optimizing {remove_diff:?} + PushFront into Update for room {}",
-                    room.room_id
-                );
+                log!("Optimizing {remove_diff:?} + PushFront into Update for room {}", room.room_id);
             }
-            let new_room =
-                RoomListServiceRoomInfo::from_room_ref(new_room.deref(), current_user_id).await;
+            let new_room = RoomListServiceRoomInfo::from_room_ref(new_room.deref(), current_user_id).await;
             update_room(room, &new_room, room_list_service).await?;
             // Send order update for the push front
-            enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::PushFront {
-                value: new_room.room_id.clone(),
-            }));
+            enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
+                VecDiff::PushFront { value: new_room.room_id.clone() }
+            ));
             all_known_rooms.push_front(new_room);
             next_diff_was_handled = true;
         }
-        Some(VectorDiff::PushBack { value: new_room }) if room.room_id == new_room.room_id() => {
+        Some(VectorDiff::PushBack { value: new_room })
+            if room.room_id == new_room.room_id() =>
+        {
             if LOG_ROOM_LIST_DIFFS {
-                log!(
-                    "Optimizing {remove_diff:?} + PushBack into Update for room {}",
-                    room.room_id
-                );
+                log!("Optimizing {remove_diff:?} + PushBack into Update for room {}", room.room_id);
             }
-            let new_room =
-                RoomListServiceRoomInfo::from_room_ref(new_room.deref(), current_user_id).await;
+            let new_room = RoomListServiceRoomInfo::from_room_ref(new_room.deref(), current_user_id).await;
             update_room(room, &new_room, room_list_service).await?;
             // Send order update for the push back
-            enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::PushBack {
-                value: new_room.room_id.clone(),
-            }));
+            enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(
+                VecDiff::PushBack { value: new_room.room_id.clone() }
+            ));
             all_known_rooms.push_back(new_room);
             next_diff_was_handled = true;
         }
@@ -3476,6 +3110,7 @@ async fn optimize_remove_then_add_into_update(
     Ok(())
 }
 
+
 /// Invoked when the room list service has received an update that changes an existing room.
 async fn update_room(
     old_room: &RoomListServiceRoomInfo,
@@ -3486,29 +3121,18 @@ async fn update_room(
     if old_room.room_id == new_room_id {
         // Handle state transitions for a room.
         if LOG_ROOM_LIST_DIFFS {
-            log!(
-                "Room {:?} ({new_room_id}) state went from {:?} --> {:?}",
-                new_room.display_name,
-                old_room.state,
-                new_room.state
-            );
+            log!("Room {:?} ({new_room_id}) state went from {:?} --> {:?}", new_room.display_name, old_room.state, new_room.state);
         }
         if old_room.state != new_room.state {
             match new_room.state {
                 RoomState::Banned => {
                     // TODO: handle rooms that this user has been banned from.
-                    log!(
-                        "Removing Banned room: {:?} ({new_room_id})",
-                        new_room.display_name
-                    );
+                    log!("Removing Banned room: {:?} ({new_room_id})", new_room.display_name);
                     remove_room(new_room);
                     return Ok(());
                 }
                 RoomState::Left => {
-                    log!(
-                        "Removing Left room: {:?} ({new_room_id})",
-                        new_room.display_name
-                    );
+                    log!("Removing Left room: {:?} ({new_room_id})", new_room.display_name);
                     // TODO: instead of removing this, we could optionally add it to
                     //       a separate list of left rooms, which would be collapsed by default.
                     //       Upon clicking a left room, we could show a splash page
@@ -3518,17 +3142,11 @@ async fn update_room(
                     return Ok(());
                 }
                 RoomState::Joined => {
-                    log!(
-                        "update_room(): adding new Joined room: {:?} ({new_room_id})",
-                        new_room.display_name
-                    );
+                    log!("update_room(): adding new Joined room: {:?} ({new_room_id})", new_room.display_name);
                     return add_new_room(new_room, room_list_service, true).await;
                 }
                 RoomState::Invited => {
-                    log!(
-                        "update_room(): adding new Invited room: {:?} ({new_room_id})",
-                        new_room.display_name
-                    );
+                    log!("update_room(): adding new Invited room: {:?} ({new_room_id})", new_room.display_name);
                     return add_new_room(new_room, room_list_service, true).await;
                 }
                 RoomState::Knocked => {
@@ -3546,12 +3164,7 @@ async fn update_room(
             spawn_fetch_room_avatar(new_room);
         }
         if old_room.display_name != new_room.display_name {
-            log!(
-                "Updating room {} name: {:?} --> {:?}",
-                new_room_id,
-                old_room.display_name,
-                new_room.display_name
-            );
+            log!("Updating room {} name: {:?} --> {:?}", new_room_id, old_room.display_name, new_room.display_name);
 
             enqueue_rooms_list_update(RoomsListUpdate::UpdateRoomName {
                 new_room_name: (new_room.display_name.clone(), new_room_id.clone()).into(),
@@ -3561,15 +3174,12 @@ async fn update_room(
         // Then, we check for changes to room data that is only relevant to joined rooms:
         // including the latest event, tags, unread counts, is_direct, tombstoned state, power levels, etc.
         // Invited or left rooms don't care about these details.
-        if matches!(new_room.state, RoomState::Joined) {
+        if matches!(new_room.state, RoomState::Joined) { 
             // For some reason, the latest event API does not reliably catch *all* changes
             // to the latest event in a given room, such as redactions.
             // Thus, we have to re-obtain the latest event on *every* update, regardless of timestamp.
             //
-            let update_latest = match (
-                old_room.latest_event_timestamp,
-                new_room.room.latest_event_timestamp(),
-            ) {
+            let update_latest = match (old_room.latest_event_timestamp, new_room.room.latest_event_timestamp()) {
                 (Some(old_ts), Some(new_ts)) => new_ts >= old_ts,
                 (None, Some(_)) => true,
                 _ => false,
@@ -3578,13 +3188,9 @@ async fn update_room(
                 update_latest_event(&new_room.room).await;
             }
 
+
             if old_room.tags != new_room.tags {
-                log!(
-                    "Updating room {} tags from {:?} to {:?}",
-                    new_room_id,
-                    old_room.tags,
-                    new_room.tags
-                );
+                log!("Updating room {} tags from {:?} to {:?}", new_room_id, old_room.tags, new_room.tags);
                 enqueue_rooms_list_update(RoomsListUpdate::Tags {
                     room_id: new_room_id.clone(),
                     new_tags: new_room.tags.clone().unwrap_or_default(),
@@ -3595,15 +3201,11 @@ async fn update_room(
                 || old_room.num_unread_messages != new_room.num_unread_messages
                 || old_room.num_unread_mentions != new_room.num_unread_mentions
             {
-                log!(
-                    "Updating room {}, marked unread {} --> {}, unread messages {} --> {}, unread mentions {} --> {}",
+                log!("Updating room {}, marked unread {} --> {}, unread messages {} --> {}, unread mentions {} --> {}",
                     new_room_id,
-                    old_room.is_marked_unread,
-                    new_room.is_marked_unread,
-                    old_room.num_unread_messages,
-                    new_room.num_unread_messages,
-                    old_room.num_unread_mentions,
-                    new_room.num_unread_mentions,
+                    old_room.is_marked_unread, new_room.is_marked_unread,
+                    old_room.num_unread_messages, new_room.num_unread_messages,
+                    old_room.num_unread_mentions, new_room.num_unread_mentions,
                 );
                 enqueue_rooms_list_update(RoomsListUpdate::UpdateNumUnreadMessages {
                     room_id: new_room_id.clone(),
@@ -3614,8 +3216,7 @@ async fn update_room(
             }
 
             if old_room.is_direct != new_room.is_direct {
-                log!(
-                    "Updating room {} is_direct from {} to {}",
+                log!("Updating room {} is_direct from {} to {}",
                     new_room_id,
                     old_room.is_direct,
                     new_room.is_direct,
@@ -3630,8 +3231,7 @@ async fn update_room(
             let mut get_timeline_update_sender = |room_id| {
                 if __timeline_update_sender_opt.is_none() {
                     if let Some(jrd) = ALL_JOINED_ROOMS.lock().unwrap().get(room_id) {
-                        __timeline_update_sender_opt =
-                            Some(jrd.main_timeline.timeline_update_sender.clone());
+                        __timeline_update_sender_opt = Some(jrd.main_timeline.timeline_update_sender.clone());
                     }
                 }
                 __timeline_update_sender_opt.clone()
@@ -3640,9 +3240,7 @@ async fn update_room(
             if !old_room.is_tombstoned && new_room.is_tombstoned {
                 let successor_room = new_room.room.successor_room();
                 log!("Updating room {new_room_id} to be tombstoned, {successor_room:?}");
-                enqueue_rooms_list_update(RoomsListUpdate::TombstonedRoom {
-                    room_id: new_room_id.clone(),
-                });
+                enqueue_rooms_list_update(RoomsListUpdate::TombstonedRoom { room_id: new_room_id.clone() });
                 if let Some(timeline_update_sender) = get_timeline_update_sender(&new_room_id) {
                     spawn_fetch_successor_room_preview(
                         room_list_service.client().clone(),
@@ -3651,9 +3249,7 @@ async fn update_room(
                         timeline_update_sender,
                     );
                 } else {
-                    error!(
-                        "BUG: could not find JoinedRoomDetails for newly-tombstoned room {new_room_id}"
-                    );
+                    error!("BUG: could not find JoinedRoomDetails for newly-tombstoned room {new_room_id}");
                 }
             }
 
@@ -3664,37 +3260,36 @@ async fn update_room(
                     log!("Updating room {new_room_id} user power levels.");
                     match timeline_update_sender.send(TimelineUpdate::UserPowerLevels(nupl)) {
                         Ok(_) => SignalToUI::set_ui_signal(),
-                        Err(_) => error!(
-                            "Failed to send the UserPowerLevels update to room {new_room_id}"
-                        ),
+                        Err(_) => error!("Failed to send the UserPowerLevels update to room {new_room_id}"),
                     }
                 } else {
-                    error!(
-                        "BUG: could not find JoinedRoomDetails for room {new_room_id} where power levels changed."
-                    );
+                    error!("BUG: could not find JoinedRoomDetails for room {new_room_id} where power levels changed.");
                 }
             }
         }
         Ok(())
-    } else {
-        warning!(
-            "UNTESTED SCENARIO: update_room(): removing old room {}, replacing with new room {}",
-            old_room.room_id,
-            new_room_id,
+    }
+    else {
+        warning!("UNTESTED SCENARIO: update_room(): removing old room {}, replacing with new room {}",
+            old_room.room_id, new_room_id,
         );
         remove_room(old_room);
         add_new_room(new_room, room_list_service, true).await
     }
 }
 
+
 /// Invoked when the room list service has received an update to remove an existing room.
 fn remove_room(room: &RoomListServiceRoomInfo) {
     ALL_JOINED_ROOMS.lock().unwrap().remove(&room.room_id);
-    enqueue_rooms_list_update(RoomsListUpdate::RemoveRoom {
-        room_id: room.room_id.clone(),
-        new_state: room.state,
-    });
+    enqueue_rooms_list_update(
+        RoomsListUpdate::RemoveRoom {
+            room_id: room.room_id.clone(),
+            new_state: room.state,
+        }
+    );
 }
+
 
 /// Invoked when the room list service has received an update with a brand new room.
 async fn add_new_room(
@@ -3704,39 +3299,26 @@ async fn add_new_room(
 ) -> Result<()> {
     match new_room.state {
         RoomState::Knocked => {
-            log!(
-                "Got new Knocked room: {:?} ({})",
-                new_room.display_name,
-                new_room.room_id
-            );
+            log!("Got new Knocked room: {:?} ({})", new_room.display_name, new_room.room_id);
             // Note: here we could optionally display Knocked rooms as a separate type of room
             //       in the rooms list, but it's not really necessary at this point.
             return Ok(());
         }
         RoomState::Banned => {
-            log!(
-                "Got new Banned room: {:?} ({})",
-                new_room.display_name,
-                new_room.room_id
-            );
+            log!("Got new Banned room: {:?} ({})", new_room.display_name, new_room.room_id);
             // Note: here we could optionally display Banned rooms as a separate type of room
             //       in the rooms list, but it's not really necessary at this point.
             return Ok(());
         }
         RoomState::Left => {
-            log!(
-                "Got new Left room: {:?} ({:?})",
-                new_room.display_name,
-                new_room.room_id
-            );
+            log!("Got new Left room: {:?} ({:?})", new_room.display_name, new_room.room_id);
             // Note: here we could optionally display Left rooms as a separate type of room
             //       in the rooms list, but it's not really necessary at this point.
             return Ok(());
         }
         RoomState::Invited => {
             let invite_details = new_room.room.invite_details().await.ok();
-            let room_name_id =
-                RoomNameId::from((new_room.display_name.clone(), new_room.room_id.clone()));
+            let room_name_id = RoomNameId::from((new_room.display_name.clone(), new_room.room_id.clone()));
             // Start with a basic text avatar; the avatar image will be fetched asynchronously below.
             let room_avatar = avatar_from_room_name(room_name_id.name_for_avatar());
             let inviter_info = if let Some(inviter) = invite_details.and_then(|d| d.inviter) {
@@ -3753,20 +3335,18 @@ async fn add_new_room(
             } else {
                 None
             };
-            rooms_list::enqueue_rooms_list_update(RoomsListUpdate::AddInvitedRoom(
-                InvitedRoomInfo {
-                    room_name_id: room_name_id.clone(),
-                    inviter_info,
-                    room_avatar,
-                    canonical_alias: new_room.room.canonical_alias(),
-                    alt_aliases: new_room.room.alt_aliases(),
-                    // we don't actually display the latest event for Invited rooms, so don't bother.
-                    latest: None,
-                    invite_state: Default::default(),
-                    is_selected: false,
-                    is_direct: new_room.is_direct,
-                },
-            ));
+            rooms_list::enqueue_rooms_list_update(RoomsListUpdate::AddInvitedRoom(InvitedRoomInfo {
+                room_name_id: room_name_id.clone(),
+                inviter_info,
+                room_avatar,
+                canonical_alias: new_room.room.canonical_alias(),
+                alt_aliases: new_room.room.alt_aliases(),
+                // we don't actually display the latest event for Invited rooms, so don't bother.
+                latest: None,
+                invite_state: Default::default(),
+                is_selected: false,
+                is_direct: new_room.is_direct,
+            }));
             Cx::post_action(AppStateAction::RoomLoadedSuccessfully {
                 room_name_id,
                 is_invite: true,
@@ -3774,21 +3354,17 @@ async fn add_new_room(
             spawn_fetch_room_avatar(new_room);
             return Ok(());
         }
-        RoomState::Joined => {} // Fall through to adding the joined room below.
+        RoomState::Joined => { } // Fall through to adding the joined room below.
     }
 
     // If we didn't already subscribe to this room, do so now.
     // This ensures we will properly receive all of its states and latest event.
     if subscribe {
-        room_list_service
-            .subscribe_to_rooms(&[&new_room.room_id])
-            .await;
+        room_list_service.subscribe_to_rooms(&[&new_room.room_id]).await;
     }
 
     let timeline = Arc::new(
-        new_room
-            .room
-            .timeline_builder()
+        new_room.room.timeline_builder()
             .with_focus(TimelineFocus::Live {
                 // we show threads as separate timelines in their own RoomScreen
                 hide_threaded_events: true,
@@ -3796,12 +3372,7 @@ async fn add_new_room(
             .track_read_marker_and_receipts(TimelineReadReceiptTracking::AllEvents)
             .build()
             .await
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "BUG: Failed to build timeline for room {}: {e}",
-                    new_room.room_id
-                )
-            })?,
+            .map_err(|e| anyhow::anyhow!("BUG: Failed to build timeline for room {}: {e}", new_room.room_id))?,
     );
     let (timeline_update_sender, timeline_update_receiver) = crossbeam_channel::unbounded();
 
@@ -3817,11 +3388,7 @@ async fn add_new_room(
     // We need to add the room to the `ALL_JOINED_ROOMS` list before we can send
     // an `AddJoinedRoom` update to the RoomsList widget, because that widget might
     // immediately issue a `MatrixRequest` that relies on that room being in `ALL_JOINED_ROOMS`.
-    log!(
-        "Adding new joined room {}, name: {:?}",
-        new_room.room_id,
-        new_room.display_name
-    );
+    log!("Adding new joined room {}, name: {:?}", new_room.room_id, new_room.display_name);
     ALL_JOINED_ROOMS.lock().unwrap().insert(
         new_room.room_id.clone(),
         JoinedRoomDetails {
@@ -3842,8 +3409,7 @@ async fn add_new_room(
     let latest = get_latest_event_details(
         &new_room.room.latest_event().await,
         room_list_service.client(),
-    )
-    .await;
+    ).await;
     let room_name_id = RoomNameId::from((new_room.display_name.clone(), new_room.room_id.clone()));
     // Start with a basic text avatar; the avatar image will be fetched asynchronously below.
     let room_avatar = avatar_from_room_name(room_name_id.name_for_avatar());
@@ -3874,8 +3440,7 @@ async fn add_new_room(
 #[allow(unused)]
 async fn current_ignore_user_list(client: &Client) -> Option<HashSet<OwnedUserId>> {
     use matrix_sdk::ruma::events::ignored_user_list::IgnoredUserListEventContent;
-    let ignored_users = client
-        .account()
+    let ignored_users = client.account()
         .account_data::<IgnoredUserListEventContent>()
         .await
         .ok()??
@@ -3939,9 +3504,7 @@ fn handle_load_app_state(user_id: OwnedUserId) {
                     && !app_state.saved_dock_state_home.dock_items.is_empty()
                 {
                     log!("Loaded room panel state from app data directory. Restoring now...");
-                    Cx::post_action(AppStateAction::RestoreAppStateFromPersistentState(
-                        app_state,
-                    ));
+                    Cx::post_action(AppStateAction::RestoreAppStateFromPersistentState(app_state));
                 }
             }
             Err(_e) => {
@@ -3960,12 +3523,12 @@ fn handle_load_app_state(user_id: OwnedUserId) {
 fn is_invalid_token_error(e: &sync_service::Error) -> bool {
     use matrix_sdk::ruma::api::client::error::ErrorKind;
     let sdk_error = match e {
-        sync_service::Error::RoomList(matrix_sdk_ui::room_list_service::Error::SlidingSync(
-            err,
-        )) => err,
-        sync_service::Error::EncryptionSync(encryption_sync_service::Error::SlidingSync(err)) => {
-            err
-        }
+        sync_service::Error::RoomList(
+            matrix_sdk_ui::room_list_service::Error::SlidingSync(err)
+        ) => err,
+        sync_service::Error::EncryptionSync(
+            encryption_sync_service::Error::SlidingSync(err)
+        ) => err,
         _ => return false,
     };
     matches!(
@@ -4047,12 +3610,14 @@ fn handle_sync_indicator_subscriber(sync_service: &SyncService) {
     const SYNC_INDICATOR_DELAY: Duration = Duration::from_millis(100);
     /// Duration for sync indicator delay before hiding
     const SYNC_INDICATOR_HIDE_DELAY: Duration = Duration::from_millis(200);
-    let sync_indicator_stream = sync_service
-        .room_list_service()
-        .sync_indicator(SYNC_INDICATOR_DELAY, SYNC_INDICATOR_HIDE_DELAY);
-
+    let sync_indicator_stream = sync_service.room_list_service()
+        .sync_indicator(
+            SYNC_INDICATOR_DELAY,
+            SYNC_INDICATOR_HIDE_DELAY
+        );
+    
     Handle::current().spawn(async move {
-        let mut sync_indicator_stream = std::pin::pin!(sync_indicator_stream);
+       let mut sync_indicator_stream = std::pin::pin!(sync_indicator_stream);
 
         while let Some(indicator) = sync_indicator_stream.next().await {
             let is_syncing = match indicator {
@@ -4065,10 +3630,7 @@ fn handle_sync_indicator_subscriber(sync_service: &SyncService) {
 }
 
 fn handle_room_list_service_loading_state(mut loading_state: Subscriber<RoomListLoadingState>) {
-    log!(
-        "Initial room list loading state is {:?}",
-        loading_state.get()
-    );
+    log!("Initial room list loading state is {:?}", loading_state.get());
     Handle::current().spawn(async move {
         while let Some(state) = loading_state.next().await {
             log!("Received a room list loading state update: {state:?}");
@@ -4076,12 +3638,8 @@ fn handle_room_list_service_loading_state(mut loading_state: Subscriber<RoomList
                 RoomListLoadingState::NotLoaded => {
                     enqueue_rooms_list_update(RoomsListUpdate::NotLoaded);
                 }
-                RoomListLoadingState::Loaded {
-                    maximum_number_of_rooms,
-                } => {
-                    enqueue_rooms_list_update(RoomsListUpdate::LoadedRooms {
-                        max_rooms: maximum_number_of_rooms,
-                    });
+                RoomListLoadingState::Loaded { maximum_number_of_rooms } => {
+                    enqueue_rooms_list_update(RoomsListUpdate::LoadedRooms { max_rooms: maximum_number_of_rooms });
                     // The SDK docs state that we cannot move from the `Loaded` state
                     // back to the `NotLoaded` state, so we can safely exit this task here.
                     return;
@@ -4104,12 +3662,12 @@ fn spawn_fetch_successor_room_preview(
     Handle::current().spawn(async move {
         log!("Updating room {tombstoned_room_id} to be tombstoned, {successor_room:?}");
         let srd = if let Some(SuccessorRoom { room_id, reason }) = successor_room {
-            match fetch_room_preview_with_avatar(&client, room_id.deref().into(), Vec::new()).await
-            {
-                Ok(room_preview) => SuccessorRoomDetails::Full {
-                    room_preview,
-                    reason,
-                },
+            match fetch_room_preview_with_avatar(
+                &client,
+                room_id.deref().into(),
+                Vec::new(),
+            ).await {
+                Ok(room_preview) => SuccessorRoomDetails::Full { room_preview, reason },
                 Err(e) => {
                     log!("Failed to fetch preview of successor room {room_id}, error: {e:?}");
                     SuccessorRoomDetails::Basic(SuccessorRoom { room_id, reason })
@@ -4143,18 +3701,12 @@ async fn fetch_room_preview_with_avatar(
         };
         match client.media().get_media_content(&media_request, true).await {
             Ok(avatar_content) => {
-                log!(
-                    "Fetched avatar for room preview {:?} ({})",
-                    room_preview.name,
-                    room_preview.room_id
-                );
+                log!("Fetched avatar for room preview {:?} ({})", room_preview.name, room_preview.room_id);
                 FetchedRoomAvatar::Image(avatar_content.into())
             }
             Err(e) => {
-                log!(
-                    "Failed to fetch avatar for room preview {:?} ({}), error: {e:?}",
-                    room_preview.name,
-                    room_preview.room_id
+                log!("Failed to fetch avatar for room preview {:?} ({}), error: {e:?}",
+                    room_preview.name, room_preview.room_id
                 );
                 avatar_from_room_name(room_preview.name.as_deref())
             }
@@ -4174,10 +3726,7 @@ async fn fetch_room_preview_with_avatar(
 async fn fetch_thread_summary_details(
     room: &Room,
     thread_root_event_id: &EventId,
-) -> (
-    u32,
-    Option<matrix_sdk::deserialized_responses::TimelineEvent>,
-) {
+) -> (u32, Option<matrix_sdk::deserialized_responses::TimelineEvent>) {
     let mut num_replies = 0;
     let mut latest_reply_event = None;
 
@@ -4235,7 +3784,10 @@ async fn fetch_latest_thread_reply_event(
 }
 
 /// Counts all replies in the given thread by paginating `/relations` in batches.
-async fn count_thread_replies(room: &Room, thread_root_event_id: &EventId) -> Option<u32> {
+async fn count_thread_replies(
+    room: &Room,
+    thread_root_event_id: &EventId,
+) -> Option<u32> {
     let mut total_replies: u32 = 0;
     let mut next_batch_token = None;
 
@@ -4248,10 +3800,7 @@ async fn count_thread_replies(room: &Room, thread_root_event_id: &EventId) -> Op
             ..Default::default()
         };
 
-        let relations = room
-            .relations(thread_root_event_id.to_owned(), options)
-            .await
-            .ok()?;
+        let relations = room.relations(thread_root_event_id.to_owned(), options).await.ok()?;
         if relations.chunk.is_empty() {
             break;
         }
@@ -4277,8 +3826,7 @@ async fn text_preview_of_latest_thread_reply(
         Ok(Some(rm)) => Some(rm),
         _ => room.get_member(&sender_id).await.ok().flatten(),
     };
-    let sender_name = sender_room_member
-        .as_ref()
+    let sender_name = sender_room_member.as_ref()
         .and_then(|rm| rm.display_name())
         .unwrap_or(sender_id.as_str());
     let text_preview = text_preview_of_raw_timeline_event(raw, sender_name).unwrap_or_else(|| {
@@ -4294,6 +3842,7 @@ async fn text_preview_of_latest_thread_reply(
         Cow::Owned(replaced) => Some(replaced),
     }
 }
+
 
 /// Returns the timestamp and an HTML-formatted text preview of the given `latest_event`.
 ///
@@ -4318,37 +3867,29 @@ async fn get_latest_event_details(
 
     match latest_event_value {
         LatestEventValue::None => None,
-        LatestEventValue::Remote {
-            timestamp,
-            sender,
-            is_own,
-            profile,
-            content,
-        } => {
+        LatestEventValue::Remote { timestamp, sender, is_own, profile, content } => {
             let sender_username = get_sender_username!(profile, sender, *is_own);
-            let latest_message_text =
-                text_preview_of_timeline_item(content, sender, &sender_username)
-                    .format_with(&sender_username, true);
+            let latest_message_text = text_preview_of_timeline_item(
+                content,
+                sender,
+                &sender_username,
+            ).format_with(&sender_username, true);
             Some((*timestamp, latest_message_text))
         }
-        LatestEventValue::Local {
-            timestamp,
-            sender,
-            profile,
-            content,
-            state: _,
-        } => {
+        LatestEventValue::Local { timestamp, sender, profile, content, state: _ } => {
             // TODO: use the `state` enum to augment the preview text with more details.
             //       Example: "<span color="blue">Sending... {msg}</span>" or
             //                "<span color="red">Failed to send {msg}</span>"
             let is_own = current_user_id().is_some_and(|id| &id == sender);
             let sender_username = get_sender_username!(profile, sender, is_own);
-            let latest_message_text =
-                text_preview_of_timeline_item(content, sender, &sender_username)
-                    .format_with(&sender_username, true);
+            let latest_message_text = text_preview_of_timeline_item(
+                content,
+                sender,
+                &sender_username,
+            ).format_with(&sender_username, true);
             Some((*timestamp, latest_message_text))
         }
-    }
+    }    
 }
 
 /// Handles the given updated latest event for the given room.
@@ -4356,9 +3897,10 @@ async fn get_latest_event_details(
 /// This function sends a `RoomsListUpdate::UpdateLatestEvent`
 /// to update the latest event in the RoomsListEntry for the given room.
 async fn update_latest_event(room: &Room) {
-    if let Some((timestamp, latest_message_text)) =
-        get_latest_event_details(&room.latest_event().await, &room.client()).await
-    {
+    if let Some((timestamp, latest_message_text)) = get_latest_event_details(
+        &room.latest_event().await,
+        &room.client(),
+    ).await {
         enqueue_rooms_list_update(RoomsListUpdate::UpdateLatestEvent {
             room_id: room.room_id().to_owned(),
             timestamp,
@@ -4395,6 +3937,7 @@ async fn timeline_subscriber_handler(
     mut request_receiver: watch::Receiver<Vec<BackwardsPaginateUntilEventRequest>>,
     thread_root_event_id: Option<OwnedEventId>,
 ) {
+
     /// An inner function that searches the given new timeline items for a target event.
     ///
     /// If the target event is found, it is removed from the `target_event_id_opt` and returned,
@@ -4403,13 +3946,14 @@ async fn timeline_subscriber_handler(
         target_event_id_opt: &mut Option<OwnedEventId>,
         mut new_items_iter: impl Iterator<Item = &'a Arc<TimelineItem>>,
     ) -> Option<(usize, OwnedEventId)> {
-        let found_index = target_event_id_opt.as_ref().and_then(|target_event_id| {
-            new_items_iter.position(|new_item| {
-                new_item
+        let found_index = target_event_id_opt
+            .as_ref()
+            .and_then(|target_event_id| new_items_iter
+                .position(|new_item| new_item
                     .as_event()
                     .is_some_and(|new_ev| new_ev.event_id() == Some(target_event_id))
-            })
-        });
+                )
+            );
 
         if let Some(index) = found_index {
             target_event_id_opt.take().map(|ev| (index, ev))
@@ -4418,13 +3962,11 @@ async fn timeline_subscriber_handler(
         }
     }
 
+
     let room_id = room.room_id().to_owned();
     log!("Starting timeline subscriber for room {room_id}, thread {thread_root_event_id:?}...");
     let (mut timeline_items, mut subscriber) = timeline.subscribe().await;
-    log!(
-        "Received initial timeline update of {} items for room {room_id}, thread {thread_root_event_id:?}.",
-        timeline_items.len()
-    );
+    log!("Received initial timeline update of {} items for room {room_id}, thread {thread_root_event_id:?}.", timeline_items.len());
 
     timeline_update_sender.send(TimelineUpdate::FirstUpdate {
         initial_items: timeline_items.clone(),
@@ -4437,266 +3979,262 @@ async fn timeline_subscriber_handler(
     // the timeline index and event ID of the target event, if it has been found.
     let mut found_target_event_id: Option<(usize, OwnedEventId)> = None;
 
-    loop {
-        tokio::select! {
-            // we should check for new requests before handling new timeline updates,
-            // because the request might influence how we handle a timeline update.
-            biased;
+    loop { tokio::select! {
+        // we should check for new requests before handling new timeline updates,
+        // because the request might influence how we handle a timeline update.
+        biased;
 
-            // Handle updates to the current backwards pagination requests.
-            Ok(()) = request_receiver.changed() => {
-                let prev_target_event_id = target_event_id.clone();
-                let new_request_details = request_receiver
-                    .borrow_and_update()
-                    .iter()
-                    .find_map(|req| req.room_id
-                        .eq(&room_id)
-                        .then(|| (req.target_event_id.clone(), req.starting_index, req.current_tl_len))
-                    );
+        // Handle updates to the current backwards pagination requests.
+        Ok(()) = request_receiver.changed() => {
+            let prev_target_event_id = target_event_id.clone();
+            let new_request_details = request_receiver
+                .borrow_and_update()
+                .iter()
+                .find_map(|req| req.room_id
+                    .eq(&room_id)
+                    .then(|| (req.target_event_id.clone(), req.starting_index, req.current_tl_len))
+                );
 
-                target_event_id = new_request_details.as_ref().map(|(ev, ..)| ev.clone());
+            target_event_id = new_request_details.as_ref().map(|(ev, ..)| ev.clone());
 
-                // If we received a new request, start searching backwards for the target event.
-                if let Some((new_target_event_id, starting_index, current_tl_len)) = new_request_details {
-                    if prev_target_event_id.as_ref() != Some(&new_target_event_id) {
-                        let starting_index = if current_tl_len == timeline_items.len() {
-                            starting_index
-                        } else {
-                            // The timeline has changed since the request was made, so we can't rely on the `starting_index`.
-                            // Instead, we have no choice but to start from the end of the timeline.
-                            timeline_items.len()
-                        };
-                        // log!("Received new request to search for event {new_target_event_id} in room {room_id}, thread {thread_root_event_id:?} starting from index {starting_index} (tl len {}).", timeline_items.len());
-                        // Search backwards for the target event in the timeline, starting from the given index.
-                        if let Some(target_event_tl_index) = timeline_items
-                            .focus()
-                            .narrow(..starting_index)
-                            .into_iter()
-                            .rev()
-                            .position(|i| i.as_event()
-                                .and_then(|e| e.event_id())
-                                .is_some_and(|ev_id| ev_id == new_target_event_id)
-                            )
-                            .map(|i| starting_index.saturating_sub(i).saturating_sub(1))
-                        {
-                            // log!("Found existing target event {new_target_event_id} in room {room_id}, thread {thread_root_event_id:?} at index {target_event_tl_index}.");
+            // If we received a new request, start searching backwards for the target event.
+            if let Some((new_target_event_id, starting_index, current_tl_len)) = new_request_details {
+                if prev_target_event_id.as_ref() != Some(&new_target_event_id) {
+                    let starting_index = if current_tl_len == timeline_items.len() {
+                        starting_index
+                    } else {
+                        // The timeline has changed since the request was made, so we can't rely on the `starting_index`.
+                        // Instead, we have no choice but to start from the end of the timeline.
+                        timeline_items.len()
+                    };
+                    // log!("Received new request to search for event {new_target_event_id} in room {room_id}, thread {thread_root_event_id:?} starting from index {starting_index} (tl len {}).", timeline_items.len());
+                    // Search backwards for the target event in the timeline, starting from the given index.
+                    if let Some(target_event_tl_index) = timeline_items
+                        .focus()
+                        .narrow(..starting_index)
+                        .into_iter()
+                        .rev()
+                        .position(|i| i.as_event()
+                            .and_then(|e| e.event_id())
+                            .is_some_and(|ev_id| ev_id == new_target_event_id)
+                        )
+                        .map(|i| starting_index.saturating_sub(i).saturating_sub(1))
+                    {
+                        // log!("Found existing target event {new_target_event_id} in room {room_id}, thread {thread_root_event_id:?} at index {target_event_tl_index}.");
 
-                            // Nice! We found the target event in the current timeline items,
-                            // so there's no need to actually proceed with backwards pagination;
-                            // thus, we can clear the locally-tracked target event ID.
-                            target_event_id = None;
-                            found_target_event_id = None;
-                            timeline_update_sender.send(
-                                TimelineUpdate::TargetEventFound {
-                                    target_event_id: new_target_event_id.clone(),
-                                    index: target_event_tl_index,
-                                }
-                            ).unwrap_or_else(
-                                |_e| panic!("Error: timeline update sender couldn't send TargetEventFound({new_target_event_id}, {target_event_tl_index}) to room {room_id}, thread {thread_root_event_id:?}!")
-                            );
-                            // Send a Makepad-level signal to update this room's timeline UI view.
-                            SignalToUI::set_ui_signal();
-                        }
-                        else {
-                            log!("Target event not in timeline. Starting backwards pagination \
-                                in room {room_id}, thread {thread_root_event_id:?} to find target event \
-                                {new_target_event_id} starting from index {starting_index}.",
-                            );
-                            // If we didn't find the target event in the current timeline items,
-                            // we need to start loading previous items into the timeline.
-                            submit_async_request(MatrixRequest::PaginateTimeline {
-                                timeline_kind: if let Some(thread_root_event_id) = thread_root_event_id.clone() {
-                                    TimelineKind::Thread {
-                                        room_id: room_id.clone(),
-                                        thread_root_event_id,
-                                    }
-                                } else {
-                                    TimelineKind::MainRoom {
-                                        room_id: room_id.clone(),
-                                    }
-                                },
-                                num_events: 50,
-                                direction: PaginationDirection::Backwards,
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Handle updates to the actual timeline content.
-            batch_opt = subscriber.next() => {
-                let Some(batch) = batch_opt else { break };
-                let mut num_updates = 0;
-                let mut index_of_first_change = usize::MAX;
-                let mut index_of_last_change = usize::MIN;
-                // whether to clear the entire cache of drawn items
-                let mut clear_cache = false;
-                // whether the changes include items being appended to the end of the timeline
-                let mut is_append = false;
-                for diff in batch {
-                    num_updates += 1;
-                    match diff {
-                        VectorDiff::Append { values } => {
-                            let _values_len = values.len();
-                            index_of_first_change = min(index_of_first_change, timeline_items.len());
-                            timeline_items.extend(values);
-                            index_of_last_change = max(index_of_last_change, timeline_items.len());
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Append {_values_len}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                            is_append = true;
-                        }
-                        VectorDiff::Clear => {
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Clear"); }
-                            clear_cache = true;
-                            timeline_items.clear();
-                        }
-                        VectorDiff::PushFront { value } => {
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PushFront"); }
-                            if let Some((index, _ev)) = found_target_event_id.as_mut() {
-                                *index += 1; // account for this new `value` being prepended.
-                            } else {
-                                found_target_event_id = find_target_event(&mut target_event_id, std::iter::once(&value));
-                            }
-
-                            clear_cache = true;
-                            timeline_items.push_front(value);
-                        }
-                        VectorDiff::PushBack { value } => {
-                            index_of_first_change = min(index_of_first_change, timeline_items.len());
-                            timeline_items.push_back(value);
-                            index_of_last_change = max(index_of_last_change, timeline_items.len());
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PushBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                            is_append = true;
-                        }
-                        VectorDiff::PopFront => {
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PopFront"); }
-                            clear_cache = true;
-                            timeline_items.pop_front();
-                            if let Some((i, _ev)) = found_target_event_id.as_mut() {
-                                *i = i.saturating_sub(1); // account for the first item being removed.
-                            }
-                            // This doesn't affect whether we should reobtain the latest event.
-                        }
-                        VectorDiff::PopBack => {
-                            timeline_items.pop_back();
-                            index_of_first_change = min(index_of_first_change, timeline_items.len());
-                            index_of_last_change = usize::MAX;
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PopBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                        }
-                        VectorDiff::Insert { index, value } => {
-                            if index == 0 {
-                                clear_cache = true;
-                            } else {
-                                index_of_first_change = min(index_of_first_change, index);
-                                index_of_last_change = usize::MAX;
-                            }
-                            if index >= timeline_items.len() {
-                                is_append = true;
-                            }
-
-                            if let Some((i, _ev)) = found_target_event_id.as_mut() {
-                                // account for this new `value` being inserted before the previously-found target event's index.
-                                if index <= *i {
-                                    *i += 1;
-                                }
-                            } else {
-                                found_target_event_id = find_target_event(&mut target_event_id, std::iter::once(&value))
-                                    .map(|(i, ev)| (i + index, ev));
-                            }
-
-                            timeline_items.insert(index, value);
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Insert at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                        }
-                        VectorDiff::Set { index, value } => {
-                            index_of_first_change = min(index_of_first_change, index);
-                            index_of_last_change  = max(index_of_last_change, index.saturating_add(1));
-                            timeline_items.set(index, value);
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Set at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                        }
-                        VectorDiff::Remove { index } => {
-                            if index == 0 {
-                                clear_cache = true;
-                            } else {
-                                index_of_first_change = min(index_of_first_change, index.saturating_sub(1));
-                                index_of_last_change = usize::MAX;
-                            }
-                            if let Some((i, _ev)) = found_target_event_id.as_mut() {
-                                // account for an item being removed before the previously-found target event's index.
-                                if index <= *i {
-                                    *i = i.saturating_sub(1);
-                                }
-                            }
-                            timeline_items.remove(index);
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Remove at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                        }
-                        VectorDiff::Truncate { length } => {
-                            if length == 0 {
-                                clear_cache = true;
-                            } else {
-                                index_of_first_change = min(index_of_first_change, length.saturating_sub(1));
-                                index_of_last_change = usize::MAX;
-                            }
-                            timeline_items.truncate(length);
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Truncate to length {length}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                        }
-                        VectorDiff::Reset { values } => {
-                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Reset, new length {}", values.len()); }
-                            clear_cache = true; // we must assume all items have changed.
-                            timeline_items = values;
-                        }
-                    }
-                }
-
-
-                if num_updates > 0 {
-                    // Handle the case where back pagination inserts items at the beginning of the timeline
-                    // (meaning the entire timeline needs to be re-drawn),
-                    // but there is a virtual event at index 0 (e.g., a day divider).
-                    // When that happens, we want the RoomScreen to treat this as if *all* events changed.
-                    if index_of_first_change == 1 && timeline_items.front().and_then(|item| item.as_virtual()).is_some() {
-                        index_of_first_change = 0;
-                        clear_cache = true;
-                    }
-
-                    let changed_indices = index_of_first_change..index_of_last_change;
-
-                    if LOG_TIMELINE_DIFFS {
-                        log!("timeline_subscriber: applied {num_updates} updates for room {room_id}, thread {thread_root_event_id:?}, timeline now has {} items. is_append? {is_append}, clear_cache? {clear_cache}. Changes: {changed_indices:?}.", timeline_items.len());
-                    }
-                    timeline_update_sender.send(TimelineUpdate::NewItems {
-                        new_items: timeline_items.clone(),
-                        changed_indices,
-                        clear_cache,
-                        is_append,
-                    }).expect("Error: timeline update sender couldn't send update with new items!");
-
-                    // We must send this update *after* the actual NewItems update,
-                    // otherwise the UI thread (RoomScreen) won't be able to correctly locate the target event.
-                    if let Some((index, found_event_id)) = found_target_event_id.take() {
+                        // Nice! We found the target event in the current timeline items,
+                        // so there's no need to actually proceed with backwards pagination;
+                        // thus, we can clear the locally-tracked target event ID.
                         target_event_id = None;
+                        found_target_event_id = None;
                         timeline_update_sender.send(
                             TimelineUpdate::TargetEventFound {
-                                target_event_id: found_event_id.clone(),
-                                index,
+                                target_event_id: new_target_event_id.clone(),
+                                index: target_event_tl_index,
                             }
                         ).unwrap_or_else(
-                            |_e| panic!("Error: timeline update sender couldn't send TargetEventFound({found_event_id}, {index}) to room {room_id}, thread {thread_root_event_id:?}!")
+                            |_e| panic!("Error: timeline update sender couldn't send TargetEventFound({new_target_event_id}, {target_event_tl_index}) to room {room_id}, thread {thread_root_event_id:?}!")
                         );
+                        // Send a Makepad-level signal to update this room's timeline UI view.
+                        SignalToUI::set_ui_signal();
                     }
+                    else {
+                        log!("Target event not in timeline. Starting backwards pagination \
+                            in room {room_id}, thread {thread_root_event_id:?} to find target event \
+                            {new_target_event_id} starting from index {starting_index}.",
+                        );
+                        // If we didn't find the target event in the current timeline items,
+                        // we need to start loading previous items into the timeline.
+                        submit_async_request(MatrixRequest::PaginateTimeline {
+                            timeline_kind: if let Some(thread_root_event_id) = thread_root_event_id.clone() {
+                                TimelineKind::Thread {
+                                    room_id: room_id.clone(),
+                                    thread_root_event_id,
+                                }
+                            } else {
+                                TimelineKind::MainRoom {
+                                    room_id: room_id.clone(),
+                                }
+                            },
+                            num_events: 50,
+                            direction: PaginationDirection::Backwards,
+                        });
+                    }
+                }
+            }
+        }
 
-                    // Send a Makepad-level signal to update this room's timeline UI view.
-                    SignalToUI::set_ui_signal();
+        // Handle updates to the actual timeline content.
+        batch_opt = subscriber.next() => {
+            let Some(batch) = batch_opt else { break };
+            let mut num_updates = 0;
+            let mut index_of_first_change = usize::MAX;
+            let mut index_of_last_change = usize::MIN;
+            // whether to clear the entire cache of drawn items
+            let mut clear_cache = false;
+            // whether the changes include items being appended to the end of the timeline
+            let mut is_append = false;
+            for diff in batch {
+                num_updates += 1;
+                match diff {
+                    VectorDiff::Append { values } => {
+                        let _values_len = values.len();
+                        index_of_first_change = min(index_of_first_change, timeline_items.len());
+                        timeline_items.extend(values);
+                        index_of_last_change = max(index_of_last_change, timeline_items.len());
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Append {_values_len}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                        is_append = true;
+                    }
+                    VectorDiff::Clear => {
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Clear"); }
+                        clear_cache = true;
+                        timeline_items.clear();
+                    }
+                    VectorDiff::PushFront { value } => {
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PushFront"); }
+                        if let Some((index, _ev)) = found_target_event_id.as_mut() {
+                            *index += 1; // account for this new `value` being prepended.
+                        } else {
+                            found_target_event_id = find_target_event(&mut target_event_id, std::iter::once(&value));
+                        }
+
+                        clear_cache = true;
+                        timeline_items.push_front(value);
+                    }
+                    VectorDiff::PushBack { value } => {
+                        index_of_first_change = min(index_of_first_change, timeline_items.len());
+                        timeline_items.push_back(value);
+                        index_of_last_change = max(index_of_last_change, timeline_items.len());
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PushBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                        is_append = true;
+                    }
+                    VectorDiff::PopFront => {
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PopFront"); }
+                        clear_cache = true;
+                        timeline_items.pop_front();
+                        if let Some((i, _ev)) = found_target_event_id.as_mut() {
+                            *i = i.saturating_sub(1); // account for the first item being removed.
+                        }
+                        // This doesn't affect whether we should reobtain the latest event.
+                    }
+                    VectorDiff::PopBack => {
+                        timeline_items.pop_back();
+                        index_of_first_change = min(index_of_first_change, timeline_items.len());
+                        index_of_last_change = usize::MAX;
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff PopBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                    }
+                    VectorDiff::Insert { index, value } => {
+                        if index == 0 {
+                            clear_cache = true;
+                        } else {
+                            index_of_first_change = min(index_of_first_change, index);
+                            index_of_last_change = usize::MAX;
+                        }
+                        if index >= timeline_items.len() {
+                            is_append = true;
+                        }
+
+                        if let Some((i, _ev)) = found_target_event_id.as_mut() {
+                            // account for this new `value` being inserted before the previously-found target event's index.
+                            if index <= *i {
+                                *i += 1;
+                            }
+                        } else {
+                            found_target_event_id = find_target_event(&mut target_event_id, std::iter::once(&value))
+                                .map(|(i, ev)| (i + index, ev));
+                        }
+
+                        timeline_items.insert(index, value);
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Insert at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                    }
+                    VectorDiff::Set { index, value } => {
+                        index_of_first_change = min(index_of_first_change, index);
+                        index_of_last_change  = max(index_of_last_change, index.saturating_add(1));
+                        timeline_items.set(index, value);
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Set at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                    }
+                    VectorDiff::Remove { index } => {
+                        if index == 0 {
+                            clear_cache = true;
+                        } else {
+                            index_of_first_change = min(index_of_first_change, index.saturating_sub(1));
+                            index_of_last_change = usize::MAX;
+                        }
+                        if let Some((i, _ev)) = found_target_event_id.as_mut() {
+                            // account for an item being removed before the previously-found target event's index.
+                            if index <= *i {
+                                *i = i.saturating_sub(1);
+                            }
+                        }
+                        timeline_items.remove(index);
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Remove at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                    }
+                    VectorDiff::Truncate { length } => {
+                        if length == 0 {
+                            clear_cache = true;
+                        } else {
+                            index_of_first_change = min(index_of_first_change, length.saturating_sub(1));
+                            index_of_last_change = usize::MAX;
+                        }
+                        timeline_items.truncate(length);
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Truncate to length {length}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                    }
+                    VectorDiff::Reset { values } => {
+                        if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Reset, new length {}", values.len()); }
+                        clear_cache = true; // we must assume all items have changed.
+                        timeline_items = values;
+                    }
                 }
             }
 
-            else => {
-                break;
+
+            if num_updates > 0 {
+                // Handle the case where back pagination inserts items at the beginning of the timeline
+                // (meaning the entire timeline needs to be re-drawn),
+                // but there is a virtual event at index 0 (e.g., a day divider).
+                // When that happens, we want the RoomScreen to treat this as if *all* events changed.
+                if index_of_first_change == 1 && timeline_items.front().and_then(|item| item.as_virtual()).is_some() {
+                    index_of_first_change = 0;
+                    clear_cache = true;
+                }
+
+                let changed_indices = index_of_first_change..index_of_last_change;
+
+                if LOG_TIMELINE_DIFFS {
+                    log!("timeline_subscriber: applied {num_updates} updates for room {room_id}, thread {thread_root_event_id:?}, timeline now has {} items. is_append? {is_append}, clear_cache? {clear_cache}. Changes: {changed_indices:?}.", timeline_items.len());
+                }
+                timeline_update_sender.send(TimelineUpdate::NewItems {
+                    new_items: timeline_items.clone(),
+                    changed_indices,
+                    clear_cache,
+                    is_append,
+                }).expect("Error: timeline update sender couldn't send update with new items!");
+
+                // We must send this update *after* the actual NewItems update,
+                // otherwise the UI thread (RoomScreen) won't be able to correctly locate the target event.
+                if let Some((index, found_event_id)) = found_target_event_id.take() {
+                    target_event_id = None;
+                    timeline_update_sender.send(
+                        TimelineUpdate::TargetEventFound {
+                            target_event_id: found_event_id.clone(),
+                            index,
+                        }
+                    ).unwrap_or_else(
+                        |_e| panic!("Error: timeline update sender couldn't send TargetEventFound({found_event_id}, {index}) to room {room_id}, thread {thread_root_event_id:?}!")
+                    );
+                }
+
+                // Send a Makepad-level signal to update this room's timeline UI view.
+                SignalToUI::set_ui_signal();
             }
         }
-    }
 
-    error!(
-        "Error: unexpectedly ended timeline subscriber for room {room_id}, thread {thread_root_event_id:?}."
-    );
+        else => {
+            break;
+        }
+    } }
+
+    error!("Error: unexpectedly ended timeline subscriber for room {room_id}, thread {thread_root_event_id:?}.");
 }
 
 /// Spawn a new async task to fetch the room's new avatar.
@@ -4721,13 +4259,8 @@ async fn room_avatar(room: &Room, room_name_id: &RoomNameId) -> FetchedRoomAvata
         _ => {
             if let Ok(room_members) = room.members(RoomMemberships::ACTIVE).await {
                 if room_members.len() == 2 {
-                    if let Some(non_account_member) =
-                        room_members.iter().find(|m| !m.is_account_user())
-                    {
-                        if let Ok(Some(avatar)) = non_account_member
-                            .avatar(AVATAR_THUMBNAIL_FORMAT.into())
-                            .await
-                        {
+                    if let Some(non_account_member) = room_members.iter().find(|m| !m.is_account_user()) {
+                        if let Ok(Some(avatar)) = non_account_member.avatar(AVATAR_THUMBNAIL_FORMAT.into()).await {
                             return FetchedRoomAvatar::Image(avatar.into());
                         }
                     }
@@ -4756,8 +4289,7 @@ async fn spawn_sso_server(
     // Post a status update to inform the user that we're waiting for the client to be built.
     Cx::post_action(LoginAction::Status {
         title: "Initializing client...".into(),
-        status: "Please wait while Matrix builds and configures the client object for login."
-            .into(),
+        status: "Please wait while Matrix builds and configures the client object for login.".into(),
     });
 
     // Wait for the notification that the client has been built
@@ -4778,21 +4310,19 @@ async fn spawn_sso_server(
         // or if the homeserver_url is *not* empty and isn't the default,
         // we cannot use the DEFAULT_SSO_CLIENT, so we must build a new one.
         let mut build_client_error = None;
-        if client_and_session.is_none()
-            || (!homeserver_url.is_empty()
+        if client_and_session.is_none() || (
+            !homeserver_url.is_empty()
                 && homeserver_url != "matrix.org"
                 && Url::parse(&homeserver_url) != Url::parse("https://matrix-client.matrix.org/")
-                && Url::parse(&homeserver_url) != Url::parse("https://matrix.org/"))
-        {
+                && Url::parse(&homeserver_url) != Url::parse("https://matrix.org/")
+        ) {
             match build_client(
                 &Cli {
                     homeserver: homeserver_url.is_empty().not().then_some(homeserver_url),
                     ..Default::default()
                 },
                 app_data_dir(),
-            )
-            .await
-            {
+            ).await {
                 Ok(success) => client_and_session = Some(success),
                 Err(e) => build_client_error = Some(e),
             }
@@ -4801,12 +4331,10 @@ async fn spawn_sso_server(
         let Some((client, client_session)) = client_and_session else {
             Cx::post_action(LoginAction::LoginFailure(
                 if let Some(err) = build_client_error {
-                    format!(
-                        "Could not create client object. Please try to login again.\n\nError: {err}"
-                    )
+                    format!("Could not create client object. Please try to login again.\n\nError: {err}")
                 } else {
                     String::from("Could not create client object. Please try to login again.")
-                },
+                }
             ));
             // This ensures that the called to `DEFAULT_SSO_CLIENT_NOTIFIER.notified()`
             // at the top of this function will not block upon the next login attempt.
@@ -4818,8 +4346,7 @@ async fn spawn_sso_server(
         let mut is_logged_in = false;
         Cx::post_action(LoginAction::Status {
             title: "Opening your browser...".into(),
-            status: "Please finish logging in using your browser, and then come back to Robrix."
-                .into(),
+            status: "Please finish logging in using your browser, and then come back to Robrix.".into(),
         });
         match client
             .matrix_auth()
@@ -4829,15 +4356,12 @@ async fn spawn_sso_server(
                     if key == "redirectUrl" {
                         let redirect_url = Url::parse(&value)?;
                         Cx::post_action(LoginAction::SsoSetRedirectUrl(redirect_url));
-                        break;
+                        break
                     }
                 }
-                Uri::new(&sso_url).open().map_err(|err| {
-                    Error::Io(io::Error::other(format!(
-                        "Unable to open SSO login url. Error: {:?}",
-                        err
-                    )))
-                })
+                Uri::new(&sso_url).open().map_err(|err|
+                    Error::Io(io::Error::other(format!("Unable to open SSO login url. Error: {:?}", err)))
+                )
             })
             .identity_provider_id(&identity_provider_id)
             .initial_device_display_name(&format!("robrix-sso-{brand}"))
@@ -4852,13 +4376,10 @@ async fn spawn_sso_server(
             }) {
             Ok(identity_provider_res) => {
                 if !is_logged_in {
-                    if let Err(e) = login_sender
-                        .send(LoginRequest::LoginBySSOSuccess(client, client_session))
-                        .await
-                    {
+                    if let Err(e) = login_sender.send(LoginRequest::LoginBySSOSuccess(client, client_session)).await {
                         error!("Error sending login request to login_sender: {e:?}");
                         Cx::post_action(LoginAction::LoginFailure(String::from(
-                            "BUG: failed to send login request to matrix worker thread.",
+                            "BUG: failed to send login request to matrix worker thread."
                         )));
                     }
                     enqueue_rooms_list_update(RoomsListUpdate::Status {
@@ -4883,6 +4404,7 @@ async fn spawn_sso_server(
         Cx::post_action(LoginAction::SsoPending(false));
     });
 }
+
 
 bitflags! {
     /// The powers that a user has in a given room.
@@ -4961,38 +4483,14 @@ impl UserPowerLevels {
         retval.set(UserPowerLevels::Invite, user_power >= power_levels.invite);
         retval.set(UserPowerLevels::Kick, user_power >= power_levels.kick);
         retval.set(UserPowerLevels::Redact, user_power >= power_levels.redact);
-        retval.set(
-            UserPowerLevels::NotifyRoom,
-            user_power >= power_levels.notifications.room,
-        );
-        retval.set(
-            UserPowerLevels::Location,
-            user_power >= power_levels.for_message(MessageLikeEventType::Location),
-        );
-        retval.set(
-            UserPowerLevels::Message,
-            user_power >= power_levels.for_message(MessageLikeEventType::Message),
-        );
-        retval.set(
-            UserPowerLevels::Reaction,
-            user_power >= power_levels.for_message(MessageLikeEventType::Reaction),
-        );
-        retval.set(
-            UserPowerLevels::RoomMessage,
-            user_power >= power_levels.for_message(MessageLikeEventType::RoomMessage),
-        );
-        retval.set(
-            UserPowerLevels::RoomRedaction,
-            user_power >= power_levels.for_message(MessageLikeEventType::RoomRedaction),
-        );
-        retval.set(
-            UserPowerLevels::Sticker,
-            user_power >= power_levels.for_message(MessageLikeEventType::Sticker),
-        );
-        retval.set(
-            UserPowerLevels::RoomPinnedEvents,
-            user_power >= power_levels.for_state(StateEventType::RoomPinnedEvents),
-        );
+        retval.set(UserPowerLevels::NotifyRoom, user_power >= power_levels.notifications.room);
+        retval.set(UserPowerLevels::Location, user_power >= power_levels.for_message(MessageLikeEventType::Location));
+        retval.set(UserPowerLevels::Message, user_power >= power_levels.for_message(MessageLikeEventType::Message));
+        retval.set(UserPowerLevels::Reaction, user_power >= power_levels.for_message(MessageLikeEventType::Reaction));
+        retval.set(UserPowerLevels::RoomMessage, user_power >= power_levels.for_message(MessageLikeEventType::RoomMessage));
+        retval.set(UserPowerLevels::RoomRedaction, user_power >= power_levels.for_message(MessageLikeEventType::RoomRedaction));
+        retval.set(UserPowerLevels::Sticker, user_power >= power_levels.for_message(MessageLikeEventType::Sticker));
+        retval.set(UserPowerLevels::RoomPinnedEvents, user_power >= power_levels.for_state(StateEventType::RoomPinnedEvents));
         retval
     }
 
@@ -5038,7 +4536,8 @@ impl UserPowerLevels {
     }
 
     pub fn can_send_message(self) -> bool {
-        self.contains(UserPowerLevels::RoomMessage) || self.contains(UserPowerLevels::Message)
+        self.contains(UserPowerLevels::RoomMessage)
+        || self.contains(UserPowerLevels::Message)
     }
 
     pub fn can_send_reaction(self) -> bool {
@@ -5054,6 +4553,7 @@ impl UserPowerLevels {
         self.contains(UserPowerLevels::RoomPinnedEvents)
     }
 }
+
 
 /// Shuts down the current Tokio runtime completely and takes ownership to ensure proper cleanup.
 pub fn shutdown_background_tasks() {
@@ -5072,16 +4572,9 @@ pub async fn clear_app_state(config: &LogoutConfig) -> Result<()> {
     ALL_JOINED_ROOMS.lock().unwrap().clear();
 
     let on_clear_appstate = Arc::new(Notify::new());
-    Cx::post_action(LogoutAction::ClearAppState {
-        on_clear_appstate: on_clear_appstate.clone(),
-    });
-
-    match tokio::time::timeout(
-        config.app_state_cleanup_timeout,
-        on_clear_appstate.notified(),
-    )
-    .await
-    {
+    Cx::post_action(LogoutAction::ClearAppState { on_clear_appstate: on_clear_appstate.clone() });
+    
+    match tokio::time::timeout(config.app_state_cleanup_timeout, on_clear_appstate.notified()).await {
         Ok(_) => {
             log!("Received signal that UI-side app state was cleaned successfully");
             Ok(())


### PR DESCRIPTION
## Summary
- add an in-app sign-up flow to the login screen, including password confirmation and homeserver-aware registration
- improve stale/invalid session recovery so expired Matrix sessions are cleared and the app returns cleanly to the login flow
- simplify the desktop login layout into a narrower centered form without the extra outer panel background

## Details
- support Matrix registration with basic UIAA dummy auth handling
- infer the homeserver from full Matrix user IDs when possible and normalize login/signup inputs
- clear persisted session state when restore fails or when the homeserver reports an invalid token
- remove the persisted Matrix store together with stale session files to avoid leaving orphaned local state behind
- reset runtime sync/login state on session invalidation so users can actually log in again without restarting the app
- update the login screen to support switching between login and sign-up modes in-app
- tighten the login screen layout for desktop so it presents like a mobile-width form instead of a wide panel
