### PR TITLE
fix: keep Room Info pane open on cancel and prevent cross-room modal leakage

### DIFF
--- a/specs/task-room-info-modal-cancel-flow.spec.md
+++ b/specs/task-room-info-modal-cancel-flow.spec.md
@@ -1,0 +1,113 @@
+spec: task
+name: "Room Info Modal Cancel Flow Consistency"
+inherits: project
+tags: [bugfix, room-info, modal, ui, navigation]
+estimate: 1d
+---
+
+## Intent
+
+Fix the Room Info panel interaction bug where opening `Report Room` or `Leave Room` shows a modal, but clicking `Cancel` first collapses the Room Info pane and only a second cancel closes the modal. Also fix modal lifetime so these dialogs do not remain visible after switching to a different room.
+The issue is in the Room Screen overlay interaction between `RoomInfoSlidingPane`, `ReportRoomModal`, and the leave-room `NegativeConfirmationModal`. Current behavior indicates modal cancel/dismiss actions are not fully isolated from underlying pane interactions, causing UI state desynchronization (pane closes unexpectedly, modal survives room switch).
+
+## Constraints
+
+- Keep existing action entry points from Room Info (`ReportRoom`, `LeaveRoom`)
+- Keep Matrix async request path unchanged:
+  - `submit_async_request(MatrixRequest::ReportRoom { ... })`
+  - `submit_async_request(MatrixRequest::LeaveRoom { ... })`
+- Do not change unrelated Room Info actions (`Invite`, `People`, profile navigation)
+- Do not redesign room navigation architecture
+
+## Decisions
+
+- Modal cancel must be single-step: one cancel action closes the active modal immediately
+- Canceling or dismissing modal must not close the Room Info pane
+- Modal visibility is scoped to the currently displayed room:
+  - switching room closes any open report/leave modal
+  - modal must not remain visible in the newly selected room
+- Room switching while modal is open must not submit report/leave requests
+- Existing submit semantics remain unchanged:
+  - report submit sends `ReportRoom` and closes modal
+  - leave confirm sends `LeaveRoom` and closes modal
+
+## Boundaries
+
+### Allowed Changes
+- `src/home/room_screen.rs`
+- `src/shared/confirmation_modal.rs` (only if needed for dismiss/cancel event handling)
+
+### Forbidden
+- Do not add new dependencies
+- Do not change Matrix request payload format or backend behavior
+- Do not change unrelated Room Info layout/content
+- Do not run `cargo fmt` or reformat unrelated code
+
+## Acceptance Criteria
+
+Scenario: Cancel report modal in one click without collapsing Room Info pane
+  Test: manual_test_room_info_report_cancel_single_step
+  Given the user opens Room Info for a room
+  And the user opens the `Report Room` modal
+  When the user clicks `Cancel`
+  Then the report modal closes immediately
+  And the Room Info pane remains open
+
+Scenario: Cancel leave modal in one click without collapsing Room Info pane
+  Test: manual_test_room_info_leave_cancel_single_step
+  Given the user opens Room Info for a room
+  And the user opens the `Leave Room` confirm modal
+  When the user clicks `Cancel`
+  Then the leave modal closes immediately
+  And the Room Info pane remains open
+
+Scenario: Dismiss modal via backdrop or dismiss action does not close Room Info pane
+  Test: manual_test_room_info_modal_dismiss_keeps_info_open
+  Level: manual
+  Targets: room_screen_modal_lifecycle
+  Given a report or leave modal is open from Room Info
+  When the modal is dismissed via non-submit close path
+  Then the modal closes
+  And the Room Info pane stays open
+
+Scenario: Switching room closes modal and prevents cross-room modal leakage
+  Test: manual_test_room_info_modal_closed_on_room_switch
+  Given a report or leave modal is open in room A
+  When the user switches to room B
+  Then no report/leave modal is visible in room B
+  And room B interaction is not blocked by stale modal overlay
+
+Scenario: Returning to original room does not resurrect stale modal
+  Test: manual_test_room_info_modal_not_restored_after_room_switch
+  Given a modal was open in room A and the user switched to room B
+  When the user switches back to room A
+  Then the previous report/leave modal is not auto-reopened
+
+Scenario: Submit behavior remains unchanged
+  Test: manual_test_room_info_modal_submit_semantics_unchanged
+  Given the user opens report/leave modal from Room Info
+  When the user confirms the action
+  Then report confirmation calls `submit_async_request(MatrixRequest::ReportRoom { ... })` exactly once
+  And leave confirmation calls `submit_async_request(MatrixRequest::LeaveRoom { ... })` exactly once
+  And the modal closes
+
+Scenario: Room Info pane close behavior still works when no modal is active
+  Test: manual_test_room_info_pane_close_regression_guard
+  Given the Room Info pane is open and no modal is active
+  When the user performs the pane close action
+  Then the Room Info pane closes as before
+
+Scenario: Report with empty reason does not submit and shows validation
+  Test: manual_test_room_info_report_empty_reason_validation
+  Given the user opens the `Report Room` modal
+  And the reason input is empty
+  When the user clicks the report/submit button
+  Then no `submit_async_request(MatrixRequest::ReportRoom { ... })` request is sent
+  And a validation error is shown in the modal
+  And the modal remains open
+
+## Out of Scope
+
+- Changing copy/text/visual design of report or leave dialogs
+- Adding telemetry for cancel/dismiss events
+- Refactoring modal framework shared by unrelated screens

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1,7 +1,7 @@
 //! The `RoomScreen` widget is the UI view that displays a single room or thread's timeline
 //! of events (messages，state changes, etc.), along with an input bar at the bottom.
 
-use std::{borrow::Cow, cell::RefCell, ops::{DerefMut, Range}, sync::Arc, time::Duration};
+use std::{borrow::Cow, cell::{Cell, RefCell}, ops::{DerefMut, Range}, sync::Arc, time::Duration};
 
 use bytesize::ByteSize;
 use hashbrown::{HashMap, HashSet};
@@ -67,6 +67,18 @@ const TRANSLATION_LANG_POPUP_SCROLL_HEIGHT: f64 = 288.0;
 const TRANSLATION_LANG_POPUP_HEIGHT: f64 = TRANSLATION_LANG_POPUP_SCROLL_HEIGHT + 8.0;
 const TRANSLATION_LANG_POPUP_GAP: f64 = 6.0;
 const TRANSLATION_LANG_POPUP_MARGIN: f64 = 8.0;
+
+thread_local! {
+    static ROOM_INFO_ACTION_MODAL_OPEN: Cell<bool> = const { Cell::new(false) };
+}
+
+fn set_room_info_action_modal_open(open: bool) {
+    ROOM_INFO_ACTION_MODAL_OPEN.with(|state| state.set(open));
+}
+
+fn is_room_info_action_modal_open() -> bool {
+    ROOM_INFO_ACTION_MODAL_OPEN.with(|state| state.get())
+}
 
 
 /// #FFF4E5
@@ -2437,7 +2449,7 @@ impl Widget for RoomInfoSlidingPane {
         }
 
         let area = self.view.area();
-        let close_pane = if is_invite_modal_open() {
+        let close_pane = if is_invite_modal_open() || is_room_info_action_modal_open() {
             matches!(
                 event,
                 Event::Actions(actions) if self.button(cx, ids!(close_button)).clicked(actions)
@@ -2856,8 +2868,14 @@ impl Widget for RoomScreen {
         let portal_list = self.portal_list(cx, ids!(timeline.list));
         let user_profile_sliding_pane = self.user_profile_sliding_pane(cx, ids!(user_profile_sliding_pane));
         let threads_sliding_pane = self.threads_sliding_pane(cx, ids!(threads_sliding_pane));
+        let threads_sliding_pane_widget_uid = threads_sliding_pane.widget_uid();
         let room_info_sliding_pane = self.room_info_sliding_pane(cx, ids!(room_info_sliding_pane));
+        let room_info_sliding_pane_widget_uid = room_info_sliding_pane.widget_uid();
         let loading_pane = self.loading_pane(cx, ids!(loading_pane));
+        set_room_info_action_modal_open(
+            self.view.modal(cx, ids!(report_room_modal)).is_open()
+                || self.view.modal(cx, ids!(leave_room_confirm_modal)).is_open()
+        );
 
         // Streaming animation frame handler
         if let Some(_ne) = self.streaming_next_frame.is_event(event) {
@@ -3069,6 +3087,23 @@ impl Widget for RoomScreen {
             self.handle_message_actions(cx, actions, &portal_list, &loading_pane);
 
             for action in actions {
+                if let Some(RoomsListAction::Selected(selected_room)) = action.downcast_ref() {
+                    if self.timeline_kind.as_ref() != selected_room.timeline_kind().as_ref() {
+                        self.close_report_room_modal(cx);
+                        self.close_leave_room_confirm_modal(cx);
+                    }
+                }
+                if let Some(AppStateAction::RoomFocused(selected_room)) = action.downcast_ref() {
+                    if self.timeline_kind.as_ref() != selected_room.timeline_kind().as_ref() {
+                        self.close_report_room_modal(cx);
+                        self.close_leave_room_confirm_modal(cx);
+                    }
+                }
+                if let Some(AppStateAction::FocusNone) = action.downcast_ref() {
+                    self.close_report_room_modal(cx);
+                    self.close_leave_room_confirm_modal(cx);
+                }
+
                 // Handle actions related to restoring the previously-saved state of rooms.
                 if let Some(AppStateAction::RoomLoadedSuccessfully { room_name_id, ..}) = action.downcast_ref() {
                     if self.room_name_id.as_ref().is_some_and(|rn| rn.room_id() == room_name_id.room_id()) {
@@ -3148,7 +3183,11 @@ impl Widget for RoomScreen {
                     }
                 }
 
-                match action.as_widget_action().cast_ref() {
+                match action
+                    .as_widget_action()
+                    .widget_uid_eq(threads_sliding_pane_widget_uid)
+                    .cast_ref()
+                {
                     ThreadsPaneAction::OpenThread(thread_root_event_id) => {
                         let Some(room_name_id) = self.room_name_id.as_ref().cloned() else { continue };
                         threads_sliding_pane.hide(cx);
@@ -3166,7 +3205,11 @@ impl Widget for RoomScreen {
                     ThreadsPaneAction::None => {}
                 }
 
-                match action.as_widget_action().cast_ref() {
+                match action
+                    .as_widget_action()
+                    .widget_uid_eq(room_info_sliding_pane_widget_uid)
+                    .cast_ref()
+                {
                     RoomInfoPaneAction::InviteUser => {
                         if let Some(room_name_id) = self.room_name_id.as_ref().cloned() {
                             cx.action(InviteModalAction::Open(room_name_id));
@@ -3334,9 +3377,15 @@ impl Widget for RoomScreen {
         // We check which overlay views are visible in the order of those views' z-ordering,
         // such that the top-most views get a chance to handle the event first.
         //
+        let room_info_action_modal_open =
+            self.view.modal(cx, ids!(report_room_modal)).is_open()
+            || self.view.modal(cx, ids!(leave_room_confirm_modal)).is_open();
         let is_interactive_hit = utils::is_interactive_hit_event(event);
         let is_pane_shown: bool;
-        if loading_pane.is_currently_shown(cx) {
+        if room_info_action_modal_open {
+            is_pane_shown = true;
+        }
+        else if loading_pane.is_currently_shown(cx) {
             is_pane_shown = true;
             if is_interactive_hit {
                 loading_pane.handle_event(cx, event, scope);
@@ -3369,7 +3418,7 @@ impl Widget for RoomScreen {
         //       Makepad already delivers most events to all views regardless of visibility,
         //       so the only thing we'd need here is the conditional below.
 
-        if !is_pane_shown || !is_interactive_hit {
+        if room_info_action_modal_open || !is_pane_shown || !is_interactive_hit {
             // Create a Scope with RoomScreenProps containing the room members.
             // This scope is needed by child widgets like MentionableTextInput during event handling.
             let room_props = if let Some(tl) = self.tl_state.as_ref() {


### PR DESCRIPTION
## What changed
- fixed the Room Info panel interaction so `Report Room` / `Leave Room` modal cancel/dismiss closes only the modal and does not collapse the Room Info panel
- fixed cross-room modal leakage when switching dock tabs/focused room
- scoped `RoomInfoPaneAction` and `ThreadsPaneAction` handling by pane `widget_uid` so one `RoomScreen` instance cannot consume another instance's actions
- added task spec: `specs/task-room-info-modal-cancel-flow.spec.md`

## Root cause
- room info actions were matched by action type without pane instance scoping, so actions could be consumed across different `RoomScreen` instances
- while room-action modals were open, input could still trigger RoomInfo pane close-path logic

## Why this fix
- keeps modal lifecycle bound to the currently active room screen instance
- ensures cancel behavior is single-step and stable
- prevents stale modal UI from reappearing after room/tab switches

## Validation
- `cargo build`