### PR TITLE
ui: polish settings screen spacing, colors, and card layout

### DIFF
--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -49,8 +49,8 @@ script_mod! {
     mod.widgets.NavigationTabButton = RadioButtonTab {
         width: Fill,
         height: (NAVIGATION_TAB_BAR_SIZE - 5),
-        padding: 5,
-        margin: 3,
+        padding: (SPACE_XS),
+        margin: (SPACE_XS),
         align: Align{x: 0.5, y: 0.5}
         flow: Down,
         text: "",
@@ -72,7 +72,7 @@ script_mod! {
             color_focus: (COLOR_NAVIGATION_TAB_BG_ACTIVE)
 
             border_size: 0.0
-            border_radius: 4.0
+            border_radius: (RADIUS_MD)
             border_color: #0000
             border_color_hover: #0000
             border_color_down: #0000
@@ -155,19 +155,19 @@ script_mod! {
         draw_icon +: { svg: (ICON_ADD) }
     }
 
-    mod.widgets.Separator = LineH { margin: 8 }
+    mod.widgets.Separator = LineH { margin: (SPACE_SM) }
 
     mod.widgets.NavigationTabBar = #(NavigationTabBar::register_widget(vm)) {
         Desktop := RoundedView {
             flow: Down,
             align: Align{x: 0.5}
-            padding: Inset{top: 8., bottom: 8}
+            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_XS), right: (SPACE_XS)}
             width: (NAVIGATION_TAB_BAR_SIZE), 
             height: Fill
 
             draw_bg +: {
                 color: (COLOR_SECONDARY)
-                border_radius: 4.0
+                border_radius: (RADIUS_LG)
             }
 
             CachedWidget {
@@ -201,7 +201,7 @@ script_mod! {
 
             draw_bg +: {
                 color: (COLOR_SECONDARY)
-                border_radius: 4.0
+                border_radius: (RADIUS_LG)
             }
 
             CachedWidget {

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -25,6 +25,7 @@ script_mod! {
         }
 
         avatar_section_label := SubsectionLabel {
+            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
             text: "Your Avatar:"
         }
 
@@ -52,20 +53,21 @@ script_mod! {
                 width: Fit, height: Fit
                 flow: Down,
                 align: Align{y: 0.5}
-                padding: Inset{ left: 10, right: 10 }
-                spacing: 10
+                padding: Inset{ left: (SPACE_SM), right: (SPACE_SM) }
+                spacing: (SPACE_SM)
 
                 View {
                     width: Fit, height: Fit
                     flow: Right,
                     align: Align{y: 0.5}
-                    spacing: 10
+                    spacing: (SPACE_SM)
 
                     upload_avatar_button := RobrixIconButton {
                         width: 140,
                         height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
                         padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
                         margin: 0,
+                        draw_bg +: { border_radius: (RADIUS_MD) }
                         draw_icon.svg: (ICON_UPLOAD)
                         icon_walk: Walk{width: 16, height: 16}
                         text: "Upload Avatar"
@@ -82,13 +84,14 @@ script_mod! {
                     width: Fit, height: Fit
                     flow: Right,
                     align: Align{y: 0.5}
-                    spacing: 10
+                    spacing: (SPACE_SM)
 
                     delete_avatar_button := RobrixNegativeIconButton {
                         width: 140,
                         height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
                         padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
                         margin: 0,
+                        draw_bg +: { border_radius: (RADIUS_MD) }
                         draw_icon.svg: (ICON_TRASH)
                         icon_walk: Walk{ width: 16, height: 16 }
                         text: "Delete Avatar"
@@ -104,11 +107,12 @@ script_mod! {
         }
 
         display_name_section_label := SubsectionLabel {
+            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
             text: "Your Display Name:"
         }
 
         display_name_input := RobrixTextInput {
-            margin: Inset{top: 3, left: 5, right: 5, bottom: 8},
+            margin: Inset{top: 3, left: (SPACE_XS), right: (SPACE_XS), bottom: (SPACE_SM)},
             width: 216, height: Fit
             empty_text: "Add a display name..."
         }
@@ -117,7 +121,7 @@ script_mod! {
             width: Fill, height: Fit
             flow: Flow.Right{wrap: true},
             align: Align{y: 0.5},
-            spacing: 10
+            spacing: (SPACE_SM)
 
             // These buttons are disabled by default, and enabled when the user
             // changes the `display_name_input` text.
@@ -127,7 +131,7 @@ script_mod! {
                 enabled: false,
                 width: Fit, height: Fit,
                 padding: 10,
-                margin: Inset{left: 5},
+                margin: Inset{left: (SPACE_XS)},
                 draw_icon.svg: (ICON_FORBIDDEN)
                 icon_walk: Walk{width: 16, height: 16, margin: 0}
                 text: "Cancel"
@@ -137,8 +141,8 @@ script_mod! {
                 enabled: false,
                 width: Fit, height: Fit,
                 padding: 10,
-                margin: Inset{left: 5},
-                draw_bg.border_radius: 5.0
+                margin: Inset{left: (SPACE_XS)},
+                draw_bg.border_radius: (RADIUS_MD)
                 draw_icon.svg: (ICON_CHECKMARK)
                 icon_walk: Walk{width: 16, height: 16, margin: 0}
                 text: "Save Name"
@@ -153,18 +157,19 @@ script_mod! {
         }
 
         user_id_section_label := SubsectionLabel {
+            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
             text: "Your User ID:"
         }
 
         View {
             width: Fill, height: Fit
             flow: Right,
-            spacing: 10
+            spacing: (SPACE_SM)
 
             copy_user_id_button := RobrixNeutralIconButton {
                 enable_long_press: true,
-                margin: Inset{left: 5}
-                padding: 12,
+                margin: Inset{left: (SPACE_XS)}
+                padding: (SPACE_MD),
                 spacing: 0,
                 draw_icon.svg: (ICON_COPY)
                 icon_walk: Walk{width: 16, height: 16, margin: Inset{right: -2} }
@@ -173,7 +178,7 @@ script_mod! {
             user_id := Label {
                 width: Fill, height: Fit
                 flow: Flow.Right{wrap: true},
-                margin: Inset{top: 10}
+                margin: Inset{top: (SPACE_SM)}
                 draw_text +: {
                     color: (MESSAGE_TEXT_COLOR),
                     text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
@@ -183,14 +188,15 @@ script_mod! {
         }
 
         multiple_accounts_section_label := SubsectionLabel {
+            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
             text: "Multiple Accounts:"
         }
 
         View {
             width: Fill, height: Fit
             flow: Down,
-            spacing: 8,
-            margin: Inset{left: 5, right: 5, bottom: 10}
+            spacing: (SPACE_SM),
+            margin: Inset{left: (SPACE_XS), right: (SPACE_XS), bottom: (SPACE_SM)}
 
             // Account entries will be shown here
             // Active account (current)
@@ -198,12 +204,12 @@ script_mod! {
                 width: Fill, height: Fit
                 flow: Right,
                 align: Align{y: 0.5}
-                padding: Inset{left: 10, right: 10, top: 8, bottom: 8}
-                spacing: 10
+                padding: Inset{left: (SPACE_MD), right: (SPACE_LG), top: (SPACE_SM), bottom: (SPACE_SM)}
+                spacing: (SPACE_SM)
                 show_bg: true
                 draw_bg +: {
-                    color: (COLOR_ACTIVE_PRIMARY)
-                    border_radius: 4.0
+                    color: (COLOR_ACCOUNT_ACTIVE_BG)
+                    border_radius: (RADIUS_LG)
                 }
 
                 View {
@@ -214,7 +220,7 @@ script_mod! {
                     active_account_label := Label {
                         width: Fill, height: Fit
                         draw_text +: {
-                            color: (COLOR_TEXT),
+                            color: (COLOR_PRIMARY),
                             text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
                         }
                         text: "@user:server"
@@ -223,7 +229,7 @@ script_mod! {
                     active_account_status_label := Label {
                         width: Fit, height: Fit
                         draw_text +: {
-                            color: (COLOR_FG_ACCEPT_GREEN),
+                            color: (COLOR_PRIMARY),
                             text_style: MESSAGE_TEXT_STYLE { font_size: 9 },
                         }
                         text: "Active"
@@ -234,7 +240,7 @@ script_mod! {
             // Other accounts section (populated dynamically)
             other_accounts_label := Label {
                 width: Fill, height: Fit
-                margin: Inset{top: 5, left: 2}
+                margin: Inset{top: (SPACE_XS), left: 2}
                 visible: false
                 draw_text +: {
                     color: (MESSAGE_TEXT_COLOR),
@@ -248,15 +254,15 @@ script_mod! {
                 width: Fill, height: Fit
                 flow: Right,
                 align: Align{y: 0.5}
-                padding: Inset{left: 10, right: 10, top: 8, bottom: 8}
-                spacing: 10
+                padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_SM)}
+                spacing: (SPACE_SM)
                 visible: false
                 show_bg: true
                 draw_bg +: {
                     color: (COLOR_SECONDARY)
-                    border_radius: 4.0
+                    border_radius: (RADIUS_LG)
                     border_size: 1.0
-                    border_color: #555
+                    border_color: (COLOR_INACTIVE_BORDER)
                 }
 
                 View {
@@ -285,7 +291,7 @@ script_mod! {
 
             account_count_label := Label {
                 width: Fill, height: Fit
-                margin: Inset{top: 5, bottom: 5, left: 5}
+                margin: Inset{top: (SPACE_XS), bottom: (SPACE_XS), left: (SPACE_XS)}
                 draw_text +: {
                     color: (MESSAGE_TEXT_COLOR),
                     text_style: MESSAGE_TEXT_STYLE { font_size: 10 },
@@ -295,8 +301,9 @@ script_mod! {
 
             add_account_button := RobrixIconButton {
                 width: Fit,
-                padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
-                margin: Inset{top: 5}
+                padding: Inset{top: 10, bottom: 10, left: (SPACE_MD), right: 15}
+                margin: Inset{top: (SPACE_XS)}
+                draw_bg +: { border_radius: (RADIUS_MD) }
                 draw_icon.svg: (ICON_ADD)
                 icon_walk: Walk{width: 16, height: 16}
                 text: "Add Another Account"
@@ -304,27 +311,30 @@ script_mod! {
         }
 
         other_actions_section_label := SubsectionLabel {
+            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
             text: "Other actions:"
         }
 
         View {
-            // margin: Inset{top: 20},
             width: Fill, height: Fit
             flow: Flow.Right{wrap: true},
             align: Align{y: 0.5},
-            spacing: 10
+            spacing: (SPACE_SM)
+            margin: Inset{bottom: (SPACE_LG)}
 
             manage_account_button := RobrixIconButton {
-                padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
-                margin: Inset{left: 5}
+                padding: Inset{top: 10, bottom: 10, left: (SPACE_MD), right: 15}
+                margin: Inset{left: (SPACE_XS)}
+                draw_bg +: { border_radius: (RADIUS_MD) }
                 draw_icon.svg: (ICON_EXTERNAL_LINK)
                 icon_walk: Walk{width: 16, height: 16}
                 text: "Manage Account"
             }
 
             logout_button := RobrixNegativeIconButton {
-                padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
-                margin: Inset{left: 5}
+                padding: Inset{top: 10, bottom: 10, left: (SPACE_MD), right: 15}
+                margin: Inset{left: (SPACE_XS)}
+                draw_bg +: { border_radius: (RADIUS_MD) }
                 draw_icon.svg: (ICON_LOGOUT)
                 icon_walk: Walk{ width: 16, height: 16, margin: Inset{right: -2} }
                 text: "Log out"

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -24,135 +24,161 @@ script_mod! {
             text: "Account Settings"
         }
 
-        avatar_section_label := SubsectionLabel {
-            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
-            text: "Your Avatar:"
-        }
-
-        View {
+        // --- Avatar card ---
+        RoundedView {
             width: Fill, height: Fit
-            // TODO: I'd like to use RightWrap here, but Makepad doesn't yet
-            //       support RightWrap with align: Align{y: 0.5}.
-            flow: Right,
-            align: Align{y: 0.5}
+            flow: Down
+            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+            margin: Inset{top: (SPACE_SM)}
+            show_bg: true
+            draw_bg +: {
+                color: #F8F8FA
+                border_radius: (RADIUS_LG)
+            }
 
-            our_own_avatar := Avatar {
-                width: 100,
-                height: 100,
-                margin: 10,
-                text_view +: {
-                    text +: {
-                        draw_text +: {
-                            text_style: theme.font_regular { font_size: 35.0 }
+            avatar_section_label := SubsectionLabel {
+                margin: Inset{top: 0, bottom: (SPACE_XS)}
+                text: "Your Avatar:"
+            }
+
+            View {
+                width: Fill, height: Fit
+                // TODO: I'd like to use RightWrap here, but Makepad doesn't yet
+                //       support RightWrap with align: Align{y: 0.5}.
+                flow: Right,
+                align: Align{y: 0.5}
+
+                our_own_avatar := Avatar {
+                    width: 100,
+                    height: 100,
+                    margin: 10,
+                    text_view +: {
+                        text +: {
+                            draw_text +: {
+                                text_style: theme.font_regular { font_size: 35.0 }
+                            }
+                        }
+                    }
+                }
+
+                View {
+                    width: Fit, height: Fit
+                    flow: Down,
+                    align: Align{y: 0.5}
+                    padding: Inset{ left: (SPACE_SM), right: (SPACE_SM) }
+                    spacing: (SPACE_SM)
+
+                    View {
+                        width: Fit, height: Fit
+                        flow: Right,
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_SM)
+
+                        upload_avatar_button := RobrixIconButton {
+                            width: 140,
+                            height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
+                            padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
+                            margin: 0,
+                            draw_bg +: { border_radius: (RADIUS_MD) }
+                            draw_icon.svg: (ICON_UPLOAD)
+                            icon_walk: Walk{width: 16, height: 16}
+                            text: "Upload Avatar"
+                        }
+
+                        upload_avatar_spinner := LoadingSpinner {
+                            width: 16, height: 16
+                            visible: false
+                            draw_bg.color: (COLOR_ACTIVE_PRIMARY)
+                        }
+                    }
+
+                    View {
+                        width: Fit, height: Fit
+                        flow: Right,
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_SM)
+
+                        delete_avatar_button := RobrixNegativeIconButton {
+                            width: 140,
+                            height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
+                            padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
+                            margin: 0,
+                            draw_bg +: { border_radius: (RADIUS_MD) }
+                            draw_icon.svg: (ICON_TRASH)
+                            icon_walk: Walk{ width: 16, height: 16 }
+                            text: "Delete Avatar"
+                        }
+
+                        delete_avatar_spinner := LoadingSpinner {
+                            width: 16, height: 16
+                            visible: false
+                            draw_bg.color: (COLOR_ACTIVE_PRIMARY)
                         }
                     }
                 }
             }
+        }
+
+        // --- Display Name card ---
+        RoundedView {
+            width: Fill, height: Fit
+            flow: Down
+            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+            margin: Inset{top: (SPACE_SM)}
+            show_bg: true
+            draw_bg +: {
+                color: #F8F8FA
+                border_radius: (RADIUS_LG)
+            }
+
+            display_name_section_label := SubsectionLabel {
+                margin: Inset{top: 0, bottom: (SPACE_XS)}
+                text: "Your Display Name:"
+            }
+
+            display_name_input := RobrixTextInput {
+                margin: Inset{top: 3, left: (SPACE_XS), right: (SPACE_XS), bottom: (SPACE_SM)},
+                width: 216, height: Fit
+                empty_text: "Add a display name..."
+            }
 
             View {
-                width: Fit, height: Fit
-                flow: Down,
-                align: Align{y: 0.5}
-                padding: Inset{ left: (SPACE_SM), right: (SPACE_SM) }
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true},
+                align: Align{y: 0.5},
                 spacing: (SPACE_SM)
 
-                View {
-                    width: Fit, height: Fit
-                    flow: Right,
-                    align: Align{y: 0.5}
-                    spacing: (SPACE_SM)
-
-                    upload_avatar_button := RobrixIconButton {
-                        width: 140,
-                        height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
-                        padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
-                        margin: 0,
-                        draw_bg +: { border_radius: (RADIUS_MD) }
-                        draw_icon.svg: (ICON_UPLOAD)
-                        icon_walk: Walk{width: 16, height: 16}
-                        text: "Upload Avatar"
-                    }
-
-                    upload_avatar_spinner := LoadingSpinner {
-                        width: 16, height: 16
-                        visible: false
-                        draw_bg.color: (COLOR_ACTIVE_PRIMARY)
-                    }
+                // These buttons are disabled by default, and enabled when the user
+                // changes the `display_name_input` text.
+                // These buttons start disabled; Rust code enables them and swaps
+                // their styles to RobrixNeutralIconButton / RobrixPositiveIconButton.
+                cancel_display_name_button := RobrixNeutralIconButton {
+                    enabled: false,
+                    width: Fit, height: Fit,
+                    padding: 10,
+                    margin: Inset{left: (SPACE_XS)},
+                    draw_icon.svg: (ICON_FORBIDDEN)
+                    icon_walk: Walk{width: 16, height: 16, margin: 0}
+                    text: "Cancel"
                 }
 
-                View {
-                    width: Fit, height: Fit
-                    flow: Right,
-                    align: Align{y: 0.5}
-                    spacing: (SPACE_SM)
-
-                    delete_avatar_button := RobrixNegativeIconButton {
-                        width: 140,
-                        height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
-                        padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
-                        margin: 0,
-                        draw_bg +: { border_radius: (RADIUS_MD) }
-                        draw_icon.svg: (ICON_TRASH)
-                        icon_walk: Walk{ width: 16, height: 16 }
-                        text: "Delete Avatar"
-                    }
-
-                    delete_avatar_spinner := LoadingSpinner {
-                        width: 16, height: 16
-                        visible: false
-                        draw_bg.color: (COLOR_ACTIVE_PRIMARY)
-                    }
+                accept_display_name_button := RobrixPositiveIconButton {
+                    enabled: false,
+                    width: Fit, height: Fit,
+                    padding: 10,
+                    margin: Inset{left: (SPACE_XS)},
+                    draw_bg.border_radius: (RADIUS_MD)
+                    draw_icon.svg: (ICON_CHECKMARK)
+                    icon_walk: Walk{width: 16, height: 16, margin: 0}
+                    text: "Save Name"
                 }
-            }
-        }
 
-        display_name_section_label := SubsectionLabel {
-            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
-            text: "Your Display Name:"
-        }
-
-        display_name_input := RobrixTextInput {
-            margin: Inset{top: 3, left: (SPACE_XS), right: (SPACE_XS), bottom: (SPACE_SM)},
-            width: 216, height: Fit
-            empty_text: "Add a display name..."
-        }
-
-        View {
-            width: Fill, height: Fit
-            flow: Flow.Right{wrap: true},
-            align: Align{y: 0.5},
-            spacing: (SPACE_SM)
-
-            // These buttons are disabled by default, and enabled when the user
-            // changes the `display_name_input` text.
-            // These buttons start disabled; Rust code enables them and swaps
-            // their styles to RobrixNeutralIconButton / RobrixPositiveIconButton.
-            cancel_display_name_button := RobrixNeutralIconButton {
-                enabled: false,
-                width: Fit, height: Fit,
-                padding: 10,
-                margin: Inset{left: (SPACE_XS)},
-                draw_icon.svg: (ICON_FORBIDDEN)
-                icon_walk: Walk{width: 16, height: 16, margin: 0}
-                text: "Cancel"
-            }
-
-            accept_display_name_button := RobrixPositiveIconButton {
-                enabled: false,
-                width: Fit, height: Fit,
-                padding: 10,
-                margin: Inset{left: (SPACE_XS)},
-                draw_bg.border_radius: (RADIUS_MD)
-                draw_icon.svg: (ICON_CHECKMARK)
-                icon_walk: Walk{width: 16, height: 16, margin: 0}
-                text: "Save Name"
-            }
-
-            save_name_spinner := LoadingSpinner {
-                width: 16, height: 16
-                margin: Inset{left: 5, top: 13} // vertically center with buttons
-                visible: false
-                draw_bg.color: (COLOR_ACTIVE_PRIMARY)
+                save_name_spinner := LoadingSpinner {
+                    width: 16, height: 16
+                    margin: Inset{left: 5, top: 13} // vertically center with buttons
+                    visible: false
+                    draw_bg.color: (COLOR_ACTIVE_PRIMARY)
+                }
             }
         }
 
@@ -187,16 +213,27 @@ script_mod! {
             }
         }
 
-        multiple_accounts_section_label := SubsectionLabel {
-            margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}
-            text: "Multiple Accounts:"
-        }
-
-        View {
+        // --- Multiple Accounts card ---
+        RoundedView {
             width: Fill, height: Fit
-            flow: Down,
-            spacing: (SPACE_SM),
-            margin: Inset{left: (SPACE_XS), right: (SPACE_XS), bottom: (SPACE_SM)}
+            flow: Down
+            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+            margin: Inset{top: (SPACE_SM)}
+            show_bg: true
+            draw_bg +: {
+                color: #F8F8FA
+                border_radius: (RADIUS_LG)
+            }
+
+            multiple_accounts_section_label := SubsectionLabel {
+                margin: Inset{top: 0, bottom: (SPACE_XS)}
+                text: "Multiple Accounts:"
+            }
+
+            View {
+                width: Fill, height: Fit
+                flow: Down,
+                spacing: (SPACE_SM),
 
             // Account entries will be shown here
             // Active account (current)
@@ -308,7 +345,8 @@ script_mod! {
                 icon_walk: Walk{width: 16, height: 16}
                 text: "Add Another Account"
             }
-        }
+            }
+        } // end Multiple Accounts card
 
         other_actions_section_label := SubsectionLabel {
             margin: Inset{top: (SPACE_MD), bottom: (SPACE_XS)}

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -16,19 +16,19 @@ script_mod! {
         flow: Overlay
 
         View {
-            padding: Inset{top: 5, left: 15, right: 15, bottom: 0},
+            padding: Inset{top: (SPACE_SM), left: (SETTINGS_CONTENT_PADDING), right: (SETTINGS_CONTENT_PADDING), bottom: (SETTINGS_CONTENT_PADDING)},
             flow: Down
 
             // The settings header shows a title, with a close button to the right.
             settings_header := View {
                 flow: Right,
                 width: Fill, height: Fit
-                margin: Inset{top: 5, left: 5, right: 5}
-                spacing: 10,
+                margin: Inset{top: (SPACE_SM), left: (SPACE_XS), right: (SPACE_XS)}
+                spacing: (SPACE_SM),
 
                 settings_header_title := TitleLabel {
                     padding: 0,
-                    margin: Inset{ left: 1, top: 11 },
+                    margin: Inset{ left: 0, top: (SPACE_SM) },
                     text: "Add/Explore Rooms"
                     draw_text +: {
                         text_style: theme.font_regular {font_size: 18},
@@ -41,43 +41,46 @@ script_mod! {
                     height: Fit,
                     spacing: 0,
                     margin: 0,
-                    padding: 15,
+                    padding: (SPACE_LG),
                     draw_icon.svg: (ICON_CLOSE)
-                    icon_walk: Walk{width: 14, height: 14}
+                    icon_walk: Walk{width: 12, height: 12}
                 }
             }
 
             // Make sure the dividing line is aligned with the close_button
-            LineH { padding: 10, margin: Inset{top: 10, right: 2} }
+            LineH { padding: 0, margin: Inset{top: (SPACE_SM), bottom: (SPACE_SM)} }
 
             settings_category_cards := View {
                 width: Fill, height: Fit
                 flow: Flow.Right{wrap: true}
                 align: Align{y: 0.5}
-                spacing: 10
-                margin: Inset{left: 5, right: 5, bottom: 8}
+                spacing: (SPACE_SM)
+                margin: Inset{left: (SPACE_XS), right: (SPACE_XS), bottom: (SPACE_SM)}
 
                 category_account_button := RobrixNeutralIconButton {
                     width: Fit, height: Fit,
-                    padding: Inset{top: 9, bottom: 9, left: 14, right: 14}
+                    padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
+                    draw_bg +: { border_radius: (RADIUS_MD) }
                     text: "Account"
                 }
 
                 category_preferences_button := RobrixNeutralIconButton {
                     width: Fit, height: Fit,
-                    padding: Inset{top: 9, bottom: 9, left: 14, right: 14}
+                    padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
+                    draw_bg +: { border_radius: (RADIUS_MD) }
                     text: "Preferences"
                 }
 
                 category_labs_button := RobrixNeutralIconButton {
                     width: Fit, height: Fit,
-                    padding: Inset{top: 9, bottom: 9, left: 14, right: 14}
+                    padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
+                    draw_bg +: { border_radius: (RADIUS_MD) }
                     text: "Labs"
                 }
             }
@@ -123,15 +126,15 @@ script_mod! {
                             show_bg: true
                             draw_bg +: {
                                 color: (COLOR_PRIMARY)
-                                border_radius: 4.0
+                                border_radius: (RADIUS_SM)
                                 border_size: 1.0
-                                border_color: #xC8D9F2
+                                border_color: (COLOR_DROPDOWN_BORDER)
                             }
 
                             language_selector_label := Label {
                                 width: Fill, height: Fit
                                 draw_text +: {
-                                    color: #x333333
+                                    color: (COLOR_DROPDOWN_TEXT)
                                     text_style: REGULAR_TEXT { font_size: 11 }
                                 }
                                 text: "English"
@@ -140,7 +143,7 @@ script_mod! {
                             language_arrow := ExpandArrow {
                                 width: 14, height: 14
                                 draw_bg +: {
-                                    color: instance(#x888888)
+                                    color: instance((COLOR_DROPDOWN_ARROW))
                                 }
                             }
                         }
@@ -154,9 +157,9 @@ script_mod! {
                             new_batch: true
                             draw_bg +: {
                                 color: (COLOR_PRIMARY)
-                                border_radius: 6.0
+                                border_radius: (RADIUS_MD)
                                 border_size: 1.0
-                                border_color: #xD3E1F6
+                                border_color: (COLOR_DROPDOWN_POPUP_BORDER)
                             }
 
                             lang_option_en := View {
@@ -170,7 +173,7 @@ script_mod! {
                                 Label {
                                     width: Fit, height: Fit
                                     draw_text +: {
-                                        color: #x333333
+                                        color: (COLOR_DROPDOWN_TEXT)
                                         text_style: REGULAR_TEXT { font_size: 11 }
                                     }
                                     text: "English"
@@ -187,7 +190,7 @@ script_mod! {
                                 Label {
                                     width: Fit, height: Fit
                                     draw_text +: {
-                                        color: #x333333
+                                        color: (COLOR_DROPDOWN_TEXT)
                                         text_style: REGULAR_TEXT { font_size: 11 }
                                     }
                                     text: "简体中文"

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -185,6 +185,31 @@ script_mod! {
     mod.widgets.COLOR_NAVIGATION_TAB_BG_HOVER = (mod.widgets.COLOR_SECONDARY * 0.85)
     mod.widgets.COLOR_NAVIGATION_TAB_BG_ACTIVE = #9
 
+    // Layout spacing constants (4px grid)
+    mod.widgets.SPACE_XS  = 4
+    mod.widgets.SPACE_SM  = 8
+    mod.widgets.SPACE_MD  = 12
+    mod.widgets.SPACE_LG  = 16
+    mod.widgets.SPACE_XL  = 20
+    mod.widgets.SPACE_XXL = 24
+
+    // Border radius constants
+    mod.widgets.RADIUS_SM = 4.0
+    mod.widgets.RADIUS_MD = 6.0
+    mod.widgets.RADIUS_LG = 8.0
+
+    // Settings screen colors
+    mod.widgets.COLOR_ACCOUNT_ACTIVE_BG = #3B8CFF  // softer blue for active account bar
+    mod.widgets.COLOR_DROPDOWN_TEXT = #x333333        // text in dropdown selectors
+    mod.widgets.COLOR_DROPDOWN_BORDER = #xC8D9F2      // dropdown border (light blue-gray)
+    mod.widgets.COLOR_DROPDOWN_POPUP_BORDER = #xD3E1F6 // popup border (slightly lighter)
+    mod.widgets.COLOR_DROPDOWN_ARROW = #x888888        // dropdown arrow icon
+    mod.widgets.COLOR_INACTIVE_BORDER = #xBBBBBB       // inactive account entry border
+
+    // Settings screen layout
+    mod.widgets.SETTINGS_CONTENT_PADDING = 16
+    mod.widgets.SETTINGS_BUTTON_HEIGHT = 36
+
     mod.widgets.COLOR_IMAGE_VIEWER_BACKGROUND = #333333CC // 80% Opacity
 
     mod.widgets.COLOR_IMAGE_VIEWER_META_BACKGROUND = #E8E8E8


### PR DESCRIPTION
## Summary
- Define layout constants (4px grid: SPACE_XS/SM/MD/LG/XL/XXL, RADIUS_SM/MD/LG) and settings-specific color tokens in `styles.rs`
- Replace magic numbers with constants across `settings_screen.rs`, `account_settings.rs`, and `navigation_tab_bar.rs`
- Fix bottom padding cutoff where Manage Account / Log out buttons were clipped
- Fix blue account bar text visibility (white text on softer blue background)
- Soften divider line, close button proportions, and button border radius locally
- Unify SubsectionLabel vertical rhythm and section spacing
- Extract hardcoded dropdown colors to semantic constants
- Wrap Avatar, Display Name, and Multiple Accounts sections in card containers for visual grouping

## Test plan
- [x] Open Settings → Account tab: verify Avatar, Display Name, and Multiple Accounts sections appear in card containers
- [x] Scroll to bottom: verify Manage Account and Log out buttons are not cut off
- [x] Check blue account bar: white text should be clearly readable
- [x] Verify tab buttons (Account/Preferences/Labs) have softer rounded corners
- [x] Switch between tabs: verify all three render correctly
- [x] Check left sidebar: gear button and navigation buttons have consistent spacing
- [x] Test on mobile viewport: verify touch targets are still usable (close button ≥44x44)