### PR TITLE
ci: disable macOS signing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,15 +306,15 @@ jobs:
           CARGO_PACKAGER_SIGN_PRIVATE_KEY_PASSWORD: ${{ secrets.CARGO_PACKAGER_SIGN_PRIVATE_KEY_PASSWORD || secrets.CARGO_PACKAGER_SIGNING_PASSWORD }}
           ROBRIX_UPDATER_PUBKEY: ${{ secrets.CARGO_PACKAGER_SIGN_PUBLIC_KEY }}
           ROBRIX_UPDATER_ENDPOINT: https://github.com/${{ github.repository }}/releases/latest/download/latest.json
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         with:
           github_token: ${{ secrets.ROBRIX_RELEASE }}
           packager_formats: dmg
-          enable_macos_notarization: true
+          enable_macos_notarization: false
           uploadUpdaterJson: true
           uploadUpdaterSignatures: true
           releaseId: ${{ needs.create_release.outputs.release_id }}


### PR DESCRIPTION
## Summary
- disable Apple certificate injection for the macOS desktop release job
- turn off macOS notarization for the desktop packaging flow
- keep the workflow on `project-robius/makepad-packaging-action@v1` without extra repo-side Android path workarounds

## Why
The current macOS desktop release workflow still enters the signing and notarization path, which makes the action import an Apple `.p12` certificate even when we want an unsigned desktop build. In CI this fails during `security import` when signing credentials are absent or intentionally unused.

This change makes the macOS desktop release job behave as an unsigned build path by default, while leaving the iOS packaging flow untouched.

## Impact
- macOS desktop release packaging no longer depends on `APPLE_CERTIFICATE` or `APPLE_CERTIFICATE_PASSWORD`
- macOS desktop release packaging no longer attempts notarization
- iOS signing and provisioning remain unchanged

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml-ok'"`
- `git diff --check`
