### PR TITLE
Fix mobile room reopening and bottom tab bar seam

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,7 +86,7 @@ script_mod! {
             main_window := Window {
                 window.inner_size: vec2(1280, 800)
                 window.title: "Robrix"
-                pass.clear_color: #FFFFFF00
+                pass.clear_color: (COLOR_SECONDARY)
                 caption_bar +: {
                     draw_bg.color: #F3F3F3
                     caption_label +: {
@@ -99,6 +99,8 @@ script_mod! {
             
 
                 body +: {
+                    show_bg: true
+                    draw_bg.color: (COLOR_SECONDARY)
                     padding: Inset{
                         top: (mod.widgets.SAFE_INSET_PAD_TOP),
                         bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
@@ -1968,6 +1970,10 @@ impl App {
     /// screen configuration are effectively no-ops — MainDesktopUI handles
     /// room display via dock tabs instead.
     fn push_selected_room_view(&mut self, cx: &mut Cx, selected_room: SelectedRoom) {
+        if self.app_state.selected_room.as_ref().is_some_and(|current| current == &selected_room) {
+            return;
+        }
+
         // Use the actual StackNavigation depth to pick the next room view slot.
         let new_depth = self.ui.stack_navigation(cx, ids!(view_stack)).depth();
 

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -201,7 +201,7 @@ script_mod! {
 
             draw_bg +: {
                 color: (COLOR_SECONDARY)
-                border_radius: (RADIUS_LG)
+                border_radius: 0.0
             }
 
             CachedWidget {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1356,6 +1356,10 @@ impl Widget for RoomsList {
                     continue;
                 };
 
+                if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_room) {
+                    continue;
+                }
+
                 self.current_active_room = Some(new_selected_room.clone());
                 cx.widget_action(
                     self.widget_uid(), 
@@ -1388,6 +1392,9 @@ impl Widget for RoomsList {
             else if let Some(SpaceLobbyAction::SpaceLobbyEntryClicked) = action.downcast_ref() {
                 let Some(space_name_id) = self.selected_space.clone() else { continue };
                 let new_selected_space = SelectedRoom::Space { space_name_id };
+                if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_space) {
+                    continue;
+                }
                 self.current_active_room = Some(new_selected_space.clone());
                 cx.widget_action(
                     self.widget_uid(), 


### PR DESCRIPTION
## What changed
- prevent duplicate mobile room and space selections from re-pushing the same `SelectedRoom`
- keep the mobile bottom tab bar and surrounding window background on the same secondary color
- remove the mobile tab bar border radius to avoid the thin bottom seam on iOS

## Why
Repeated taps on the same room could push the same mobile room screen twice. The second screen could render with a header but no timeline content because the timeline endpoints are singleton-backed and the duplicate screen could not acquire them again.

The bottom tab bar seam came from the mobile bar sitting on top of a different background layer while still using rounded corners. Squaring off the mobile tab bar removes the exposed edge and keeps the bottom area visually continuous.

## User impact
- double-tapping the same room on mobile no longer opens a blank duplicate room screen
- the mobile bottom tab bar now has a continuous bottom edge without the visible white hairline

## Validation
- `cargo build`
