### PR TITLE
fix: skip duplicate JoinRoom requests and deduplicate room list

### DIFF
--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -525,6 +525,21 @@ macro_rules! should_display_room {
     };
 }
 
+fn for_each_room_id_in_display_order<'a, I, F>(room_ids: I, mut f: F)
+where
+    I: IntoIterator<Item = &'a OwnedRoomId>,
+    F: FnMut(&'a OwnedRoomId),
+{
+    let mut seen_room_ids = HashSet::new();
+    for room_id in room_ids {
+        if !seen_room_ids.insert(room_id.clone()) {
+            warning!("Ignoring duplicate room ID {room_id} in all_known_rooms_order");
+            continue;
+        }
+        f(room_id);
+    }
+}
+
 
 impl RoomsList {
     /// Returns whether the homeserver has finished syncing all of the rooms
@@ -1088,7 +1103,7 @@ impl RoomsList {
         else {
             let mut seen_joined = HashSet::new();
             let mut seen_invited = HashSet::new();
-            for room_id in &self.all_known_rooms_order {
+            for_each_room_id_in_display_order(self.all_known_rooms_order.iter(), |room_id| {
                 if let Some(jr) = self.all_joined_rooms.get(room_id) {
                     if should_display_room!(self, room_id, jr) {
                         seen_joined.insert(room_id.clone());
@@ -1100,7 +1115,7 @@ impl RoomsList {
                         new_displayed_invited_rooms.push(room_id.clone());
                     }
                 }
-            }
+            });
 
             for (room_id, jr) in &self.all_joined_rooms {
                 if !seen_joined.contains(room_id) && should_display_room!(self, room_id, jr) {
@@ -1813,4 +1828,31 @@ struct RoomCategoryIndexes {
     first_room_index: usize,
     /// The index after the last room in this category, which is where the next category should start.
     after_rooms_index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_sdk::ruma::owned_room_id;
+
+    #[test]
+    fn room_order_iteration_ignores_duplicate_room_ids() {
+        let first_room_id = owned_room_id!("!first:example.com");
+        let second_room_id = owned_room_id!("!second:example.com");
+        let ordered_room_ids = [
+            first_room_id.clone(),
+            first_room_id.clone(),
+            second_room_id.clone(),
+        ];
+
+        let mut iterated_room_ids = Vec::new();
+        for_each_room_id_in_display_order(ordered_room_ids.iter(), |room_id| {
+            iterated_room_ids.push(room_id.clone());
+        });
+
+        assert_eq!(
+            iterated_room_ids,
+            vec![first_room_id, second_room_id],
+        );
+    }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1717,14 +1717,19 @@ async fn matrix_worker_task(
                 let _join_room_task = Handle::current().spawn(async move {
                     log!("Sending request to join room {room_id}...");
                     let result_action = if let Some(room) = client.get_room(&room_id) {
-                        match room.join().await {
-                            Ok(()) => {
-                                log!("Successfully joined known room {room_id}.");
-                                JoinRoomResultAction::Joined { room_id }
-                            }
-                            Err(e) => {
-                                error!("Error joining known room {room_id}: {e:?}");
-                                JoinRoomResultAction::Failed { room_id, error: e }
+                        if room.state() == RoomState::Joined {
+                            log!("Room {room_id} is already joined, skipping join request.");
+                            JoinRoomResultAction::Joined { room_id }
+                        } else {
+                            match room.join().await {
+                                Ok(()) => {
+                                    log!("Successfully joined known room {room_id}.");
+                                    JoinRoomResultAction::Joined { room_id }
+                                }
+                                Err(e) => {
+                                    error!("Error joining known room {room_id}: {e:?}");
+                                    JoinRoomResultAction::Failed { room_id, error: e }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- **Skip redundant JoinRoom requests**: When creating a DM with a bot, a race condition between `create_room` and sliding sync caused a duplicate `JoinRoom` request, triggering a "Failed to join: it has already been joined" error popup. Now checks `room.state() == RoomState::Joined` before sending the request.
- **Deduplicate room list display**: Added `for_each_room_id_in_display_order()` to filter out duplicate room IDs during rendering, preventing duplicate entries in the rooms list UI.

## Test plan
- [x] Build passes (`cargo build`)
- [x] All 130 unit tests pass (`cargo test --lib`)
- [x] Manual test: search for bot → Create DM → no error popup
- [x] Manual test: full clean environment (fresh Palpo DB + Robrix cache) verified