### PR TITLE
ui: polish Preferences and Labs tabs with constants and card layout

### DIFF
--- a/src/settings/bot_settings.rs
+++ b/src/settings/bot_settings.rs
@@ -14,7 +14,7 @@ script_mod! {
     mod.widgets.BotSettingsInfoLabel = Label {
         width: Fill
         height: Fit
-        margin: Inset{left: 5, top: 2, bottom: 2}
+        margin: Inset{left: (SPACE_XS), top: 2, bottom: 2}
         draw_text +: {
             color: (MESSAGE_TEXT_COLOR)
             text_style: REGULAR_TEXT { font_size: 10.5 }
@@ -26,15 +26,14 @@ script_mod! {
         width: Fill
         height: Fit
         flow: Down
-        spacing: 10
+        spacing: (SPACE_SM)
 
         app_service_header := View {
             width: Fill
             height: Fit
-            flow: Right
-            align: Align{y: 1.0}
-            spacing: 8
-            margin: Inset{left: 5, right: 8, bottom: 2}
+            flow: Down
+            spacing: (SPACE_XS)
+            margin: Inset{left: (SPACE_XS), right: (SPACE_SM), bottom: 2}
 
             app_service_title := TitleLabel {
                 width: Fit
@@ -45,7 +44,7 @@ script_mod! {
                 width: Fill
                 margin: 0
                 draw_text +: {
-                    color: #7A7A7A
+                    color: (COLOR_DESCRIPTION_TEXT)
                     text_style: REGULAR_TEXT { font_size: 9.5 }
                 }
                 text: "Enable Matrix app service support here. Robrix stays a normal Matrix client: it binds BotFather to a room and sends the matching slash commands."
@@ -57,17 +56,20 @@ script_mod! {
             height: Fit
             flow: Right
             align: Align{x: 0.0, y: 0.5}
-            spacing: 8
-            margin: Inset{left: 5, bottom: 2}
+            spacing: (SPACE_SM)
+            margin: Inset{left: (SPACE_XS), bottom: 2}
 
             app_service_switch := Toggle {
                 width: Fit
                 height: Fit
-                padding: Inset{top: 8, right: 8, bottom: 8, left: 8}
+                padding: Inset{top: (SPACE_SM), right: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_SM)}
                 text: ""
                 active: false
                 draw_bg +: {
                     size: 20.0
+                    color_active: (COLOR_ACTIVE_PRIMARY)
+                    border_color_active: (COLOR_ACTIVE_PRIMARY)
+                    mark_color_active: #fff
                 }
             }
 
@@ -75,7 +77,7 @@ script_mod! {
                 width: Fit
                 height: Fit
                 draw_text +: {
-                    color: #999
+                    color: (COLOR_DISABLED_TEXT)
                     text_style: REGULAR_TEXT { font_size: 10.5 }
                 }
                 text: "Disabled"
@@ -139,7 +141,7 @@ impl BotSettings {
             script_apply_eval!(cx, switch_state_label, {
                 text: #(tr_key(self.app_language, "settings.labs.app_service.status.enabled")),
                 draw_text +: {
-                    color: mod.widgets.COLOR_FG_ACCEPT_GREEN
+                    color: mod.widgets.COLOR_ACTIVE_PRIMARY
                 }
             });
         } else {

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -104,24 +104,37 @@ script_mod! {
                         visible: false
                         width: Fill, height: Fit
                         flow: Down
-                        spacing: 8
+                        spacing: (SPACE_SM)
 
                         preferences_language_title := TitleLabel {
                             text: "Language"
                         }
 
-                        preferences_application_language_label := SubsectionLabel {
-                            text: "Application language"
-                        }
+                        // --- Language card ---
+                        RoundedView {
+                            width: Fill, height: Fit
+                            flow: Down
+                            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+                            margin: Inset{top: (SPACE_XS)}
+                            show_bg: true
+                            draw_bg +: {
+                                color: #F8F8FA
+                                border_radius: (RADIUS_LG)
+                            }
 
-                        // Custom language selector: button + popup list
-                        // (replaces DropDown which has unsolvable arrow shader artifact)
-                        language_selector_button := RoundedView {
-                            width: 200, height: Fit
-                            flow: Right
-                            align: Align{y: 0.5}
-                            padding: Inset{left: 12, right: 10, top: 10, bottom: 10}
-                            margin: Inset{left: 5, top: 2, bottom: 2}
+                            preferences_application_language_label := SubsectionLabel {
+                                margin: Inset{top: 0, bottom: (SPACE_XS)}
+                                text: "Application language"
+                            }
+
+                            // Custom language selector: button + popup list
+                            // (replaces DropDown which has unsolvable arrow shader artifact)
+                            language_selector_button := RoundedView {
+                                width: 200, height: Fit
+                                flow: Right
+                                align: Align{y: 0.5}
+                                padding: Inset{left: (SPACE_MD), right: 10, top: 10, bottom: 10}
+                                margin: Inset{left: (SPACE_XS), top: 2, bottom: 2}
                             cursor: MouseCursor.Hand
                             show_bg: true
                             draw_bg +: {
@@ -198,33 +211,64 @@ script_mod! {
                             }
                         }
 
-                        preferences_language_hint_label := Label {
-                            width: Fill
-                            height: Fit
-                            margin: Inset{left: 5, right: 8, top: 3, bottom: 4}
-                            draw_text +: {
-                                color: (MESSAGE_TEXT_COLOR)
-                                text_style: REGULAR_TEXT { font_size: 10.5 }
+                            preferences_language_hint_label := Label {
+                                width: Fill
+                                height: Fit
+                                margin: Inset{left: (SPACE_XS), right: (SPACE_SM), top: 3, bottom: (SPACE_XS)}
+                                draw_text +: {
+                                    color: (MESSAGE_TEXT_COLOR)
+                                    text_style: REGULAR_TEXT { font_size: 10.5 }
+                                }
+                                text: "The app will reload after selecting another language"
                             }
-                            text: "The app will reload after selecting another language"
-                        }
+                        } // end Language card
                     }
 
                     labs_settings_section := View {
                         visible: false
                         width: Fill, height: Fit
                         flow: Down
+                        spacing: (SPACE_SM)
 
-                        bot_settings := BotSettings {}
+                        // --- App Service card ---
+                        RoundedView {
+                            width: Fill, height: Fit
+                            flow: Down
+                            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+                            show_bg: true
+                            draw_bg +: {
+                                color: #F8F8FA
+                                border_radius: (RADIUS_LG)
+                            }
+                            bot_settings := BotSettings {}
+                        }
 
-                        LineH { width: 400, padding: 10, margin: Inset{top: 20, bottom: 5} }
+                        // --- Translation card ---
+                        RoundedView {
+                            width: Fill, height: Fit
+                            flow: Down
+                            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+                            show_bg: true
+                            draw_bg +: {
+                                color: #F8F8FA
+                                border_radius: (RADIUS_LG)
+                            }
+                            translation_settings := TranslationSettings {}
+                        }
 
-                        translation_settings := TranslationSettings {}
-
-                        LineH { width: 400, padding: 10, margin: Inset{top: 20, bottom: 5} }
-
-                        // The TSP wallet settings section.
-                        tsp_settings_screen := TspSettingsScreen {}
+                        // --- TSP card ---
+                        RoundedView {
+                            width: Fill, height: Fit
+                            flow: Down
+                            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+                            show_bg: true
+                            draw_bg +: {
+                                color: #F8F8FA
+                                border_radius: (RADIUS_LG)
+                            }
+                            // The TSP wallet settings section.
+                            tsp_settings_screen := TspSettingsScreen {}
+                        }
                     }
                 }
             }

--- a/src/settings/translation_settings.rs
+++ b/src/settings/translation_settings.rs
@@ -18,15 +18,14 @@ script_mod! {
         width: Fill
         height: Fit
         flow: Down
-        spacing: 10
+        spacing: (SPACE_SM)
 
         translation_header := View {
             width: Fill
             height: Fit
-            flow: Right
-            align: Align{y: 1.0}
-            spacing: 8
-            margin: Inset{left: 5, right: 8, bottom: 2}
+            flow: Down
+            spacing: (SPACE_XS)
+            margin: Inset{left: (SPACE_XS), right: (SPACE_SM), bottom: 2}
 
             translation_title := TitleLabel {
                 width: Fit
@@ -38,7 +37,7 @@ script_mod! {
                 height: Fit
                 margin: 0
                 draw_text +: {
-                    color: #x7A7A7A
+                    color: (COLOR_DESCRIPTION_TEXT)
                     text_style: REGULAR_TEXT { font_size: 9.5 }
                 }
                 text: "Configure an OpenAI-compatible API for real-time message translation in the input bar."
@@ -50,17 +49,20 @@ script_mod! {
             height: Fit
             flow: Right
             align: Align{x: 0.0, y: 0.5}
-            spacing: 8
-            margin: Inset{left: 5, bottom: 2}
+            spacing: (SPACE_SM)
+            margin: Inset{left: (SPACE_XS), bottom: 2}
 
             translation_switch := Toggle {
                 width: Fit
                 height: Fit
-                padding: Inset{top: 8, right: 8, bottom: 8, left: 8}
+                padding: Inset{top: (SPACE_SM), right: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_SM)}
                 text: ""
                 active: false
                 draw_bg +: {
                     size: 20.0
+                    color_active: (COLOR_ACTIVE_PRIMARY)
+                    border_color_active: (COLOR_ACTIVE_PRIMARY)
+                    mark_color_active: #fff
                 }
             }
 
@@ -68,7 +70,7 @@ script_mod! {
                 width: Fit
                 height: Fit
                 draw_text +: {
-                    color: #999
+                    color: (COLOR_DISABLED_TEXT)
                     text_style: REGULAR_TEXT { font_size: 10.5 }
                 }
                 text: "Disabled"
@@ -80,8 +82,8 @@ script_mod! {
             width: Fill
             height: Fit
             flow: Down
-            spacing: 8
-            margin: Inset{left: 5, right: 8}
+            spacing: (SPACE_SM)
+            margin: Inset{left: (SPACE_XS), right: (SPACE_SM)}
 
             View {
                 width: Fill, height: Fit
@@ -89,7 +91,7 @@ script_mod! {
                 api_url_label := Label {
                     width: Fit, height: Fit
                     draw_text +: {
-                        color: #555
+                        color: (COLOR_FIELD_LABEL)
                         text_style: REGULAR_TEXT { font_size: 10 }
                     }
                     text: "API URL"
@@ -107,7 +109,7 @@ script_mod! {
                 api_key_label := Label {
                     width: Fit, height: Fit
                     draw_text +: {
-                        color: #555
+                        color: (COLOR_FIELD_LABEL)
                         text_style: REGULAR_TEXT { font_size: 10 }
                     }
                     text: "API Key"
@@ -126,7 +128,7 @@ script_mod! {
                 model_label := Label {
                     width: Fit, height: Fit
                     draw_text +: {
-                        color: #555
+                        color: (COLOR_FIELD_LABEL)
                         text_style: REGULAR_TEXT { font_size: 10 }
                     }
                     text: "Model"
@@ -141,8 +143,8 @@ script_mod! {
             View {
                 width: Fill, height: Fit
                 flow: Right
-                spacing: 8
-                margin: Inset{top: 4}
+                spacing: (SPACE_SM)
+                margin: Inset{top: (SPACE_XS)}
 
                 save_button := RobrixIconButton {
                     padding: Inset{top: 8, bottom: 8, left: 16, right: 16}
@@ -160,10 +162,10 @@ script_mod! {
 
                 test_result_label := Label {
                     width: Fit, height: Fit
-                    margin: Inset{left: 8}
+                    margin: Inset{left: (SPACE_SM)}
                     align: Align{y: 0.5}
                     draw_text +: {
-                        color: #x999999
+                        color: (COLOR_DISABLED_TEXT)
                         text_style: REGULAR_TEXT { font_size: 10 }
                     }
                     text: ""
@@ -373,7 +375,7 @@ impl TranslationSettings {
             script_apply_eval!(cx, switch_state_label, {
                 text: #(tr_key(self.app_language, "settings.labs.translation.status.enabled")),
                 draw_text +: {
-                    color: mod.widgets.COLOR_FG_ACCEPT_GREEN
+                    color: mod.widgets.COLOR_ACTIVE_PRIMARY
                 }
             });
         } else {

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -205,6 +205,9 @@ script_mod! {
     mod.widgets.COLOR_DROPDOWN_POPUP_BORDER = #xD3E1F6 // popup border (slightly lighter)
     mod.widgets.COLOR_DROPDOWN_ARROW = #x888888        // dropdown arrow icon
     mod.widgets.COLOR_INACTIVE_BORDER = #xBBBBBB       // inactive account entry border
+    mod.widgets.COLOR_DESCRIPTION_TEXT = #x7A7A7A      // secondary description text
+    mod.widgets.COLOR_FIELD_LABEL = #x555555           // form field labels
+    mod.widgets.COLOR_DISABLED_TEXT = #x999999          // disabled/inactive state text
 
     // Settings screen layout
     mod.widgets.SETTINGS_CONTENT_PADDING = 16


### PR DESCRIPTION
## Summary
- Replace magic numbers with `SPACE_*`/`RADIUS_*` constants in `bot_settings.rs` and `translation_settings.rs`
- Extract hardcoded colors (`#7A7A7A`, `#555`, `#999`) to semantic constants (`COLOR_DESCRIPTION_TEXT`, `COLOR_FIELD_LABEL`, `COLOR_DISABLED_TEXT`)
- Change header layout from `flow: Right` to `flow: Down` — fixes baseline alignment issue between title (font_size 15) and description (font_size 9.5)
- Add blue active state to Toggle switches (`color_active`, `mark_color_active`) so ON state is visually distinct
- Change "Enabled" label from green to blue (`COLOR_ACTIVE_PRIMARY`) for consistency with app accent color
- Wrap Preferences language section in card container (`#F8F8FA` + `RADIUS_LG`)
- Replace Labs `LineH` separators with card containers for each section (App Service, Translation, TSP)

Follow-up to #73 — applies the same polish principles to Preferences and Labs tabs.

**Known limitation:** Makepad Toggle shader mixes `hover` after `active`, so hovering an active toggle briefly shows gray. This is an upstream issue in the Toggle pixel shader's mix chain order.

## Test plan
- [x] Open Settings → Preferences tab: language section in card container, spacing consistent
- [x] Open Settings → Labs tab: each section in separate card, no LineH separators
- [x] Toggle ON: pill turns blue, circle turns white, label says "Enabled" in blue
- [x] Toggle OFF: pill turns gray, label says "Disabled" in gray
- [x] All three tabs render correctly with no layout breakage