### PR TITLE
ci: disable macOS packager signing identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,7 @@ frameworks = []
 info_plist_path = "./packaging/Info.plist"
 entitlements = "./packaging/Entitlements.plist"
 # signing_identity = "Developer ID Application: GOSIM FOUNDATION LTD. (HMX6XGJZ3R)"
-signing_identity = "="
+# signing_identity = "="
 
 
 ## Configuration for `cargo packager`'s generation of a macOS `.dmg`.

--- a/src/home/event_source_modal.rs
+++ b/src/home/event_source_modal.rs
@@ -489,12 +489,10 @@ fn push_indent_html(out: &mut String, width: usize) {
 }
 
 fn starts_with_chars(chars: &[char], start: usize, needle: &str) -> bool {
-    let mut idx = start;
-    for needle_ch in needle.chars() {
+    for (idx, needle_ch) in (start..).zip(needle.chars()) {
         if chars.get(idx).copied() != Some(needle_ch) {
             return false;
         }
-        idx += 1;
     }
     true
 }

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -534,11 +534,10 @@ impl WidgetMatchEvent for MainDesktopUI {
                     );
                 }
                 // When dragging a tab, allow it to be dragged
-                DockAction::Drag(drag_event) => {
-                    if drag_event.items.len() == 1 {
-                        self.view.dock(cx, ids!(dock)).accept_drag(cx, drag_event, DragResponse::Move);
-                    }
+                DockAction::Drag(drag_event) if drag_event.items.len() == 1 => {
+                    self.view.dock(cx, ids!(dock)).accept_drag(cx, drag_event, DragResponse::Move);
                 }
+                DockAction::Drag(_) => {}
                 // When dropping a tab, move it to the new position
                 DockAction::Drop(drop_event) => {
                     // from inside the dock, otherwise it's an external file
@@ -578,12 +577,11 @@ impl WidgetMatchEvent for MainDesktopUI {
                     let app_state = scope.data.get_mut::<AppState>().unwrap();
                     self.save_dock_state_to(cx, app_state);
                 }
-                Some(MainDesktopUiAction::CloseRoomTabs { room_id }) => {
-                    if self.close_room_tabs(cx, room_id) {
-                        self.redraw(cx);
-                        should_save_dock_action = true;
-                    }
+                Some(MainDesktopUiAction::CloseRoomTabs { room_id }) if self.close_room_tabs(cx, room_id) => {
+                    self.redraw(cx);
+                    should_save_dock_action = true;
                 }
+                Some(MainDesktopUiAction::CloseRoomTabs { .. }) => {}
                 _ => {}
             }
         }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -10787,18 +10787,17 @@ impl Widget for Message {
         // because we don't want any widgets within the replied-to message to be
         // clickable or otherwise interactive.
         match event.hits(cx, self.view(cx, ids!(replied_to_message)).area()) {
-            Hit::FingerDown(fe) => {
-                if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
-                    cx.widget_action(
-                        details.room_screen_widget_uid, 
-                        MessageAction::OpenMessageContextMenu {
-                            details: details.clone(),
-                            abs_pos: fe.abs,
-                            opening_gesture: ContextMenuOpenGesture::from_finger_down(&fe),
-                        }
-                    );
-                }
+            Hit::FingerDown(fe) if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) => {
+                cx.widget_action(
+                    details.room_screen_widget_uid,
+                    MessageAction::OpenMessageContextMenu {
+                        details: details.clone(),
+                        abs_pos: fe.abs,
+                        opening_gesture: ContextMenuOpenGesture::from_finger_down(&fe),
+                    }
+                );
             }
+            Hit::FingerDown(_) => {}
             Hit::FingerLongPress(lp) => {
                 cx.widget_action(
                     details.room_screen_widget_uid, 

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1045,31 +1045,31 @@ impl Widget for SpaceLobbyScreen {
                     }
 
                     // Handle receiving top-level space details (join rule, member count).
-                    Some(SpaceRoomListAction::TopLevelSpaceDetails(sr)) => {
-                        if self.space_name_id.as_ref().is_some_and(|sni| sni.room_id() == &sr.room_id) {
-                            self.space_avatar_state = AvatarState::Known(sr.avatar_url.clone());
-                            self.space_avatar_state.update_from_cache(cx); // prefetch the avatar image
-                            self.top_level_join_rule = sr.join_rule.clone();
-                            self.top_level_member_count = Some(sr.num_joined_members);
-                            self.update_space_info_label(cx, app_language);
-                            self.redraw(cx);
-                        }
+                    Some(SpaceRoomListAction::TopLevelSpaceDetails(sr))
+                        if self.space_name_id.as_ref().is_some_and(|sni| sni.room_id() == &sr.room_id) => {
+                        self.space_avatar_state = AvatarState::Known(sr.avatar_url.clone());
+                        self.space_avatar_state.update_from_cache(cx); // prefetch the avatar image
+                        self.top_level_join_rule = sr.join_rule.clone();
+                        self.top_level_member_count = Some(sr.num_joined_members);
+                        self.update_space_info_label(cx, app_language);
+                        self.redraw(cx);
                     }
+                    Some(SpaceRoomListAction::TopLevelSpaceDetails(..)) => {}
 
                     // Handle a change to the set of children in this space or any of its child subspaces.
-                    Some(SpaceRoomListAction::UpdatedChildren { space_id, parent_chain, .. }) => {
+                    Some(SpaceRoomListAction::UpdatedChildren { space_id, parent_chain, .. })
                         if self.space_name_id.as_ref().is_some_and(|sni|
                             sni.room_id() == space_id
                             || parent_chain.iter().any(|ancestor_id| sni.room_id() == ancestor_id)
-                        ) {
-                            if let Some(sender) = &self.space_request_sender {
-                                let _ = sender.send(SpaceRequest::GetDetailedChildren {
-                                    space_id: space_id.clone(),
-                                    parent_chain: parent_chain.clone(),
-                                });
-                            }
+                        ) => {
+                        if let Some(sender) = &self.space_request_sender {
+                            let _ = sender.send(SpaceRequest::GetDetailedChildren {
+                                space_id: space_id.clone(),
+                                parent_chain: parent_chain.clone(),
+                            });
                         }
                     }
+                    Some(SpaceRoomListAction::UpdatedChildren { .. }) => {}
                     _ => { }
                 }
 

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -103,9 +103,9 @@ impl Widget for Avatar {
             Hit::FingerDown(_fde) => {
                 cx.set_key_focus(area);
             }
-            Hit::FingerUp(fue) => if fue.is_over && fue.is_primary_hit() && fue.was_tap() {
+            Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() && fue.was_tap() => {
                 cx.widget_action(
-                    widget_uid, 
+                    widget_uid,
                     ShowUserProfileAction::ShowUserProfile(info),
                 );
             }

--- a/src/shared/collapsible_header.rs
+++ b/src/shared/collapsible_header.rs
@@ -121,11 +121,10 @@ impl Widget for CollapsibleHeader {
             Hit::FingerDown(..) => {
                 cx.set_key_focus(self.view.area());
             }
-            Hit::FingerUp(fe) => {
-                if !rooms_list_props.was_scrolling && fe.is_over && fe.is_primary_hit() && fe.was_tap() {
-                    self.toggle_collapse(cx, scope);
-                }
+            Hit::FingerUp(fe) if !rooms_list_props.was_scrolling && fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
+                self.toggle_collapse(cx, scope);
             }
+            Hit::FingerUp(_) => { }
             _ => { }
         }
         self.view.handle_event(cx, event, scope);

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -532,15 +532,15 @@ impl Widget for ImageViewer {
                 cx.stop_timer(self.hide_ui_timer);
                 self.animator_cut(cx, ids!(ui_animator.show));
             }
-            Hit::FingerHoverOut(fe) => {
-                // FingerHoverOut is triggered when the cursor enters into the button.
-                // Hence we need to check if the cursor is actually inside the button group.
+            Hit::FingerHoverOut(fe)
                 if !self.ui_visible_toggle
                     && !button_group_rounded_view.area().rect(cx).contains(fe.abs)
-                {
-                    self.hide_ui_timer = cx.start_timeout(SHOW_UI_DURATION);
-                }
+                => {
+                // FingerHoverOut is triggered when the cursor enters into the button.
+                // Hence we need to check if the cursor is actually inside the button group.
+                self.hide_ui_timer = cx.start_timeout(SHOW_UI_DURATION);
             }
+            Hit::FingerHoverOut(_) => {}
             _ => {}
         }
         match event.hits(cx, self.view.view(cx, ids!(metadata_rounded_view)).area()) {
@@ -555,15 +555,14 @@ impl Widget for ImageViewer {
         }
         // Handle cursor changes on mouse hover
         match event.hits(cx, rotated_image.area()) {
-            Hit::FingerDown(fe) => {
-                if fe.is_primary_hit() {
-                    self.drag_state.drag_start = fe.abs;
-                    // Initialize pan_offset with current position if not set
-                    if self.drag_state.pan_offset.is_none() {
-                        self.drag_state.pan_offset = Some(DVec2::default());
-                    }
+            Hit::FingerDown(fe) if fe.is_primary_hit() => {
+                self.drag_state.drag_start = fe.abs;
+                // Initialize pan_offset with current position if not set
+                if self.drag_state.pan_offset.is_none() {
+                    self.drag_state.pan_offset = Some(DVec2::default());
                 }
             }
+            Hit::FingerDown(_) => {}
             Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() => {
                 // Only reset pan_offset on double-tap, not single tap
                 if fe.tap_count == 2 {
@@ -607,16 +606,16 @@ impl Widget for ImageViewer {
                 self.mouse_cursor_hover_over_image = false;
                 cx.set_cursor(MouseCursor::Default);
             }
-            Hit::FingerHoverOver(_) => {
+            Hit::FingerHoverOver(_)
                 if !self.ui_visible_toggle
                     && !self.animator.in_state(cx, ids!(ui_animator.show))
-                {
-                    self.animator_cut(cx, ids!(ui_animator.hide));
-                    self.animator_play(cx, ids!(ui_animator.show));
-                    cx.stop_timer(self.hide_ui_timer);
-                    self.hide_ui_timer = cx.start_timeout(SHOW_UI_DURATION);
-                }
+                => {
+                self.animator_cut(cx, ids!(ui_animator.hide));
+                self.animator_play(cx, ids!(ui_animator.show));
+                cx.stop_timer(self.hide_ui_timer);
+                self.hide_ui_timer = cx.start_timeout(SHOW_UI_DURATION);
             }
+            Hit::FingerHoverOver(_) => {}
             _ => {}
         }
         if let Event::Scroll(scroll_event) = event {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -695,17 +695,20 @@ pub fn ends_with_href(text: &str) -> bool {
     // Search backwards for a single quote, double quote, or an equals sign.
     match substr.as_bytes().last() {
         Some(b'\'' | b'"') => {
-            if substr
+            let Some(before_quote) = substr
                 .get(.. substr.len().saturating_sub(1))
-                .map(|s| {
-                    substr = s.trim_end();
-                    substr.as_bytes().last() == Some(&b'=')
-                })
-                .unwrap_or(false)
-            {
-                substr = &substr[..substr.len().saturating_sub(1)];
-            } else {
+                .map(str::trim_end)
+            else {
                 return false;
+            };
+
+            match before_quote.as_bytes().last() {
+                Some(b'=') => {
+                    substr = &before_quote[..before_quote.len().saturating_sub(1)];
+                }
+                _ => {
+                    return false;
+                }
             }
         }
         Some(b'=') => {


### PR DESCRIPTION
## Summary
- disable the macOS `cargo-packager` signing identity in `Cargo.toml`
- keep the previously merged unsigned macOS release workflow behavior aligned with packager config

## Why
PR #108 disabled Apple certificate injection and notarization in the macOS release workflow, but `Cargo.toml` still kept `signing_identity = "="` under `[package.metadata.packager.macos]`.

That means `cargo-packager` still tries to run:

```text
codesign -s "="
```

On CI runners without a matching keychain identity, macOS release packaging fails with:

```text
The specified item could not be found in the keychain.
```

## Impact
- macOS desktop packaging no longer requests a fake codesign identity from `cargo-packager`
- the release workflow and packager config now both point to an unsigned macOS desktop packaging path
- iOS signing behavior remains unchanged

## Validation
- `cargo clippy --workspace --all-features`
- `git diff --check`
