### PR TITLE
fix(mobile): align room header info button and polish top bar layout

### DIFF
--- a/specs/task-mobile-room-header-info-alignment.spec.md
+++ b/specs/task-mobile-room-header-info-alignment.spec.md
@@ -1,0 +1,82 @@
+spec: task
+name: "Mobile Room Header Layout & Info Button Alignment"
+inherits: project
+tags: [bugfix, mobile, room-screen, header, navigation]
+estimate: 0.5d
+---
+
+## Intent
+
+修复移动端房间页面顶部导航栏样式异常的问题，并确保房间 `info` 图标位于右侧，与返回 icon 水平对齐。
+当前问题主要表现为：顶部区域视觉高度/留白不正确，且房间信息入口图标位置不符合预期。
+
+## Constraints
+
+- 只修复移动端 `StackNavigation` 下的房间页顶部导航栏
+- 保持现有导航行为不变（返回按钮、房间切换栈行为）
+- 保持现有 Room Info 打开逻辑不变（点击 `info` 仍触发 `MessageAction::ShowRoomInfoPane`）
+- `Invite` 与 `SpaceLobby` 页面不显示顶部 `info` 图标
+- 不修改桌面端布局和样式
+
+## Decisions
+
+- 调整移动端公共内容容器 `RobrixContentView` 的 header 布局参数，使顶部栏高度与内容区域一致，避免异常顶部留白/错位
+- 使用继承合并方式覆盖 header 右侧按钮，确保 `info` 图标在 header 右侧
+- 左右按钮使用同一垂直对齐基准，确保 `info` 图标与返回 icon 水平对齐
+- 保留现有条件显示逻辑：
+  - `JoinedRoom` / `Thread` 显示 `info`
+  - `InvitedRoom` / `Space` 隐藏 `info`
+
+## Boundaries
+
+### Allowed Changes
+- `src/home/home_screen.rs` — 移动端 `RobrixContentView` header 样式与右侧按钮布局
+- `src/app.rs` — 若需要，微调移动端 header 右侧 `info` 按钮显隐与状态同步
+
+### Forbidden
+- 不修改桌面端 `MainDesktopUI` 布局
+- 不改动 Room Info pane 内部交互逻辑
+- 不改动消息列表、输入框、时间线业务逻辑
+- 不新增依赖
+- 不运行 `cargo fmt` 或进行无关格式化
+
+## Acceptance Criteria
+
+Scenario: Mobile room header no longer shows incorrect top style
+  Test: manual_test_mobile_room_header_style_fixed
+  Given 用户在移动端进入 JoinedRoom
+  When 房间页面显示顶部导航栏
+  Then 顶部不再出现异常留白或错位样式
+  And 顶部导航栏高度与正文起始位置视觉一致
+
+Scenario: Info icon is displayed on the right for JoinedRoom and Thread
+  Test: manual_test_mobile_room_header_info_visible_on_chat_views
+  Given 用户在移动端进入 JoinedRoom 或 Thread
+  When 页面顶部导航栏渲染完成
+  Then `info` 图标可见
+  And 图标位于顶部导航栏右侧
+
+Scenario: Info icon aligns horizontally with back icon
+  Test: manual_test_mobile_room_header_info_back_horizontal_alignment
+  Given 用户在移动端进入 JoinedRoom 或 Thread
+  When 页面顶部导航栏渲染完成
+  Then 左侧返回 icon 与右侧 `info` icon 在同一水平线上
+
+Scenario: Info icon remains hidden on Invite and SpaceLobby
+  Test: manual_test_mobile_room_header_info_hidden_on_invite_and_space
+  Given 用户在移动端进入 Invite 页面或 SpaceLobby 页面
+  When 页面顶部导航栏渲染完成
+  Then 顶部右侧不显示 `info` 图标
+
+Scenario: Clicking header info still opens room info pane
+  Test: manual_test_mobile_room_header_info_click_opens_room_info
+  Given 用户在移动端 JoinedRoom 页面且顶部 `info` 图标可见
+  When 用户点击 `info` 图标
+  Then 触发 `MessageAction::ShowRoomInfoPane`
+  And Room Info pane 正常打开
+
+## Out of Scope
+
+- 重新设计移动端整体导航视觉风格
+- 调整 status bar/系统安全区域策略以外的全局窗口策略
+- 修改 Room Info pane 的内容和交互细节

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -39,13 +39,13 @@ script_mod! {
                 gradient_fill_horizontal: uniform(0.0)
                 color_2: instance(vec4(-1))
 
-                border_radius: uniform(4.0)
+                border_radius: uniform(0.0)
                 border_size: uniform(0.0)
                 border_color: instance(#0000)
                 border_color_2: instance(vec4(-1))
 
-                shadow_color: instance(#0005)
-                shadow_radius: uniform(12.0)
+                shadow_color: instance(#0002)
+                shadow_radius: uniform(8.0)
                 shadow_offset: uniform(vec2(0.0, 0.0))
 
                 rect_size2: varying(vec2(0))
@@ -111,32 +111,34 @@ script_mod! {
                 }
             }
 
-            padding: Inset{top: 30, bottom: 0}
+            padding: Inset{top: 0, bottom: 0}
             height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT),
 
                 content +: {
                     height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)
                     button_container +: {
                         width: Fill
-                        flow: Overlay
+                        height: Fill
+                        flow: Right
                         padding: 0,
                         margin: 0
                         left_button +: {
-                            align: Align{x: 0.0, y: 0.5}
-                            width: Fit, height: Fit,
-                            padding: Inset{left: 20, right: 23, top: 10, bottom: 10}
-                            margin: Inset{left: 8, right: 0, top: 0, bottom: 0}
+                            width: 56, height: Fill,
+                            padding: 0,
+                            margin: 0
                             draw_icon +: { color: (ROOM_NAME_TEXT_COLOR) }
-                            icon_walk: Walk{width: 13, height: Fit}
+                            icon_walk: Walk{width: 14, height: Fit}
                             spacing: 0
                             text: ""
                         }
+                        button_spacer := View {
+                            width: Fill, height: Fill
+                        }
                         right_button := ButtonFlatterIcon {
                             visible: false
-                            align: Align{x: 1.0, y: 0.5}
-                            width: Fit, height: Fit,
-                            padding: Inset{left: 23, right: 20, top: 10, bottom: 10}
-                            margin: Inset{left: 0, right: 8, top: 0, bottom: 0}
+                            width: 56, height: Fill,
+                            padding: 0,
+                            margin: 0
                             draw_icon +: {
                                 color: (ROOM_NAME_TEXT_COLOR)
                                 svg: (ICON_INFO)
@@ -147,9 +149,14 @@ script_mod! {
                         }
                     }
                     title_container +: {
-                    padding: Inset{top: 8}
+                    width: Fill
+                    height: Fill
+                    padding: Inset{top: 0}
+                    align: Align{x: 0.5, y: 0.5}
                     title +: {
+                        margin: 0
                         draw_text +: {
+                            text_style: theme.font_bold { font_size: 11.5 }
                             color: (ROOM_NAME_TEXT_COLOR)
                         }
                     }

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -151,10 +151,14 @@ script_mod! {
                     title_container +: {
                     width: Fill
                     height: Fill
-                    padding: Inset{top: 0}
+                    padding: Inset{top: 0, left: 56, right: 56}
                     align: Align{x: 0.5, y: 0.5}
                     title +: {
+                        width: Fill
                         margin: 0
+                        flow: Flow.Right{wrap: false}
+                        max_lines: 1
+                        text_overflow: Ellipsis
                         draw_text +: {
                             text_style: theme.font_bold { font_size: 11.5 }
                             color: (ROOM_NAME_TEXT_COLOR)


### PR DESCRIPTION
## Summary
- fix mobile room header button container layout so the info icon is anchored on the right
- keep back/info icons horizontally aligned with symmetric touch target slots
- polish mobile room header visuals (title alignment, spacing, shadow)
- add task spec for scope/constraints/acceptance criteria

## Scope
- src/home/home_screen.rs
- specs/task-mobile-room-header-info-alignment.spec.md

## Verification
- cargo build
- manually verified mobile header:
  - info icon visible on JoinedRoom/Thread and placed on right side
  - back/info icons are horizontally aligned
  - invite/space lobby does not show info icon