### PR TITLE
ci: retire -D warnings, adopt Cargo [lints] as sole lint policy

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -93,8 +93,6 @@ jobs:
           key: ubuntu-build-${{ hashFiles('Cargo.lock') }}
 
       - name: Build
-        env:
-          RUSTFLAGS: "-D warnings"
         run: |
           cargo build --profile fast
 
@@ -124,8 +122,6 @@ jobs:
           key: macos-${{ matrix.arch }}-build-${{ hashFiles('Cargo.lock') }}
 
       - name: Build
-        env:
-          RUSTFLAGS: "-D warnings"
         run: |
           cargo build --profile fast
 
@@ -148,8 +144,6 @@ jobs:
           key: windows-build-${{ hashFiles('Cargo.lock') }}
 
       - name: Build
-        env:
-          RUSTFLAGS: "-D warnings"
         run: |
           cargo build --profile fast
 
@@ -192,7 +186,6 @@ jobs:
 
       - name: Build for iOS targets
         env:
-          RUSTFLAGS: "-D warnings"
           AWS_LC_SYS_CMAKE_BUILDER: 1
         run: |
           # Install iOS targets
@@ -233,7 +226,6 @@ jobs:
 
       - name: Build Android APK
         env:
-          RUSTFLAGS: "-D warnings"
           AWS_LC_SYS_CMAKE_BUILDER: 1
         run: |
           cargo makepad android build -p robrix \
@@ -267,7 +259,6 @@ jobs:
 
       - name: Build Android APK
         env:
-          RUSTFLAGS: "-D warnings"
           AWS_LC_SYS_CMAKE_BUILDER: 1
         run: |
           cargo makepad android build -p robrix \
@@ -308,7 +299,6 @@ jobs:
 
       - name: Build Android APK
         env:
-          RUSTFLAGS: "-D warnings"
           AWS_LC_SYS_CMAKE_BUILDER: 1
           CMAKE_GENERATOR: Ninja
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,6 @@ env:
     CARGO_TERM_COLOR: always
     CARGO_INCREMENTAL: "0"  # Disable incremental compilation in CI
     RUST_BACKTRACE: 1
-    # Enable warnings as errors for strict checks
-    RUSTFLAGS: "-D warnings"
 
 jobs:
   clippy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,6 +294,8 @@ non_local_definitions = "forbid"
 unsafe_op_in_unsafe_fn = "forbid"
 unnameable_types = "warn"
 unused_import_braces = "warn"
+unused = { level = "deny", priority = -1 }
+dead_code = "deny"
 
 ## Configuration for clippy lints.
 [lints.clippy]


### PR DESCRIPTION
## Summary

- Deletes `RUSTFLAGS: "-D warnings"` from 8 call sites (main.yml global env + builds.yml × 7 build jobs)
- Adds `unused = { level = "deny", priority = -1 }` and `dead_code = "deny"` to `Cargo.toml [lints.rust]` to preserve the "author self-defect" half of `-D warnings`' job
- `release.yml` already omitted `-D warnings` — unchanged here

## Why

Floating `dtolnay/rust-toolchain@stable` × blanket `-D warnings` is the well-known "time bomb" combo: every ~6 weeks Rust stable can promote a clippy lint from `allow` to `warn` by default, and the next unrelated PR fails on errors its author did not introduce.

`Cargo.toml [lints.rust]` / `[lints.clippy]` (stable since Cargo 1.74) is the modern replacement — per-lint, manifest-versioned, explicit. This repo already uses it for 6 rustc entries and 8 clippy entries. This PR retires the old env-flag mechanism so `[lints]` is the single source of truth.

The two new denies (`unused` group, `dead_code`) are pinned per-lint, so they catch author-introduced mistakes in the PR's own CI without being affected by upstream lint additions.

The `unused` group uses `priority = -1` so the existing `unused_import_braces = "warn"` declaration continues to win for that specific lint — this is required by `clippy::lint_groups_priority` (stable since Cargo 1.74) and is the idiomatic shape used in rust-lang/rust, cargo, and tokio.

## Responsibility split after this PR

| Concern | Owner |
|---------|-------|
| Toolchain drift (upstream adds warn-level lints) | Maintainer during toolchain bumps (see #112) |
| Author's own `unused_*` / `dead_code` | This PR's CI (`[lints.rust]` deny entries) |
| Safety / correctness hard gates | Existing `[lints.rust] forbid` entries (unchanged) |

## Test plan

- [x] Local `cargo build --profile fast` passes
- [x] Local `cargo clippy --workspace --all-features` passes (0 warnings, 0 errors)
- [x] CI on this PR is green (main.yml clippy + builds.yml × 7)

## Companion PR

#112 expands the story: pins `rust-toolchain.toml` to an exact version, swaps CI to a toml-aware toolchain action, adds a non-blocking `clippy_report` job to `release.yml`, and documents the upgrade cadence in the toml itself. Together, these two PRs move robrix2 from passive lint/toolchain drift to active control.