### PR TITLE
fix(search): support exact MXID people search and fallback to full list on empty local results

### DIFF
--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1013,7 +1013,19 @@ impl RoomsList {
     /// If `false`, the scroll position is preserved, unless it exceeds the new list length,
     /// in which case the logic in `draw_walk()` will limit it to the max valid index.
     fn update_displayed_rooms(&mut self, cx: &mut Cx, reset_scroll: bool) {
-        let (invited, regular, direct) = self.generate_displayed_rooms();
+        let (mut invited, mut regular, mut direct) = self.generate_displayed_rooms();
+        if self.display_filter.is_some()
+            && invited.is_empty()
+            && regular.is_empty()
+            && direct.is_empty()
+        {
+            self.display_filter = RoomDisplayFilter::default();
+            self.sort_fn = None;
+            let (fallback_invited, fallback_regular, fallback_direct) = self.generate_displayed_rooms();
+            invited = fallback_invited;
+            regular = fallback_regular;
+            direct = fallback_direct;
+        }
         self.displayed_invited_rooms = invited;
         self.displayed_regular_rooms = regular;
         self.displayed_direct_rooms = direct;

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -846,6 +846,11 @@ impl SpacesBar {
         } else {
             filtered_spaces_iter.map(|(space_id, _)| space_id.clone()).collect()
         };
+        if self.displayed_spaces.is_empty() {
+            self.is_filtered = false;
+            self.display_filter = RoomDisplayFilter::default();
+            self.displayed_spaces = self.all_joined_spaces.keys().cloned().collect();
+        }
 
         portal_list.set_first_id_and_scroll(0, 0.0);
         self.redraw(cx);

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1493,6 +1493,7 @@ async fn matrix_worker_task(
                 let _search_task = Handle::current().spawn(async move {
                     let query = query.trim().to_owned();
                     let action_kind = kind.clone();
+                    log!("Remote directory search request: kind={kind:?}, query=\"{query}\", limit={limit}");
                     if query.is_empty() {
                         Cx::post_action(RoomFilterRemoteSearchAction::Results {
                             query,
@@ -1504,19 +1505,42 @@ async fn matrix_worker_task(
 
                     let result = match &kind {
                         RemoteDirectorySearchKind::People => {
-                            client.search_users(&query, limit).await
-                                .map(|response| {
-                                    response.results.into_iter()
-                                        .map(|user| {
-                                            RemoteDirectorySearchResult::User(UserProfile {
+                            let mut users = Vec::new();
+                            let mut seen_user_ids = HashSet::new();
+
+                            if let Ok(user_id) = UserId::parse(&query).map(|u| u.to_owned()) {
+                                if let Ok(response) = client.account().fetch_user_profile_of(&user_id).await {
+                                    if seen_user_ids.insert(user_id.clone()) {
+                                        users.push(RemoteDirectorySearchResult::User(UserProfile {
+                                            username: response.get_static::<DisplayName>().ok().flatten(),
+                                            user_id,
+                                            avatar_state: response.get_static::<AvatarUrl>()
+                                                .ok()
+                                                .map_or(AvatarState::Unknown, AvatarState::Known),
+                                        }));
+                                    }
+                                }
+                            }
+
+                            match client.search_users(&query, limit).await {
+                                Ok(response) => {
+                                    for user in response.results.into_iter() {
+                                        if seen_user_ids.insert(user.user_id.clone()) {
+                                            users.push(RemoteDirectorySearchResult::User(UserProfile {
                                                 username: user.display_name,
                                                 user_id: user.user_id,
                                                 avatar_state: AvatarState::Known(user.avatar_url),
-                                            })
-                                        })
-                                        .collect::<Vec<_>>()
-                                })
-                                .map_err(|e| e.to_string())
+                                            }));
+                                        }
+                                        if users.len() >= limit as usize {
+                                            break;
+                                        }
+                                    }
+                                    Ok(users)
+                                }
+                                Err(_e) if !users.is_empty() => Ok(users),
+                                Err(e) => Err(e.to_string()),
+                            }
                         }
                         RemoteDirectorySearchKind::Rooms | RemoteDirectorySearchKind::Spaces => {
                             let mut filter = PublicRoomsFilter::new();


### PR DESCRIPTION
## Summary
- Improve remote People search by supporting exact MXID lookup (`@user:server`) via profile fetch.
- Merge exact-lookup and user-directory search results with de-duplication by user ID.
- Add logging for remote directory search requests to improve diagnosability.
- Improve UX for local filtering:
  - When room search has no matches, fallback to the same full list shown for empty search input.
  - When space search has no matches, fallback to the same full list shown for empty search input.

## Why
- Some homeserver directory behaviors do not reliably return results for full MXID queries.
- Empty local search results felt like a dead end; fallback keeps navigation context and reduces friction.

## Testing
- `cargo check -q` passes.
- Manually verified:
  - People search can find full MXID targets.
  - Non-empty keywords with zero local matches now show full rooms/spaces list.
