### PR TITLE
ci: add Cargo.toml patch guard to prevent local path leaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,3 +67,24 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for typos
         uses: crate-ci/typos@master
+
+  check_patches:
+    if: github.event.pull_request.draft == false
+    name: check patches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Forbid local path patches in Cargo.toml
+        # Local `path = ...` in a [patch.*] block is useful for upstream
+        # debugging but breaks CI and every teammate's checkout when
+        # accidentally committed. Upstream patches must use `git = ...`.
+        run: |
+          awk '
+            /^[[:space:]]*#/ {next}
+            /^[[:space:]]*\[patch/ {in_patch=1; next}
+            /^[[:space:]]*\[/ {in_patch=0}
+            in_patch && /path[[:space:]]*=/ {
+              print "::error file=Cargo.toml,line=" NR "::local path patch found: " $0
+              exit 1
+            }
+          ' Cargo.toml


### PR DESCRIPTION
## Summary

Reject local `path = ...` patches in Cargo.toml `[patch.*]` blocks via a tiny awk-based CI job.

## Why

Cargo's `[patch.*]` table supports `git = ...` (safe for CI) and `path = ...` (useful for local upstream debugging, lethal when committed). A single forgotten `git commit -a` can land a local patch on main and break every checkout and CI run until reverted. robrix2's patched-dependency chain (makepad, matrix-sdk, ruma) makes this a live maintainer risk — the kind of tripwire worth automating once.

## Approach

Borrowed from moly-ai's [`check-patches`](https://github.com/moly-ai/moly-ai/blob/main/.github/workflows/checks.yml) job. Two small upgrades over the original:

1. **POSIX-compatible regex** (`[[:space:]]` instead of gawk-only `\s`) so the same script runs identically during local dry-run on macOS (BSD awk) and in CI on ubuntu-latest (gawk).
2. **GitHub Actions annotation** (`::error file=Cargo.toml,line=N::...`) so violations surface inline on the PR's Files Changed page rather than buried in the job log.

## Test plan

Local awk dry-run, 4 scenarios:

| Scenario | Expected | Actual |
|----------|----------|--------|
| Current `Cargo.toml` (all `git = ...`) | pass | exit 0 ✅ |
| Synthetic `{ path = "../makepad" }` in `[patch.*]` | fail with error | exit 1, error emitted ✅ |
| `[patch.*]` with `git = ...` only (URL contains no `path`) | pass | exit 0 ✅ |
| Commented-out `# path = ...` inside `[patch.*]` | pass | exit 0 ✅ |

- [ ] CI confirms new `check patches` job runs and passes on this PR
- [ ] (Post-merge, optional) Open a throwaway branch with a deliberate `path = ...` in `[patch.crates-io]`, confirm the job fails and the file:line annotation appears on the PR diff

## Relationship to #111 / #112

Pure addition to `main.yml` — does not overlap with the `-D warnings` removal in #111 or the toolchain-pin / action-swap changes in #112. All three PRs are rebase-clean against any merge order.