### PR TITLE
Fix logout when homeserver is unreachable

### DIFF
--- a/src/logout/logout_state_machine.rs
+++ b/src/logout/logout_state_machine.rs
@@ -348,6 +348,20 @@ impl LogoutStateMachine {
                     if let Err(e) = delete_latest_user_id().await {
                         log!("Warning: Failed to delete latest user ID: {}", e);
                     }
+                } else if should_continue_local_logout_without_server(&e) {
+                    log!("Homeserver appears unavailable, continuing with local logout: {}", e);
+                    self.point_of_no_return.store(true, Ordering::Release);
+                    set_logout_point_of_no_return(true);
+                    self.transition_to(
+                        LogoutState::PointOfNoReturn,
+                        "Homeserver unavailable, continuing with local logout".to_string(),
+                        50
+                    ).await?;
+
+                    // Same delete operation as in the success case above
+                    if let Err(e) = delete_latest_user_id().await {
+                        log!("Warning: Failed to delete latest user ID: {}", e);
+                    }
                 } else {
                     // Restart sync service since we haven't reached point of no return
                     if let Some(sync_service) = get_sync_service() {
@@ -550,6 +564,33 @@ impl LogoutStateMachine {
                 Cx::post_action(LogoutAction::LogoutFailure(error.to_string()));
             }
         }
+    }
+}
+
+fn should_continue_local_logout_without_server(error: &LogoutError) -> bool {
+    match error {
+        LogoutError::Recoverable(RecoverableError::Timeout(_)) => true,
+        LogoutError::Recoverable(RecoverableError::ServerLogoutFailed(msg)) => {
+            let msg_lower = msg.to_ascii_lowercase();
+            msg_lower.contains("timeout")
+                || msg_lower.contains("timed out")
+                || msg_lower.contains("service unavailable")
+                || msg_lower.contains("bad gateway")
+                || msg_lower.contains("gateway timeout")
+                || msg_lower.contains("too many requests")
+                || msg_lower.contains("error sending request")
+                || msg_lower.contains("connection")
+                || msg_lower.contains("connect")
+                || msg_lower.contains("network")
+                || msg_lower.contains("dns")
+                || msg_lower.contains("i/o")
+                || msg_lower.contains("tls")
+                || msg_lower.contains("status code: 429")
+                || msg_lower.contains("status code: 502")
+                || msg_lower.contains("status code: 503")
+                || msg_lower.contains("status code: 504")
+        }
+        _ => false,
     }
 }
 

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -368,6 +368,11 @@ impl MatchEvent for AccountSettings {
             }
         }
 
+        if self.view.button(cx, ids!(logout_button)).clicked(actions) {
+            cx.action(LogoutConfirmModalAction::Open);
+            return;
+        }
+
         let Some(own_profile) = &self.own_profile else { return };
 
         if upload_avatar_button.clicked(actions) {
@@ -456,9 +461,6 @@ impl MatchEvent for AccountSettings {
             );
         }
 
-        if self.view.button(cx, ids!(logout_button)).clicked(actions) {
-            cx.action(LogoutConfirmModalAction::Open);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
This PR fixes two related logout issues in Settings:

1. If the Matrix homeserver is down/unreachable, clicking **Log out** could fail and keep users stuck in the current account.
2. In some states, clicking the **Log out** button had no response at all.

With this change, users can always trigger logout from Settings, and logout can still complete locally even when server-side logout cannot be reached.

## What changed
- Updated logout state machine to continue local logout cleanup when server logout fails due to connectivity/unavailability conditions (for example timeout, connection/network/DNS/TLS errors, HTTP 429/502/503/504, service unavailable/gateway timeout).
- Kept existing behavior for other server logout failures: they remain recoverable failures and do not proceed to local teardown.
- Moved Settings logout button click handling before the `own_profile` guard so the button action is not skipped when profile data is unavailable.

## Why
Users must be able to exit the current session and switch accounts even if the homeserver is temporarily unavailable.