### PR TITLE
feat(register): align with element-desktop — Phase 1+2 (MAS browser signup)

### DIFF
--- a/docs/superpowers/plans/2026-04-21-register-phase-1-skeleton.md
+++ b/docs/superpowers/plans/2026-04-21-register-phase-1-skeleton.md
@@ -1,0 +1,1200 @@
+# Register 阶段 1 实施计划：骨架 + HS 能力发现
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 建立 `src/register/` 模块的骨架（4 个文件），实现 homeserver 能力发现，让用户从 login 屏点击 "Sign up here" 后进入注册屏选服务器并看到 "MAS OAuth / UIAA / 不允许注册" 三种状态。本阶段**不**实现任何真正的注册动作。
+
+**Architecture:** 独立 `src/register/` 模块，包含 `mod.rs`、`register_screen.rs`、`register_status_modal.rs`、`validation.rs`。`RegisterScreen` widget 主导 UI；新增 `MatrixRequest::DiscoverHomeserverCapabilities` 在后台异步探测 `.well-known/matrix/client` + `/_matrix/client/versions` + `/_matrix/client/v3/login` + 空 body `POST /register`。结果通过 `RegisterAction::CapabilitiesDiscovered(HsCapabilities)` 回到 UI。`login_screen.rs` 删除现有 signup mode 并把 "Sign up here" 按钮的点击改为派发 `LoginAction::NavigateToRegister`。
+
+**Tech Stack:** Rust + Makepad 2.0 DSL (`script_mod!`)，`matrix-sdk`（已引入），`url = "2.5"`（已引入），`reqwest`（通过 matrix-sdk transitive dep 已引入），`robius_open`（已引入，但本阶段不使用），`tokio`（已引入）。
+
+**依赖的 spec：** `specs/task-register-flow.spec.md` ，阶段 1 对应 "骨架 + 能力发现" 子章节。
+
+---
+
+## File Structure
+
+### Create
+
+| 文件 | 职责 | 预计 LOC |
+|---|---|---|
+| `src/register/mod.rs` | 模块入口 + `RegisterAction` / `HsCapabilities` / `RegisterMode` 数据类型 + `script_mod(vm)` 聚合函数 | ~120 |
+| `src/register/register_screen.rs` | `RegisterScreen` widget 及其 `script_mod!` DSL；ServerPicker、能力状态显示 | ~250 |
+| `src/register/register_status_modal.rs` | 进度/状态模态（Phase 1 仅骨架） | ~80 |
+| `src/register/validation.rs` | URL 归一化 + 校验 + 对应单元测试 | ~80 |
+
+### Modify
+
+| 文件 | 改动 |
+|---|---|
+| `src/lib.rs` | 追加 `pub mod register;`；`script_mod` 注册点调用 `register::script_mod(vm)` |
+| `src/login/login_screen.rs` | 删除 signup mode 相关代码（confirm_password DSL 字段、`set_signup_mode`、Sign Up 内部注册逻辑），改 "Sign up here" 按钮 click 派发 `LoginAction::NavigateToRegister` |
+| `src/login/login_screen.rs` (enum) | `LoginAction` 新增 `NavigateToRegister` 变体 |
+| `src/app.rs` | 处理 `LoginAction::NavigateToRegister` / `RegisterAction::NavigateToLogin` 实现登录屏 ↔ 注册屏切换 |
+| `src/sliding_sync.rs` (L695 附近) | `MatrixRequest` 新增 `DiscoverHomeserverCapabilities { url: String }` 变体 |
+| `src/sliding_sync.rs` (worker loop) | 实现能力发现 handler：调 matrix-sdk + 直接 HTTP probe 四条端点 |
+
+### Out of Phase 1 (留给阶段 2+)
+
+- `src/register/oidc.rs`（阶段 2）
+- `src/register/uiaa.rs`（阶段 3）
+- 实际触发注册：本阶段仅显示能力状态，**不**发起真正的 /register
+
+---
+
+## Prerequisite: 现有代码的关键位置（执行者速查）
+
+- `MatrixRequest` enum 位置：`src/sliding_sync.rs:695`
+- `LoginRequest` enum + `RegisterAccount` struct：`src/sliding_sync.rs:1245-1270`
+- `LoginAction` enum：`src/login/login_screen.rs:1223`
+- 现有 signup mode 相关 click handler：`src/login/login_screen.rs` 中搜索 `set_signup_mode`
+- Matrix worker loop 的 match 点：`src/sliding_sync.rs:1288`（`match request { ... }`）
+- `login/mod.rs` 中的 `script_mod` 聚合模式：就是我们要在 `register/mod.rs` 复制的结构
+
+---
+
+## Task 1: 模块骨架 + lib.rs 注册
+
+**Files:**
+- Create: `src/register/mod.rs`
+- Create: `src/register/validation.rs`
+- Create: `src/register/register_screen.rs`（本 task 只做占位 stub）
+- Create: `src/register/register_status_modal.rs`（占位 stub）
+- Modify: `src/lib.rs`（追加 `pub mod register;`）
+
+- [ ] **Step 1：创建 `src/register/mod.rs`（最小骨架）**
+
+```rust
+//! Account registration feature.
+//!
+//! Covers the dual-mode register flow (OIDC for MAS-delegated servers,
+//! UIAA wizard for legacy servers). See `specs/task-register-flow.spec.md`.
+
+use makepad_widgets::ScriptVm;
+
+pub mod register_screen;
+pub mod register_status_modal;
+pub mod validation;
+
+pub fn script_mod(vm: &mut ScriptVm) {
+    register_status_modal::script_mod(vm);
+    register_screen::script_mod(vm);
+}
+```
+
+- [ ] **Step 2：创建 `src/register/validation.rs`（占位）**
+
+```rust
+//! URL / localpart / password validators for registration.
+
+// Functions are added in Task 2.
+```
+
+- [ ] **Step 3：创建 `src/register/register_screen.rs`（最小 stub）**
+
+```rust
+//! RegisterScreen widget: homeserver picker + capability display.
+//!
+//! The full wizard body is added in later phases; Phase 1 only wires
+//! server selection and shows the MAS/UIAA/Disabled three-state result.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use makepad_widgets::base::*;
+    use makepad_widgets::theme_desktop_dark::*;
+
+    pub RegisterScreen := {{RegisterScreen}} View {
+        width: Fill,
+        height: Fill,
+        show_bg: true,
+        draw_bg: { color: #x1F2124 }
+
+        // TODO: Task 5 fills in this body.
+    }
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct RegisterScreen {
+    #[deref] view: View,
+}
+
+impl Widget for RegisterScreen {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+    }
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+```
+
+- [ ] **Step 4：创建 `src/register/register_status_modal.rs`（最小 stub）**
+
+```rust
+//! Status modal shared by both OIDC and UIAA branches.
+//!
+//! Phase 1 scaffolds the widget; full wiring comes in Phases 2-4.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use makepad_widgets::base::*;
+    use makepad_widgets::theme_desktop_dark::*;
+
+    pub RegisterStatusModal := {{RegisterStatusModal}} Modal {
+        // TODO: Phase 2 wires title + status text + cancel button.
+    }
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct RegisterStatusModal {
+    #[deref] modal: Modal,
+}
+
+impl Widget for RegisterStatusModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.modal.handle_event(cx, event, scope);
+    }
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.modal.draw_walk(cx, scope, walk)
+    }
+}
+```
+
+- [ ] **Step 5：修改 `src/lib.rs`，追加 `pub mod register;`**
+
+定位：在 `pub mod login;` 后面（让 login 和 register 视觉上相邻）。
+
+编辑示意：
+
+```rust
+pub mod login;
+pub mod register;  // NEW
+pub mod logout;
+```
+
+同时，在该文件的 `script_mod` 聚合函数里加入 `register::script_mod(vm)`。搜索 `login::script_mod(vm)` 所在位置，紧跟其后加一行：
+
+```rust
+pub fn script_mod(vm: &mut ScriptVm) {
+    // ... existing lines ...
+    login::script_mod(vm);
+    register::script_mod(vm);  // NEW
+    // ... other lines ...
+}
+```
+
+> **注意**：具体 `script_mod` 聚合函数在 `src/lib.rs` 里的位置可能略有差异；执行者 grep `login::script_mod(vm)` 定位后插入即可。
+
+- [ ] **Step 6：验证 `cargo build` 通过**
+
+```bash
+cargo build 2>&1 | tail -20
+```
+
+预期：无 error。有 `unused import` 或 `dead_code` warning 是正常的（本阶段是骨架）。
+
+- [ ] **Step 7：commit**
+
+```bash
+git add src/register/ src/lib.rs
+git commit -m "feat(register): scaffold src/register/ module
+
+Add empty register module with mod.rs, register_screen.rs,
+register_status_modal.rs, validation.rs. Register the module
+in src/lib.rs and wire the script_mod aggregator per the
+login/mod.rs pattern.
+
+Part of specs/task-register-flow.spec.md Phase 1."
+```
+
+---
+
+## Task 2: URL 归一化 + 单元测试
+
+**Files:**
+- Modify: `src/register/validation.rs`
+
+**TDD 顺序：先写测试，再写实现。**
+
+- [ ] **Step 1：在 `src/register/validation.rs` 写测试（用 `#[cfg(test)]` 模块）**
+
+```rust
+//! URL / localpart / password validators for registration.
+
+use url::Url;
+
+/// Errors returned by homeserver URL normalization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HomeserverUrlError {
+    /// Input was empty or whitespace only.
+    Empty,
+    /// Scheme is neither `http` nor `https`.
+    UnsupportedScheme(String),
+    /// URL could not be parsed.
+    Invalid,
+}
+
+/// Normalize a user-entered homeserver URL.
+///
+/// - Bare hostname (e.g. `matrix.org`) becomes `https://matrix.org`.
+/// - Explicit `http(s)://` schemes are kept as-is.
+/// - Any non-`http(s)` scheme is rejected.
+/// - Trailing `/` is stripped.
+/// - Empty string is rejected.
+pub fn normalize_homeserver_url(input: &str) -> Result<Url, HomeserverUrlError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(HomeserverUrlError::Empty);
+    }
+
+    let with_scheme = if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    };
+
+    let mut url = Url::parse(&with_scheme).map_err(|_| HomeserverUrlError::Invalid)?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(HomeserverUrlError::UnsupportedScheme(other.to_string())),
+    }
+
+    // Strip trailing slash for canonical form (Url keeps path = "/" by default;
+    // set to "" so discovery appends cleanly).
+    if url.path() == "/" {
+        url.set_path("");
+    }
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_hostname_gets_https() {
+        let url = normalize_homeserver_url("matrix.org").unwrap();
+        assert_eq!(url.as_str(), "https://matrix.org");
+    }
+
+    #[test]
+    fn explicit_https_is_kept() {
+        let url = normalize_homeserver_url("https://alvin.meldry.com").unwrap();
+        assert_eq!(url.as_str(), "https://alvin.meldry.com");
+    }
+
+    #[test]
+    fn explicit_http_is_kept() {
+        let url = normalize_homeserver_url("http://127.0.0.1:8128").unwrap();
+        assert_eq!(url.as_str(), "http://127.0.0.1:8128");
+    }
+
+    #[test]
+    fn trailing_slash_is_stripped() {
+        let url = normalize_homeserver_url("https://matrix.org/").unwrap();
+        assert_eq!(url.as_str(), "https://matrix.org");
+    }
+
+    #[test]
+    fn whitespace_is_trimmed() {
+        let url = normalize_homeserver_url("  matrix.org  ").unwrap();
+        assert_eq!(url.as_str(), "https://matrix.org");
+    }
+
+    #[test]
+    fn empty_input_is_rejected() {
+        assert_eq!(
+            normalize_homeserver_url(""),
+            Err(HomeserverUrlError::Empty),
+        );
+        assert_eq!(
+            normalize_homeserver_url("   "),
+            Err(HomeserverUrlError::Empty),
+        );
+    }
+
+    #[test]
+    fn non_http_scheme_is_rejected() {
+        let result = normalize_homeserver_url("ftp://example.com");
+        assert!(matches!(result, Err(HomeserverUrlError::UnsupportedScheme(ref s)) if s == "ftp"));
+    }
+
+    #[test]
+    fn malformed_url_is_rejected() {
+        let result = normalize_homeserver_url("http://  /not a url");
+        assert!(matches!(result, Err(HomeserverUrlError::Invalid)));
+    }
+}
+```
+
+- [ ] **Step 2：跑测试验证**
+
+```bash
+cargo test -p robrix register::validation 2>&1 | tail -20
+```
+
+预期：全部 pass（上面 8 个 test 都应该通过）。如果 fail，检查 `url` crate 的行为是否和我假设一致（有些 trailing slash 处理和版本有关）。
+
+- [ ] **Step 3：commit**
+
+```bash
+git add src/register/validation.rs
+git commit -m "feat(register): homeserver URL normalizer + tests
+
+Accept bare hostname (prepend https://), strip trailing slash,
+reject non-http(s) schemes and empty input. 8 unit tests cover
+the edge cases."
+```
+
+---
+
+## Task 3: `RegisterAction` + `HsCapabilities` 数据类型
+
+**Files:**
+- Modify: `src/register/mod.rs`
+
+- [ ] **Step 1：在 `src/register/mod.rs` 追加数据类型**
+
+在 `pub fn script_mod(...)` 下方追加：
+
+```rust
+use matrix_sdk::ruma::api::client::uiaa::UiaaInfo;
+use makepad_widgets::DefaultNone;
+
+/// Homeserver capabilities discovered before register branching.
+#[derive(Clone, Debug)]
+pub struct HsCapabilities {
+    /// Normalized base URL the client will use.
+    pub base_url: String,
+    /// True iff the server advertises `m.authentication.issuer` in
+    /// `.well-known/matrix/client` (MSC2965 / MAS delegation).
+    pub is_mas_native_oidc: bool,
+    /// True iff `POST /_matrix/client/v3/register` with empty body returns
+    /// 401 with parseable UIAA flows (NOT 403 M_FORBIDDEN).
+    pub registration_enabled: bool,
+    /// Optional UIAA probe result (empty when server requires MAS).
+    pub uiaa_probe: Option<UiaaInfo>,
+    /// Identity providers harvested from `/_matrix/client/v3/login`.
+    /// Phase 1 populates but does not render; Phase 4 renders buttons.
+    pub sso_providers: Vec<IdentityProviderSummary>,
+}
+
+/// Minimal info per identity provider. Full matrix-sdk type is not
+/// used because we only need name + id at this phase.
+#[derive(Clone, Debug)]
+pub struct IdentityProviderSummary {
+    pub id: String,
+    pub name: String,
+    pub icon_url: Option<String>,
+}
+
+/// Outcome classification of capability discovery.
+///
+/// Derived from `HsCapabilities` by `classify()` below; used for UI display.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RegisterMode {
+    /// Server advertises MAS OAuth; register goes through browser.
+    MasWebOnly,
+    /// Server supports direct UIAA register.
+    Uiaa,
+    /// Server explicitly disallows registration.
+    Disabled,
+}
+
+impl HsCapabilities {
+    /// Produce a human-routable mode. Follows element-web `Registration.tsx`:
+    /// MAS presence wins over UIAA even when both are possible.
+    pub fn mode(&self) -> RegisterMode {
+        if self.is_mas_native_oidc {
+            RegisterMode::MasWebOnly
+        } else if self.registration_enabled {
+            RegisterMode::Uiaa
+        } else {
+            RegisterMode::Disabled
+        }
+    }
+}
+
+/// Actions produced by or consumed by the register feature.
+///
+/// `Cx::post_action(RegisterAction::*)` from any widget; handled by `App` and
+/// by `RegisterScreen`.
+#[derive(Clone, Debug, DefaultNone)]
+pub enum RegisterAction {
+    /// User clicked the back button on RegisterScreen.
+    NavigateToLogin,
+    /// Sliding-sync reports the result of capability discovery.
+    CapabilitiesDiscovered(HsCapabilities),
+    /// Capability discovery failed (network error, bad URL, 5xx).
+    DiscoveryFailed(String),
+    None,
+}
+```
+
+- [ ] **Step 2：验证 `cargo build` 通过**
+
+```bash
+cargo build 2>&1 | tail -15
+```
+
+预期：无 error。`DefaultNone` 来自 `makepad_widgets` — 如果 grep `DefaultNone` 在项目中的用法并对齐（例如 `src/home/` 里常用）。
+
+- [ ] **Step 3：commit**
+
+```bash
+git add src/register/mod.rs
+git commit -m "feat(register): add RegisterAction + HsCapabilities types
+
+Introduce the data model used across Phase 1-5:
+- HsCapabilities with is_mas_native_oidc / registration_enabled /
+  uiaa_probe / sso_providers fields matching the spec
+- RegisterMode enum (MasWebOnly / Uiaa / Disabled) derived via
+  HsCapabilities::mode() — MAS wins over UIAA per element-web rule
+- RegisterAction with NavigateToLogin / CapabilitiesDiscovered /
+  DiscoveryFailed variants for Phase 1 + None default"
+```
+
+---
+
+## Task 4: `LoginAction::NavigateToRegister` 变体 + 入口按钮改派
+
+**Files:**
+- Modify: `src/login/login_screen.rs`（L1223 附近 enum，以及 "Sign up here" 按钮 click handler）
+
+- [ ] **Step 1：在 `LoginAction` enum 追加 `NavigateToRegister` 变体**
+
+定位：`src/login/login_screen.rs:1223`。在 `ShowAddAccountScreen` 之后、`CancelAddAccount` 之前加：
+
+```rust
+    /// User clicked "Sign up here"; the main App should hide the
+    /// login screen and show RegisterScreen.
+    NavigateToRegister,
+```
+
+- [ ] **Step 2：grep 定位 "Sign up here" 按钮的现有 click handler**
+
+```bash
+grep -n "set_signup_mode\|sign up here\|Sign up here" src/login/login_screen.rs | head -10
+```
+
+找到 click 分支。它当前调用 `set_signup_mode(true)`。
+
+- [ ] **Step 3：替换 click handler**
+
+把 `set_signup_mode(true)` 的那一整段 click 分支改成：
+
+```rust
+Cx::post_action(LoginAction::NavigateToRegister);
+```
+
+（保留任何围绕的 `if button_clicked` / `if let Some(...)` 外层结构；只替换函数体。）
+
+> **注意**：本 Task 仅改入口。删除 signup mode 的其它残留在 Task 7 统一做，避免一次改动过大。
+
+- [ ] **Step 4：`cargo build` 不应破坏现有代码**
+
+```bash
+cargo build 2>&1 | tail -15
+```
+
+预期：编译通过。如果出现 "未使用的函数 `set_signup_mode`" warning，Task 7 会删除。
+
+- [ ] **Step 5：commit**
+
+```bash
+git add src/login/login_screen.rs
+git commit -m "feat(login): dispatch NavigateToRegister for Sign Up click
+
+Add LoginAction::NavigateToRegister variant. Replace
+set_signup_mode(true) call with Cx::post_action dispatch so
+the main App can route to the new RegisterScreen.
+
+The signup-mode rendering code is removed in a later task."
+```
+
+---
+
+## Task 5: `RegisterScreen` widget 完整 DSL + handle_event
+
+**Files:**
+- Modify: `src/register/register_screen.rs`（替换 Task 1 的 stub）
+
+- [ ] **Step 1：参考 `login_screen.rs` 的 DSL 结构和命名习惯**
+
+```bash
+head -200 src/login/login_screen.rs | grep -E "script_mod|:= |widget|View" | head -20
+```
+
+留意项目常见模式：`View { width: Fill, ... }`、命名子 widget 用 `:= {{Type}}`、事件用 `click` action。
+
+- [ ] **Step 2：替换 `src/register/register_screen.rs` 完整内容**
+
+```rust
+//! RegisterScreen widget: homeserver picker + capability display.
+//!
+//! Phase 1 renders:
+//!   - Back button (returns to login)
+//!   - Screen title
+//!   - Homeserver URL input
+//!   - Next button (triggers capability discovery)
+//!   - Three-state status area (MAS / UIAA / Disabled / errors)
+//!
+//! Phases 2-5 fill in OIDC launch / UIAA form / SSO buttons.
+
+use makepad_widgets::*;
+use crate::register::{RegisterAction, RegisterMode};
+use crate::register::validation::{normalize_homeserver_url, HomeserverUrlError};
+use crate::sliding_sync::{submit_async_request, MatrixRequest};
+
+script_mod! {
+    use makepad_widgets::base::*;
+    use makepad_widgets::theme_desktop_dark::*;
+
+    pub RegisterScreen := {{RegisterScreen}} View {
+        width: Fill,
+        height: Fill,
+        flow: Flow.Down,
+        padding: Inset { top: 24., right: 32., bottom: 24., left: 32. },
+        spacing: 16.,
+        show_bg: true,
+        draw_bg: { color: #x1F2124 }
+
+        back_button := <Button> {
+            width: Fit, height: Fit,
+            text: "← Back to Login",
+            draw_text: { color: #xAAB2BE }
+        }
+
+        title := <Label> {
+            width: Fit, height: Fit,
+            draw_text: {
+                color: #xF1F2F3,
+                text_style: { font_size: 22. }
+            },
+            text: "Create Account"
+        }
+
+        homeserver_row := <View> {
+            width: Fill, height: Fit,
+            flow: Flow.Down, spacing: 4.,
+
+            <Label> {
+                text: "Homeserver URL",
+                draw_text: { color: #xAAB2BE, text_style: { font_size: 12. } }
+            }
+
+            homeserver_input := <TextInput> {
+                width: Fill, height: 40.,
+                empty_message: "matrix.org",
+            }
+        }
+
+        next_button := <Button> {
+            width: Fit, height: Fit,
+            text: "Next",
+        }
+
+        status_area := <View> {
+            width: Fill, height: Fit,
+            flow: Flow.Down, spacing: 8.,
+            visible: false,
+
+            status_label := <Label> {
+                width: Fill, height: Fit,
+                draw_text: {
+                    color: #xE0E3E8,
+                    text_style: { font_size: 14. }
+                },
+                text: ""
+            }
+        }
+    }
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct RegisterScreen {
+    #[deref] view: View,
+
+    /// Cached capabilities from last successful discovery; None before first probe.
+    #[rust] last_discovery: Option<crate::register::HsCapabilities>,
+}
+
+impl Widget for RegisterScreen {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.handle_actions(cx, event);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl RegisterScreen {
+    fn handle_actions(&mut self, cx: &mut Cx, event: &Event) {
+        let actions = event.actions();
+        let back = self.view.button(ids!(back_button));
+        let next = self.view.button(ids!(next_button));
+
+        if back.clicked(&actions) {
+            Cx::post_action(RegisterAction::NavigateToLogin);
+            return;
+        }
+
+        if next.clicked(&actions) {
+            let raw = self.view.text_input(ids!(homeserver_input)).text();
+            match normalize_homeserver_url(&raw) {
+                Ok(url) => {
+                    self.show_status(cx, "Checking server capabilities...");
+                    submit_async_request(MatrixRequest::DiscoverHomeserverCapabilities {
+                        url: url.as_str().to_string(),
+                    });
+                }
+                Err(HomeserverUrlError::Empty) => {
+                    self.show_status(cx, "Please enter a homeserver URL (e.g. matrix.org).");
+                }
+                Err(HomeserverUrlError::UnsupportedScheme(s)) => {
+                    self.show_status(cx, &format!("Unsupported scheme: {s}. Only http(s) is allowed."));
+                }
+                Err(HomeserverUrlError::Invalid) => {
+                    self.show_status(cx, "That URL looks invalid. Please check and try again.");
+                }
+            }
+        }
+
+        // Capability discovery results from sliding_sync.
+        for action in actions {
+            match action.cast() {
+                RegisterAction::CapabilitiesDiscovered(caps) => {
+                    let msg = match caps.mode() {
+                        RegisterMode::MasWebOnly => {
+                            "This server uses browser-based registration (MAS OAuth). Phase 2 will handle this."
+                        }
+                        RegisterMode::Uiaa => {
+                            "This server allows direct account creation. Phase 3 will handle the form."
+                        }
+                        RegisterMode::Disabled => {
+                            "This server does not allow registration. Please choose a different homeserver or sign in with an existing account."
+                        }
+                    };
+                    self.show_status(cx, msg);
+                    self.last_discovery = Some(caps);
+                }
+                RegisterAction::DiscoveryFailed(err) => {
+                    self.show_status(cx, &format!("Could not reach that server: {err}"));
+                    self.last_discovery = None;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn show_status(&mut self, cx: &mut Cx, message: &str) {
+        self.view.view(ids!(status_area)).set_visible(cx, true);
+        self.view.label(ids!(status_label)).set_text(cx, message);
+        self.view.redraw(cx);
+    }
+}
+```
+
+> **执行者注意**：`submit_async_request`、`MatrixRequest::DiscoverHomeserverCapabilities` 此时尚未定义（在 Task 6 加）。本 Task 代码会 `cargo build` **失败**——这是预期的。下一步验证编译失败点和预期消息对得上，然后继续 Task 6。
+
+- [ ] **Step 3：验证 cargo build 的错误是"预期的"**
+
+```bash
+cargo build 2>&1 | grep -E "error\[|no variant|no function" | head -10
+```
+
+预期 error：`no variant named \`DiscoverHomeserverCapabilities\` found for enum \`MatrixRequest\``。 这条 error 确认 RegisterScreen 代码已经接入了请求调度系统；Task 6 补齐 MatrixRequest 即可消除。
+
+> **不 commit，本 Task 的 commit 和 Task 6 合并。**
+
+---
+
+## Task 6: `MatrixRequest::DiscoverHomeserverCapabilities` + handler
+
+**Files:**
+- Modify: `src/sliding_sync.rs`（L695 enum + worker loop match arm）
+
+- [ ] **Step 1：`MatrixRequest` enum 追加变体**
+
+定位 `src/sliding_sync.rs:695`。在 `MatrixRequest::Login(LoginRequest)` 之前（或之后，保持枚举可读）加：
+
+```rust
+    /// Request to probe a homeserver's registration capabilities.
+    /// Sent from RegisterScreen's Next button; result arrives as
+    /// `RegisterAction::CapabilitiesDiscovered` or `DiscoveryFailed`.
+    DiscoverHomeserverCapabilities {
+        /// Already-normalized homeserver URL (has scheme).
+        url: String,
+    },
+```
+
+- [ ] **Step 2：在 worker loop 的 match 里加新分支**
+
+定位 `src/sliding_sync.rs:1288`（`match request { ... MatrixRequest::Login(login_request) => { ... } ...`）。在该 match 的**末尾**（`}` 前）加：
+
+```rust
+            MatrixRequest::DiscoverHomeserverCapabilities { url } => {
+                tokio::spawn(async move {
+                    use crate::register::{RegisterAction, HsCapabilities, IdentityProviderSummary};
+
+                    match discover_homeserver_capabilities(&url).await {
+                        Ok(caps) => {
+                            Cx::post_action(RegisterAction::CapabilitiesDiscovered(caps));
+                        }
+                        Err(e) => {
+                            Cx::post_action(RegisterAction::DiscoveryFailed(e.to_string()));
+                        }
+                    }
+                });
+            }
+```
+
+- [ ] **Step 3：在 `sliding_sync.rs` 文件末尾（在 `matrix_worker_task` 函数外）加 helper 函数**
+
+```rust
+/// Probe a homeserver's registration capabilities.
+///
+/// Fetches in order:
+/// 1. GET `.well-known/matrix/client` — discover base_url and MAS issuer
+/// 2. GET `/_matrix/client/versions` — liveness check
+/// 3. GET `/_matrix/client/v3/login` — enumerate top-level flows (SSO providers)
+/// 4. POST `/_matrix/client/v3/register` with empty body — harvest UIAA flows
+///
+/// Each step is lenient: a failure in steps 1-3 falls back to reasonable
+/// defaults; only step 4 error or total network failure bubbles up.
+async fn discover_homeserver_capabilities(
+    raw_url: &str,
+) -> anyhow::Result<crate::register::HsCapabilities> {
+    use crate::register::{HsCapabilities, IdentityProviderSummary};
+    use serde_json::Value;
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    // Step 1: .well-known (lenient — default base_url = raw_url on failure).
+    let wk_url = format!("{raw_url}/.well-known/matrix/client");
+    let (base_url, is_mas) = match http.get(&wk_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: Value = resp.json().await.unwrap_or(Value::Null);
+            let base = body
+                .get("m.homeserver")
+                .and_then(|m| m.get("base_url"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(raw_url)
+                .trim_end_matches('/')
+                .to_string();
+            let mas = body
+                .get("m.authentication")
+                .and_then(|m| m.get("issuer"))
+                .and_then(|v| v.as_str())
+                .is_some();
+            (base, mas)
+        }
+        _ => (raw_url.trim_end_matches('/').to_string(), false),
+    };
+
+    // Step 2: versions (liveness; we only care about 2xx).
+    let versions_url = format!("{base_url}/_matrix/client/versions");
+    http.get(&versions_url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| anyhow::anyhow!("homeserver unreachable: {e}"))?;
+
+    // Step 3: /v3/login — SSO providers (non-fatal on failure).
+    let login_url = format!("{base_url}/_matrix/client/v3/login");
+    let sso_providers = match http.get(&login_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: Value = resp.json().await.unwrap_or(Value::Null);
+            body.get("flows")
+                .and_then(|f| f.as_array())
+                .map(|flows| {
+                    flows
+                        .iter()
+                        .filter(|f| {
+                            f.get("type").and_then(|t| t.as_str()) == Some("m.login.sso")
+                        })
+                        .flat_map(|f| {
+                            f.get("identity_providers")
+                                .and_then(|ip| ip.as_array())
+                                .cloned()
+                                .unwrap_or_default()
+                        })
+                        .filter_map(|p| {
+                            Some(IdentityProviderSummary {
+                                id: p.get("id")?.as_str()?.to_string(),
+                                name: p
+                                    .get("name")
+                                    .and_then(|n| n.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                icon_url: p
+                                    .get("icon")
+                                    .and_then(|v| v.as_str())
+                                    .map(String::from),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    // Step 4: POST /register empty body — harvest UIAA flows.
+    let register_url = format!("{base_url}/_matrix/client/v3/register");
+    let reg_resp = http
+        .post(&register_url)
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = reg_resp.status();
+    let body: Value = reg_resp.json().await.unwrap_or(Value::Null);
+
+    let (registration_enabled, uiaa_probe) = if status == reqwest::StatusCode::UNAUTHORIZED {
+        // Expected UIAA challenge. Parse into ruma UiaaInfo.
+        match serde_json::from_value(body.clone()) {
+            Ok(info) => (true, Some(info)),
+            Err(_) => (true, None), // server returned 401 but odd shape; treat as enabled
+        }
+    } else if status == reqwest::StatusCode::FORBIDDEN
+        && body.get("errcode").and_then(|v| v.as_str()) == Some("M_FORBIDDEN")
+    {
+        (false, None)
+    } else {
+        // Unexpected status — treat cautiously as disabled.
+        (false, None)
+    };
+
+    Ok(HsCapabilities {
+        base_url,
+        is_mas_native_oidc: is_mas,
+        registration_enabled,
+        uiaa_probe,
+        sso_providers,
+    })
+}
+```
+
+> **注意**：`reqwest` 已作为 matrix-sdk 的 transitive dep 存在，但可能没有直接在 `Cargo.toml` 声明。如果 `cargo build` 报 `unresolved import reqwest`，加一行到 `Cargo.toml` `[dependencies]`：`reqwest = { version = "0.12", features = ["json"] }`（检查 matrix-sdk 实际拉取的 reqwest 版本，对齐它）。但**若 CLAUDE.md / project.spec.md 禁止新增 Cargo 依赖**，则改用 matrix-sdk 的 `Client::http_client()` 替代；本 plan 草案假设 reqwest 已可直接用。
+
+- [ ] **Step 4：`cargo build` 通过**
+
+```bash
+cargo build 2>&1 | tail -15
+```
+
+预期：无 error。Task 5 + Task 6 合并编译通过。若 reqwest 需要显式声明，按上条注释处理。
+
+- [ ] **Step 5：commit（Task 5 + Task 6 一起）**
+
+```bash
+git add src/register/register_screen.rs src/sliding_sync.rs
+git commit -m "feat(register): capability discovery + RegisterScreen UI
+
+Implement MatrixRequest::DiscoverHomeserverCapabilities handler
+that probes .well-known, /versions, /v3/login, and empty POST
+/register to build HsCapabilities. Results post back as
+RegisterAction::CapabilitiesDiscovered / DiscoveryFailed.
+
+RegisterScreen widget renders the homeserver input, Next button,
+and three-state status area (MAS / UIAA / Disabled / errors).
+The full wizard body is added in Phase 2+."
+```
+
+---
+
+## Task 7: 删除 `login_screen.rs` 的 signup mode 残留
+
+**Files:**
+- Modify: `src/login/login_screen.rs`（删除约 80 行）
+
+- [ ] **Step 1：定位 signup mode 相关代码段**
+
+```bash
+grep -n "set_signup_mode\|confirm_password\|signup_mode" src/login/login_screen.rs | head -20
+```
+
+常见位置：
+- DSL 里的 `confirm_password_input := <TextInput>` 字段
+- DSL 里的 mode toggle 按钮（形如 `mode_toggle_button`）
+- Rust 侧的 `fn set_signup_mode(&mut self, cx: &mut Cx, is_signup: bool)`
+- `handle_event` 里的 `if button_clicked(mode_toggle_button) { ... }` 分支
+- `handle_event` 里依 signup 模式分支的 submit 逻辑（password vs RegisterAccount）
+
+- [ ] **Step 2：逐段删除**
+
+删掉以下各处（具体行号以 grep 结果为准）：
+
+1. DSL 里 `confirm_password_input` 的定义整块
+2. DSL 里 `mode_toggle_button` 的定义整块
+3. DSL 里任何 `signup_mode_only := <View>` 类包装
+4. Rust 侧 `fn set_signup_mode` 整个函数体
+5. Rust 侧 `handle_event` / `handle_actions` 中触发 signup 提交的 match 分支（形如 `LoginRequest::Register(...)`）——注意保留 **登录** 路径（LoginByPassword）
+6. 结构体字段 `is_signup_mode: bool`（如果有）及其 `#[rust]` 标注
+7. `login_screen.rs` 顶部 import 里用不到的东西（`RegisterAccount` 等）
+
+> **不删** "Sign up here" 按钮本身（Task 4 保留了它；它的 click 已改为 NavigateToRegister）。
+
+- [ ] **Step 3：验证登录路径仍然工作**
+
+```bash
+cargo build 2>&1 | tail -15
+```
+
+预期：无 error。warning 可能提到 `unused import RegisterAccount` 等，把它们也删掉。
+
+- [ ] **Step 4：手工测试 — 运行 robrix2 验证普通密码登录不破**
+
+```bash
+cargo run 2>&1 | tail -30
+```
+
+用已有 Matrix 账号登录，验证：
+- 登录屏正常显示
+- 输入 user_id 和 password 能成功登录
+- SSO 按钮仍能工作
+- 顶端的 "Sign up here" 按钮仍然在原位置，文字和样式未变
+
+- [ ] **Step 5：在本次测试用户确认登录无回归后 commit**
+
+等用户 OK 后：
+
+```bash
+git add src/login/login_screen.rs
+git commit -m "refactor(login): remove signup mode
+
+Delete confirm_password input, mode toggle button, set_signup_mode
+function, and signup-submit branch. The \"Sign up here\" button
+retains its text/position/style; its click now posts
+LoginAction::NavigateToRegister instead.
+
+Registration logic moves wholesale to src/register/ — see
+specs/task-register-flow.spec.md."
+```
+
+---
+
+## Task 8: `App` 导航 — 登录屏 ↔ 注册屏
+
+**Files:**
+- Modify: `src/app.rs`
+
+- [ ] **Step 1：在 app DSL 里加 `RegisterScreen` 子 widget**
+
+```bash
+grep -n "LoginScreen\|login_screen" src/app.rs | head -10
+```
+
+找到 `LoginScreen` widget 在 app DSL 中声明的位置。按同级结构加上：
+
+```makepad
+register_screen = <RegisterScreen> {
+    visible: false,
+}
+```
+
+（放在 `login_screen` 定义之后；同一父 View 内；`visible: false` 作为默认隐藏。）
+
+- [ ] **Step 2：导入 `RegisterScreen` 的 widget 注册**
+
+确认 app.rs 文件顶部有 `use crate::register;` 或类似，使 `script_mod` 能找到 RegisterScreen。如果没有，加一行。
+
+- [ ] **Step 3：在 App 的 `handle_actions` 处理 `LoginAction::NavigateToRegister` 和 `RegisterAction::NavigateToLogin`**
+
+```bash
+grep -n "handle_actions\|handle_event" src/app.rs | head -10
+```
+
+定位到 `MatchEvent` impl 或 `handle_actions` 函数，加：
+
+```rust
+use crate::register::RegisterAction;
+use crate::login::login_screen::LoginAction;
+
+// Inside handle_actions:
+for action in actions {
+    match action.cast() {
+        LoginAction::NavigateToRegister => {
+            self.ui.view(ids!(login_screen)).set_visible(cx, false);
+            self.ui.view(ids!(register_screen)).set_visible(cx, true);
+            self.ui.redraw(cx);
+        }
+        _ => {}
+    }
+    match action.cast() {
+        RegisterAction::NavigateToLogin => {
+            self.ui.view(ids!(register_screen)).set_visible(cx, false);
+            self.ui.view(ids!(login_screen)).set_visible(cx, true);
+            self.ui.redraw(cx);
+        }
+        _ => {}
+    }
+}
+```
+
+> 执行者注意：具体 `ids!(register_screen)` 的嵌套路径取决于 app DSL 结构。如果 app 有中间 View（如 `root_view`），路径要写全。
+
+- [ ] **Step 4：`cargo build` 通过**
+
+```bash
+cargo build 2>&1 | tail -15
+```
+
+- [ ] **Step 5：手工测试 — 验证导航**
+
+```bash
+cargo run 2>&1 | tail -30
+```
+
+验证：
+- 启动 → 登录屏
+- 点 "Sign up here" → 登录屏隐藏，注册屏显示（只有空白框架 + 输入框 + Next 按钮）
+- 点注册屏上的 "← Back to Login" → 注册屏隐藏，登录屏显示
+
+- [ ] **Step 6：用户确认导航功能 OK 后 commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat(app): wire login <-> register navigation
+
+Handle LoginAction::NavigateToRegister and
+RegisterAction::NavigateToLogin to toggle visibility between
+LoginScreen and RegisterScreen. Both screens live under the same
+parent view; default visibility stays on LoginScreen."
+```
+
+---
+
+## Task 9: 端到端手工验证（Phase 1 DoD）
+
+**Files:** 无改动；仅验证 + 最终 commit（若有遗漏）。
+
+- [ ] **Step 1：启动 robrix2**
+
+```bash
+cargo run 2>&1 | tail -30
+```
+
+- [ ] **Step 2：验证场景 A — MAS OAuth 服务器（用你的 alvin.meldry.com）**
+
+- 点 "Sign up here"
+- 在 Homeserver URL 输入 `alvin.meldry.com` （bare hostname）
+- 点 "Next"
+- **预期**：status area 显示 "This server uses browser-based registration (MAS OAuth). Phase 2 will handle this."
+
+- [ ] **Step 3：验证场景 B — matrix.org（也是 MAS）**
+
+- 点 "← Back to Login"
+- 再点 "Sign up here"
+- 输入 `matrix.org`
+- 点 "Next"
+- **预期**：同 alvin.meldry.com，显示 MAS 消息
+
+- [ ] **Step 4：验证场景 C — 不存在的服务器**
+
+- 输入 `this-server-does-not-exist.example`
+- 点 "Next"
+- **预期**：status area 显示 "Could not reach that server: ..." 错误
+
+- [ ] **Step 5：验证场景 D — 非法 URL**
+
+- 输入 `ftp://example.com`
+- 点 "Next"
+- **预期**：status area 显示 "Unsupported scheme: ftp. Only http(s) is allowed."
+
+- [ ] **Step 6：验证场景 E — 空输入**
+
+- 清空输入框
+- 点 "Next"
+- **预期**：status area 显示 "Please enter a homeserver URL (e.g. matrix.org)."
+
+- [ ] **Step 7：回归验证 — 密码登录仍工作**
+
+- 点 "← Back to Login"
+- 用已有账号（user_id + password）登录
+- **预期**：登录成功进入主屏
+
+- [ ] **Step 8：用户 sign off**
+
+所有 6 个场景 + 回归场景都通过后，和用户确认"阶段 1 验收通过"，然后 commit any trailing cleanup：
+
+```bash
+# 如果之前 task 的测试 / lint 遗漏任何 warning：
+cargo build 2>&1 | grep warning | head -10
+# 修掉后：
+git status
+git add <...>
+git commit -m "chore(register): post-review cleanup for Phase 1"
+# 如果无需 cleanup，跳过该 commit。
+```
+
+- [ ] **Step 9：运行 agent-spec verify 对齐 spec 的阶段 1 场景**
+
+```bash
+agent-spec explain specs/task-register-flow.spec.md --scenario "[Phase 1]" 2>&1 | head -20
+```
+
+对照 spec 的 3 个 Phase 1 场景（`manual_test_phase1_hs_discovery`、`manual_test_phase1_registration_disabled`、`manual_test_signup_entry_button_layout`）逐条核对。
+
+---
+
+## Self-Review
+
+### Spec coverage（对照 `specs/task-register-flow.spec.md`）
+
+| Spec 要素 | 对应 Task |
+|---|---|
+| 创建 `src/register/mod.rs` | Task 1 + Task 3 |
+| 创建 `src/register/register_screen.rs` | Task 1 + Task 5 |
+| 创建 `src/register/register_status_modal.rs` | Task 1（scaffold 已创建，Phase 2 再填 body） |
+| 创建 `src/register/validation.rs` | Task 2 |
+| `src/register/oidc.rs` / `src/register/uiaa.rs` | ❌ 阶段 2/3，不在本 plan |
+| `src/lib.rs` 加 `pub mod register;` | Task 1 |
+| `src/app.rs` 处理 NavigateToRegister / NavigateToLogin | Task 8 |
+| `src/login/login_screen.rs` 删 signup mode + 改 click | Task 4（click） + Task 7（删除残留） |
+| `MatrixRequest::DiscoverHomeserverCapabilities` + handler | Task 6 |
+| Scenario `manual_test_signup_entry_button_layout` | Task 4 + Task 9 Step 7 |
+| Scenario `manual_test_phase1_hs_discovery` | Task 6 + Task 9 Step 2-3 |
+| Scenario `manual_test_phase1_registration_disabled` | Task 6 + Task 9 Step 4 |
+
+### Placeholder scan
+
+无 TBD / TODO-without-code / "类似 Task N" — 每条 step 都带可执行命令或可粘代码。reqwest dep 的注释是条件分支（如果需要就加，不需要就跳），不是 placeholder。
+
+### Type consistency
+
+- `RegisterAction::CapabilitiesDiscovered(HsCapabilities)`：Task 3 定义，Task 5 / Task 6 使用 — 签名一致
+- `HsCapabilities::mode() -> RegisterMode`：Task 3 定义，Task 5 `handle_actions` 使用 — 一致
+- `MatrixRequest::DiscoverHomeserverCapabilities { url: String }`：Task 6 定义，Task 5 使用 — 字段名一致
+- `LoginAction::NavigateToRegister`：Task 4 定义，Task 8 app.rs 使用 — 一致
+- `RegisterAction::NavigateToLogin`：Task 3 定义，Task 5 发出，Task 8 接收 — 一致
+
+### 依赖 review
+
+- `zxcvbn`：**阶段 1 不需要**，延迟到阶段 5
+- `reqwest`：本 plan 默认作为 matrix-sdk transitive dep 直接用；若 cargo 抱怨则显式加进 `Cargo.toml`。这个决定需要执行者验证——本 plan 第一次接触 Cargo.toml 新增依赖的风险点
+- 无其它新依赖
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-register-phase-1-skeleton.md`.
+
+**Two execution options:**
+
+**1. Subagent-Driven (recommended)** — 每 Task 派一个 fresh subagent 执行，Task 之间可以 review；适合 9 个原子 Task 按顺序推进
+
+**2. Inline Execution** — 本 session 继续直接执行，每几个 Task 一个 checkpoint 让用户 review；批量更快但 session 可能膨胀
+
+选哪个？

--- a/docs/superpowers/plans/2026-04-21-register-phase-2-mas-browser.md
+++ b/docs/superpowers/plans/2026-04-21-register-phase-2-mas-browser.md
@@ -1,0 +1,331 @@
+# Register Phase 2: MAS Browser-Based Registration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 当 homeserver 是 MAS 类(stable `m.authentication` 或 unstable `org.matrix.msc2965.authentication`),点 Next 之后自动打开系统浏览器到服务器的账户管理页(`account` URL 或 `<issuer>/account/`),用户在网页上完成注册,回 robrix2 用新账号手动登录。
+
+**Architecture:**
+1. `HsCapabilities` 扩展一个 `mas_account_url: Option<String>` 字段,在 Phase 1 已有的 `.well-known` 解析同一处填充,不增加额外 HTTP 往返。
+2. `RegisterScreen` 的 `CapabilitiesDiscovered(caps)` handler 在 `MasWebOnly` 分支里调用 `robius_open::Uri::new(&url).open()`,状态区切换到"浏览器已打开"指引。
+3. 不做 OAuth callback、不做 token exchange、不引入新依赖。Element Desktop 完整 callback 版的实现放在未来的 Phase 2.5(独立 PR)。
+
+**Tech Stack:** Phase 1 全部依赖 + `robius_open`(已在 `src/sliding_sync.rs:2791` / `src/home/room_screen.rs:6758` / `src/settings/settings_screen.rs:774` 多处使用,模式统一:`robius_open::Uri::new(&url).open()` → `Result<(), _>`)。
+
+---
+
+## File Structure
+
+| 文件 | 责任 |
+|---|---|
+| `src/register/mod.rs` | 扩 `HsCapabilities` 字段 |
+| `src/sliding_sync.rs` | `discover_homeserver_capabilities` 内 populate `mas_account_url` |
+| `src/register/register_screen.rs` | `MasWebOnly` 分支从"显示占位文本"改为"启动浏览器 + 新状态文本" |
+
+无新文件、无新 action、无新 MatrixRequest。
+
+---
+
+## Task 1: HsCapabilities 加 mas_account_url 字段
+
+**Files:**
+- Modify: `src/register/mod.rs`
+
+- [ ] **Step 1:struct 加字段**
+
+在 `HsCapabilities` 的字段列表末尾加:
+
+```rust
+/// URL to open in the system browser for MAS registration.
+/// Populated from `.well-known` `m.authentication.account` (or the
+/// unstable variant), with fallback to `<issuer>/account/`. None when
+/// the server is not MAS (non-MasWebOnly modes).
+pub mas_account_url: Option<String>,
+```
+
+放在 `pub sso_providers: Vec<IdentityProviderSummary>,` 之后。
+
+- [ ] **Step 2:确认构造处全部显式填 None**
+
+```bash
+grep -rn "HsCapabilities {" src/
+```
+
+如果有别的地方构造 HsCapabilities struct literal(比如测试),把 `mas_account_url: None` 加上。
+
+- [ ] **Step 3:build 通过**
+
+```bash
+cargo build 2>&1 | tail -10
+```
+
+- [ ] **Step 4:commit**
+
+```bash
+git add src/register/mod.rs
+git commit -m "feat(register): HsCapabilities carries mas_account_url"
+```
+
+---
+
+## Task 2: Discovery 填充 mas_account_url
+
+**Files:**
+- Modify: `src/sliding_sync.rs`
+
+- [ ] **Step 1:定位现有 MAS 检测代码**
+
+```bash
+grep -n "m.authentication\|msc2965" src/sliding_sync.rs
+```
+
+应该在 `discover_homeserver_capabilities` 里找到之前修过的 `["m.authentication", "org.matrix.msc2965.authentication"].iter().any(...)` 循环(位置大约 L6250-L6264 附近,具体行号 grep 为准)。
+
+- [ ] **Step 2:把检测 + URL 提取融合成一次遍历**
+
+当前代码只是 `.is_some()` 布尔判断。改成"找到第一个匹配的 key,同时拿它的 issuer + account":
+
+```rust
+// Replace the existing .any(|key| ...) block with:
+let (is_mas, mas_account_url) = ["m.authentication", "org.matrix.msc2965.authentication"]
+    .iter()
+    .find_map(|key: &&str| {
+        let block = body.get(*key)?;
+        let issuer = block.get("issuer").and_then(|v: &Value| v.as_str())?;
+        // Prefer the explicit `account` field; fall back to <issuer>/account/.
+        let account = block
+            .get("account")
+            .and_then(|v: &Value| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| format!("{}/account/", issuer.trim_end_matches('/')));
+        Some((true, Some(account)))
+    })
+    .unwrap_or((false, None));
+let mas = is_mas;
+```
+
+要点:
+- 用 `find_map` 取第一个匹配到 `issuer` 的 block(稳定 key 优先)。
+- `account` 字段不存在时 fallback `<issuer>/account/`(`trim_end_matches('/')` 防止双斜杠)。
+- 保持变量名 `mas` 与后续代码兼容(`HsCapabilities.is_mas_native_oidc` 仍然用它)。
+
+- [ ] **Step 3:HsCapabilities 构造处把 mas_account_url 写进去**
+
+找到 `Ok(HsCapabilities { ... })` 那块(函数末尾),加一行:
+
+```rust
+Ok(HsCapabilities {
+    base_url,
+    is_mas_native_oidc: is_mas,
+    registration_enabled,
+    uiaa_probe,
+    sso_providers,
+    mas_account_url,     // <- new
+})
+```
+
+- [ ] **Step 4:build 通过**
+
+```bash
+cargo build 2>&1 | tail -10
+```
+
+零新 warning。
+
+- [ ] **Step 5:commit**
+
+```bash
+git add src/sliding_sync.rs
+git commit -m "feat(register): extract mas_account_url from .well-known"
+```
+
+---
+
+## Task 3: RegisterScreen MasWebOnly 分支启动浏览器
+
+**Files:**
+- Modify: `src/register/register_screen.rs`
+
+- [ ] **Step 1:定位现有 MasWebOnly 分支**
+
+```bash
+grep -n "MasWebOnly\|CapabilitiesDiscovered" src/register/register_screen.rs
+```
+
+当前代码形如:
+
+```rust
+RegisterMode::MasWebOnly => "This server uses browser-based registration (MAS OAuth). Phase 2 will handle this.",
+```
+
+是 `match caps.mode() { ... }` 表达式内的一个 arm,返回一个 `&str` 给后面的 `self.show_status(cx, msg)`。
+
+- [ ] **Step 2:把 match 表达式重构为 if-else 式副作用**
+
+因为 MasWebOnly 分支需要从 `caps` 读 URL + 做副作用(打开浏览器),单纯返回 `&str` 不够。改成:
+
+```rust
+match caps.mode() {
+    RegisterMode::MasWebOnly => {
+        match caps.mas_account_url.as_deref() {
+            Some(url) => {
+                match robius_open::Uri::new(url).open() {
+                    Ok(()) => {
+                        self.show_status(
+                            cx,
+                            "Browser opened. Complete registration in your web browser, \
+                             then click ← Back to Login and sign in with your new account.",
+                        );
+                    }
+                    Err(e) => {
+                        log!("robius_open failed for MAS signup url {url}: {e}");
+                        self.show_status(
+                            cx,
+                            &format!(
+                                "Could not open the browser. Please visit this URL manually:\n{url}"
+                            ),
+                        );
+                    }
+                }
+            }
+            None => {
+                // 不应到达:is_mas_native_oidc = true 时 discovery 必定填了 url
+                self.show_status(
+                    cx,
+                    "This server advertises browser-based registration but no signup URL was found.",
+                );
+            }
+        }
+    }
+    RegisterMode::Uiaa => {
+        self.show_status(
+            cx,
+            "This server allows direct account creation. Phase 3 will handle the form.",
+        );
+    }
+    RegisterMode::Disabled => {
+        self.show_status(
+            cx,
+            "This server does not allow registration. Please choose a different homeserver \
+             or sign in with an existing account.",
+        );
+    }
+}
+self.last_discovery = Some(caps.clone());
+```
+
+要点:
+- `log!` 宏来自 `makepad_widgets`,已在其它文件用过;若当前文件没 import,加 `use makepad_widgets::log;` 或用 `makepad_widgets::log!` 完整路径。
+- 错误文案里直接把 URL 给用户(方便复制粘贴),不要截断。
+- `self.last_discovery = Some(caps.clone())` 保留原行为(Phase 4 会用它来渲染 SSO 按钮,此时无影响)。
+
+- [ ] **Step 3:build 通过**
+
+```bash
+cargo build 2>&1 | tail -10
+```
+
+零新 warning。如果 `log!` 或 `robius_open` import 缺失,顶上 import 区加:
+
+```rust
+use makepad_widgets::*;  // 已有,log! 通常透过这个
+// robius_open 已在 matrix-sdk 的 transitive deps 里,不需要新 Cargo.toml
+```
+
+- [ ] **Step 4:cargo run 跑一下(确认 DSL 不炸)**
+
+```bash
+cargo run 2>&1 | head -80
+```
+
+看 register_screen.rs 相关行无 Makepad VM 报错。
+
+- [ ] **Step 5:不要 commit,等 Task 4 用户端到端验证通过再一起 commit**
+
+---
+
+## Task 4: 端到端手工验证
+
+**Files:** 无改动;跑 app。
+
+- [ ] **Step 1:启动 robrix2**
+
+```bash
+cargo run 2>&1 | tail -30
+```
+
+- [ ] **Step 2:场景 A — alvin.meldry.com 完整注册流**
+
+1. 点 "Sign up here"
+2. 输入 `alvin.meldry.com`,点 "Next"
+3. **预期 UI**:状态区显示 *"Browser opened. Complete registration in your web browser, then click ← Back to Login and sign in with your new account."*
+4. **预期浏览器**:系统浏览器自动打开到 `https://auth.alvin.meldry.com/account/`(或 `/register` 从该页进入)
+5. 在浏览器完成注册(随便 user_id + password)
+6. 回 robrix2,点 "← Back to Login"
+7. 用刚注册的账号登录 → 进入主屏
+
+- [ ] **Step 3:场景 B — matrix.org 到达注册页即可**
+
+1. 返回注册屏,输 `matrix.org`,"Next"
+2. **预期**:浏览器打开 `https://account.matrix.org/account/`,状态区显示"Browser opened..."
+3. 注册页可见即可(不需要真注册)
+
+- [ ] **Step 4:场景 C — 回归 Phase 1 的错误路径**
+
+确认 Phase 1 三条错误路径仍然生效:
+- 空输入:*"Please enter a homeserver URL (e.g. matrix.org)."*
+- 非法 scheme `ftp://example.com`:*"Unsupported scheme: ftp. Only http(s) is allowed."*
+- 不存在服务器 `this-server-does-not-exist.example`:*"Could not reach that server: ..."*
+
+- [ ] **Step 5:场景 D — 登录回归**
+
+"← Back to Login" → 用已有账号密码登录 → 进主屏。(Phase 1 已验证过,再确认一次没退化。)
+
+- [ ] **Step 6:用户 sign off + commit Task 3 的改动**
+
+所有场景 OK 后:
+
+```bash
+git add src/register/register_screen.rs
+git commit -m "feat(register): open system browser for MAS signup
+
+When CapabilitiesDiscovered reports MasWebOnly, launch the MAS
+account URL via robius_open so the user can complete registration
+in their browser. After signup the user returns to robrix2 and
+logs in with the new account via the existing password flow.
+This is the simple-version scope: no OAuth callback, no token
+exchange — those are future Phase 2.5 if needed."
+```
+
+- [ ] **Step 7:最终 PR**
+
+Phase 1 + Phase 2 全部落在 `fix/register` 分支,push 并开 PR 打到 main:
+
+```bash
+git push -u origin fix/register
+gh pr create --title "feat(register): align with element-desktop — Phase 1+2" ...
+```
+
+PR 描述对照 Phase 1 + Phase 2 各自的成果。
+
+---
+
+## Self-Review
+
+### 覆盖 spec(`specs/task-register-flow.spec.md`)的 Phase 2 范围?
+
+- ✅ MAS 类服务器发现后自动进入浏览器路径
+- ✅ 不引入 webview 依赖(符合 spec 禁止条款)
+- ✅ 复用 `robius_open`(符合 spec 的 "不增加依赖"条款)
+- ❌ Spec 里 OIDC 一节提到的 `loopback HTTP` / `code 换 token`——这些是 Phase 2.5 的完整 callback 范围,本 plan 显式 scope-out
+- ❌ Spec 里 `oidc.rs` 单独文件——本 plan 不创建,流程足够简单不必新增文件
+
+### 类型一致性
+- `HsCapabilities.mas_account_url: Option<String>` 在 mod.rs 声明、sliding_sync.rs 填充、register_screen.rs 消费,三处类型一致 ✓
+- `robius_open::Uri::new(&str).open() -> Result<(), _>` 使用方式与 `src/sliding_sync.rs:2791` 对齐 ✓
+
+### Placeholder 检查
+无 TBD / TODO / 占位符 ✓
+
+### 遗漏?
+- 没处理用户在浏览器注册期间切换 homeserver 又点 Next 的 race——这是 acceptable 的(每次 Next 都是独立 discovery → 独立 browser open),不需要特殊 state。
+- 没处理用户反复点 Next(会反复开浏览器标签页)——可接受,不值得加 rate-limit。

--- a/specs/task-register-flow.spec.md
+++ b/specs/task-register-flow.spec.md
@@ -1,0 +1,349 @@
+spec: task
+name: "双模账号注册（OIDC + UIAA），对齐 Element Desktop"
+inherits: project
+tags: [feature, register, login, matrix, uiaa, oidc, mas, ui]
+estimate: 5w
+---
+
+## Intent
+
+在 robrix2 中实现完整的 Matrix 账号注册流程，行为上对齐 Element Desktop 1.12.x：当服务器声明支持 MSC3861 / MAS OAuth 时，把注册委托给系统浏览器经 OIDC（使用 matrix-sdk 的 `oidc_auth` API）加 loopback HTTP 回调完成；当服务器只支持传统 Interactive Authentication（UIAA）时，robrix2 在本地渲染一个向导式 wizard 引导用户逐 stage 完成 UIAA，对无法本地渲染的 stage（reCAPTCHA、UIAA 中的 SSO 阶段、未知类型）用 UIAA 规范里的 `fallback/web` URL 作为逃生舱。
+
+目标同时满足两点：代码**功能隔离**——所有注册相关代码放进新的 `src/register/` 目录；用户**习惯兼容**——`login_screen.rs` 的 "Sign up here" 入口按钮文字、位置、样式完全不变。协议行为和 wizard 结构以 element-web 的 `Registration.tsx` + `InteractiveAuthEntryComponents.tsx` 为参考蓝本。
+
+## Constraints
+
+- 双模分路必须由**运行时服务器能力发现**驱动（`.well-known/matrix/client` + `/_matrix/client/versions` + `/_matrix/client/v3/login` + 空 body `POST /register` 探测），禁止对服务器做硬编码判断
+- 禁止在客户端硬编码 identity provider ID：所有 SSO 按钮和 OIDC 端点都来自服务器响应，不得出现像 `"oidc-google"` 这样的客户端字面量
+- 所有新增 Matrix I/O 都走 `submit_async_request(MatrixRequest::*)` — 禁止为注册相关网络调用裸开 `tokio::spawn`
+- UIAA 错误判定必须用 `uiaa_info.auth_error.kind` 的结构化字段来区分"stage 做错了"和"推进下一 stage"，禁止对错误消息做字符串匹配
+- `src/login/login_screen.rs` 的 "Sign up here" 按钮文字、位置、视觉样式保持不变；只改它的点击行为（从原来调用 `set_signup_mode(true)` 改为派发 `LoginAction::NavigateToRegister`）
+- 所有收集用户输入的 UIAA stage widget（协议勾选、注册令牌输入、邮件等待、短信验证码）必须用 Makepad 2.0 `script_mod!` DSL 加 Widget derive 实现
+- UIAA stage 的分派和推进由 UI 层的 `UiaaController` widget 协调，不得把状态机埋进 `sliding_sync.rs`，确保 stage 渲染和等待用户输入都在 UI 层发生
+- OIDC 回调的 loopback 端口必须每次尝试动态分配（不得用固定端口），避免端口冲突并允许用户连续尝试多次注册而无需重启
+- 注册时提交的设备名默认为 `"Robrix2 on {OS}"`，其中 `{OS}` 来自 `std::env::consts::OS`，后续用户可在设置里改名
+- 批准新增一项依赖：`zxcvbn`（v3.x 系列），用于密码强度估算；此处的批准记录即为正式批准，不再需要单独改 `project.spec.md`
+- 除 `zxcvbn` 外不增加任何新依赖；系统浏览器调用复用 `sliding_sync.rs` 已引入的 `robius_open` crate
+- 本 spec 不包含任何移动端深链（如 `robrix://callback`）URL scheme 注册；loopback HTTP 足以覆盖本 spec 所限定的桌面端目标
+- 注册完成后必须走已有的自动登录 / `finalize_authenticated_client` / 会话持久化路径 — 禁止为注册成功另开一条鉴权落地代码路径
+
+## Decisions
+
+### 范围与对齐对象
+
+- 目标：对齐 Element Desktop 1.12.x 的完整行为，实现方式是**双模**客户端 — 既不是单模全原生，也不是单模全浏览器
+- 参考物：element-web 的 `Registration.tsx` / `RegistrationForm.tsx` / `InteractiveAuthEntryComponents.tsx`（协议与 wizard 结构）；本地安装的 Element Desktop 1.12.15（路径 `/Applications/Element.app/Contents/Resources/webapp.asar`）已实证包含全部 7 种 UIAA auth type 字符串以及 MSC3861 / OIDC 相关字符串
+- 现有 robrix2 的起点：`src/sliding_sync.rs` 第 435–492 行已存在 `LoginRequest::Register` 分支，但只认 `m.login.dummy`，其它 flow 一律 bail；本 spec 用完整的双模分派器替换那段代码
+- 先验参考（不是代码平移来源）：https://github.com/project-robius/robrix/pull/579 — 借鉴 `RegisterScreen` 布局思路和 `RegistrationForm` 字段顺序；**不**沿用 PR #579 里硬编码的 Google-only SSO、min-8 字符密码启发式、以及字符串匹配判 UIAA 错误
+
+### 模块结构
+
+- 新建目录 `src/register/`，且只有 6 个文件：
+  - `mod.rs` — 导出和模块级文档
+  - `register_screen.rs` — 注册主屏：ServerPicker、能力探测、分派到 OIDC 或 UIAA 分支
+  - `oidc.rs` — OIDC / MAS OAuth 分支：loopback HTTP、通过 `robius_open` 打开浏览器、回调处理、code 换 token
+  - `uiaa.rs` — UIAA 分支：`UiaaController` + 6 个 stage widget（`DummyStage` / `TermsStage` / `RegistrationTokenStage` / `EmailStage` / `MsisdnStage` / `FallbackStage`）
+  - `register_status_modal.rs` — 进度模态，两个分支共用
+  - `validation.rs` — localpart 校验器、URL 校验器、zxcvbn 包装
+- `src/lib.rs` 追加 `pub mod register;`
+- `src/app.rs` 新增对 `LoginAction::NavigateToRegister` 和 `RegisterAction::*` 的分派以完成屏幕切换
+- `src/login/login_screen.rs` 删除 signup-mode 分支（confirm_password 字段渲染、`set_signup_mode` 函数、Sign Up 按钮内部的注册提交逻辑，共约 80 行），并把 "Sign up here" 按钮的 click 改为派发 `LoginAction::NavigateToRegister`；按钮文字、位置、样式保持不变
+- `src/sliding_sync.rs` 新增 `MatrixRequest` 变体：`DiscoverHomeserverCapabilities`、`RegisterViaOidc`、`RegisterViaUiaa`、`ContinueUiaa`、`RequestRegisterEmailToken`、`RequestRegisterMsisdnToken`、`CheckUsernameAvailable`；删除旧的 `LoginRequest::Register` 分支
+
+### 服务器能力发现（两分支共用前置）
+
+- 进入 `RegisterScreen` 并在用户确认 homeserver URL 后派发 `DiscoverHomeserverCapabilities`：
+  - GET `/.well-known/matrix/client`（宽松模式：失败时回退到用户输入的原始 URL，对齐 Element 的 AutoDiscoveryUtils）
+  - GET `/_matrix/client/versions`（存活性检查 + feature flag）
+  - GET `/_matrix/client/v3/login`（枚举顶层 flow：`m.login.password`、`m.login.sso` 带 identity_providers 等）
+  - POST `/_matrix/client/v3/register` 空 body（预期 401 → 解析 UIAA `flows` 和 `params`；若返回 403 `M_FORBIDDEN` 则表示服务器禁用注册）
+  - 检查 `unstable_features["org.matrix.msc3861"]` 和/或 `/auth_issuer` OIDC 发现端点来判定 MAS 支持
+- 返回 `HsCapabilities { is_mas_native_oidc: bool, registration_enabled: bool, sso_providers: Vec<IdentityProvider>, uiaa_probe: Option<UiaaInfo> }`
+- `RegisterScreen` 按 `is_mas_native_oidc` 分派：
+  - `true` → 渲染 OIDC 卡片，显示 "Continue in browser" 按钮
+  - `false && registration_enabled` → 渲染 `RegistrationForm`（走 UIAA 分支）
+  - `false && !registration_enabled` → 渲染 "This server doesn't allow registration" 和 "Log in instead" 按钮
+
+### OIDC / MAS 分支（`src/register/oidc.rs`）
+
+- 使用 matrix-sdk 的 OIDC API：`client.matrix_auth_oidc().url_for_oidc_login(OidcRegistrationData)`
+- 打开浏览器**之前**先在 `http://localhost:<动态端口>/callback` 启一个短生命周期的 loopback HTTP server
+- 用 `robius_open::Uri::new(&authorization_url).open()` 启动系统浏览器（沿用 `src/sliding_sync.rs:5969` 处已有的用法）
+- 处理 loopback 回调：解析 `code` 和 `state`，对比出站 `state` 参数校验，再通过 matrix-sdk 把 code 换成 tokens
+- 用户侧 UX：进度模态文案从 "Opening browser…" 切到 "Waiting for completion…"，带一个可见的 Cancel 按钮（点击关掉 loopback 并返回 RegisterScreen）
+- 取消逻辑：关闭 loopback server，关闭模态，恢复 "Continue in browser" 按钮可用
+- 超时（默认 5 分钟，未来可配置）：在超时后报错文案 inline 显示并返回 RegisterScreen
+- 成功：派发 `RegisterAction::OidcSuccess(Client)` → `finalize_authenticated_client()` → `LoginAction::LoginSuccess`
+- 对**非 MAS 但 `/v3/login` 公布了 `m.login.sso`** 的服务器：顶层 SSO 登录沿用 `src/sliding_sync.rs` 已有的 `SpawnSSOServer` 机制（不重复实现）；注册侧 SSO 使用同一机制，只是语义上带 registration intent
+
+### UIAA 分支（`src/register/uiaa.rs`）
+
+- `RegistrationForm` 结构体一次性采集：username、password、confirm_password、可选 email、可选带区号 phone、可选 registration_token、device_name 默认
+- email 和 phone 字段是否显示由 `uiaa_probe.flows` 决定：只要**任一** flow 要 `m.login.email.identity` 或 `m.login.msisdn`，就显示对应字段并标必填（与 Element 规则一致）
+- SSO 按钮（由 `/v3/login` 发现）显示在密码表单旁；点击走已有的 `SpawnSSOServer` 路径
+- 点击 Submit 时，`RegistrationForm` 依次执行：
+  - 客户端校验：username 非空且满足 localpart 正则、password 长度 ≥1 且 zxcvbn 分数 ≥3、confirm_password 与 password 一致、email（若填了）格式合法、phone（若填了）格式合法
+  - 异步查重：username 失焦或输入暂停 500ms 后派发 `CheckUsernameAvailable`，调 `GET /_matrix/client/v3/register/available?username=<value>`，UI 渲染 available / taken / invalid / checking
+  - 派发 `RegisterViaUiaa(RegistrationForm)`；sliding_sync 侧发出第一次真正的 `/register`，`initial_device_display_name` 已设置
+- UIAA 循环：
+  - 返回 200 → 成功，拿到 `access_token`，走 `finalize_authenticated_client()`
+  - 返回 401 且带 `auth_error` → 当前 stage 被拒，在 stage widget 上 inline 显示错误，`stage_index` 不动
+  - 返回 401 不带 `auth_error` → 正常推进，根据选定的 flow 取下一个 stage，渲染对应 widget
+- Flow 选择（首次 UIAA 进入时、渲染第一个 stage widget 之前）：
+  - 对每个候选 flow 打分：本地可渲染的 stage 加分；要 fallback URL 的 stage 减分；要 3pid 但用户未填对应字段的减分
+  - 选分数最高的；同分选 stage 数最少的
+- Stage widget（每个 ≤150 行，全部放在同一个 `uiaa.rs` 文件里）：
+  - `DummyStage` — 无 UI，自动提交 `AuthData::Dummy { session }`
+  - `TermsStage` — 每条 `params.policies` 一个勾选框（策略名是可点击链接，点开后用 `robius_open` 打开策略 URL）；Continue 按钮在全部勾完后才可用
+  - `RegistrationTokenStage` — 单行文本输入；提交时派发 `AuthData::RegistrationToken { session, token }`
+  - `EmailStage` — 进入时用表单里已采集的 email 调 `RequestRegisterEmailToken` 拿 `sid`；显示 "Verification email sent to {email}" + Continue 按钮；点 Continue 重新 POST `/register`，`auth.threepid_creds = {sid, client_secret}`；不做轮询
+  - `MsisdnStage` — 进入时用表单里的 phone 调 `RequestRegisterMsisdnToken`；显示短信验证码输入框；提交派发 `AuthData::Msisdn { session, threepid_creds }`
+  - `FallbackStage` — 兜底 `m.login.recaptcha`、`m.login.sso`（UIA 阶段中的 SSO）、所有未识别类型：通过 `robius_open` 打开 `GET {homeserver}/_matrix/client/v3/auth/{stage_type}/fallback/web?session={session}`；显示 "Complete verification in browser, then click Continue"；Continue 重新 POST `/register`，body 不变、session 不变、不带新 auth 字段
+
+### 错误处理
+
+- 统一 `RegisterError` 枚举，11 个变体：`UserInUse`、`InvalidUsername`、`WeakPassword`、`ThreepidInUse`、`Forbidden`、`RateLimited`、`MasNotAvailable`、`OidcCallbackTimeout`、`NetworkError`、`UnsupportedFallback`、`Other(String)`
+- Matrix `ErrorKind` 到 `RegisterError` 的映射放在 `uiaa.rs::map_matrix_error()` 里，使用结构化字段（禁止字符串匹配）
+- 屏幕级错误（HS 不可达、不允许注册）inline 显示在 RegisterScreen 顶部
+- Stage 级错误（token 无效、3pid 已占用）inline 显示在当前 stage widget 上；已输入的字段值保持不变
+
+### 用户名查重
+
+- Debounce：输入框失焦或输入暂停 500ms 后触发
+- 端点：`GET /_matrix/client/v3/register/available?username=<value>`
+- UI 状态：`Idle`、`Checking`、`Available`、`Taken`、`Invalid`、`NetworkError`
+- 视觉：用户名输入框旁边显示小图标加文字状态
+
+### 密码强度
+
+- 使用 `zxcvbn` crate v3.x（新依赖，本 spec 批准）
+- 输入变化时计算得分（debounce 150ms）
+- UI：0-4 分强度条；0-2 分时显示本地化提示
+- 得分 <3 禁用 Submit 按钮（对齐 Element 的 `PASSWORD_MIN_SCORE`）
+- 仅作用于 UIAA 分支 — OIDC 分支的密码在 MAS 网页里输入，不归 robrix2 管
+
+### 注册成功后（两分支共用）
+
+- 两条分支都以 `finalize_authenticated_client(client, client_session, &user_id, /* is_add_account */ false)` 收尾；该函数已有，复用不改
+- 不提供注册时手填设备名 UI；名字以 `"Robrix2 on {OS}"` 预填，用户可在 Settings 里改名
+- 本 spec 不包含 E2EE 密钥备份 UI（归属 `src/verification/` 的独立关注点）
+
+### 分阶段实施（spec 本身是完整且单一的；实现分 5 个 PR 落地）
+
+- **阶段 1 — 骨架 + 能力发现**：建 `src/register/` 目录；`RegisterScreen` 带 ServerPicker；`DiscoverHomeserverCapabilities` 实现；`login_screen.rs` 删 signup mode；`NavigateToRegister` 连线。可感知价值：用户能选 HS 并看到 "MAS / UIAA / 禁用"
+- **阶段 2 — OIDC 分支**：`oidc.rs` 完整（loopback + 浏览器 + 回调 → token）。可感知价值：matrix.org 新用户能完成注册
+- **阶段 3 — UIAA 核心 + 本地 stage**：`uiaa.rs` 加 `UiaaController`、`DummyStage`、`TermsStage`、`RegistrationTokenStage`；密码 + confirm 输入。可感知价值：Palpo / 简单自建 Synapse 能密码注册
+- **阶段 4 — 3pid + fallback**：`EmailStage`、`MsisdnStage`、`FallbackStage`；多 provider SSO 按钮从 `/v3/login` 动态渲染。可感知价值：覆盖完整 Synapse 部署
+- **阶段 5 — 打磨**：zxcvbn 强度条、用户名实时查重、错误文案 i18n、设备名 OS 检测、UI 细节。可感知价值：Element Desktop 级观感
+
+只有阶段 1 的 plan 会和本 spec 一起交付；阶段 2-5 的 plan 在前序阶段合并后再各自撰写。
+
+## Boundaries
+
+### Allowed Changes
+
+- 创建：`src/register/mod.rs`、`src/register/register_screen.rs`、`src/register/oidc.rs`、`src/register/uiaa.rs`、`src/register/register_status_modal.rs`、`src/register/validation.rs`
+- 修改：`src/lib.rs`（追加 `pub mod register;`）
+- 修改：`src/app.rs`（派发 `LoginAction::NavigateToRegister` 和 `RegisterAction::*` 来完成屏幕切换与 finalize 调用）
+- 修改：`src/login/login_screen.rs`（删除 signup-mode 渲染和处理代码约 80 行；把 "Sign up here" 点击改为派发 `LoginAction::NavigateToRegister`；按钮文字/位置/样式保持不变）
+- 修改：`src/sliding_sync.rs`（新增能力发现、OIDC 注册、UIAA 注册、stage 推进、3pid token 请求、用户名查重等 `MatrixRequest::*` 变体；删除旧的 `LoginRequest::Register` 分支；`finalize_authenticated_client` 复用不改）
+- 修改：`Cargo.toml`（在 `[dependencies]` 下追加 `zxcvbn = "3"`）
+- 修改：i18n 资源文件，新增注册相关文案
+- 修改：`DESIGN.md`（可选，阶段 5 批量更新：在模块组织一节加入 `src/register/`）
+
+### Forbidden
+
+- 除了 `zxcvbn = "3"`，禁止对 `Cargo.toml` 做任何其它依赖变更
+- 禁止修改 `finalize_authenticated_client()` 的签名或它的持久化 / 拉起 sync 行为
+- 禁止在客户端加 SSO identity provider 名（如 `"oidc-google"`）作为常量；provider 全部来自服务器响应
+- 本 spec 内禁止任何深链 URL scheme（如 `robrix://`）或移动端特有回调的实现
+- 禁止对任何文件执行 `cargo fmt`
+- 禁止把 `LoginAction::LoginBySSOSuccess` 复用作注册成功载体；新增 `RegisterAction::OidcSuccess(Client)` 变体
+- 禁止引入任何内嵌 webview 依赖（`wry`、`webview2` 等）；所有需要浏览器的 stage 全部通过 `robius_open` 调起系统浏览器
+- 禁止依赖对 Matrix 错误消息做字符串匹配；UIAA 错误分类必须使用 `auth_error.kind` 结构化字段
+- 禁止以严格模式实现 `.well-known`（即不得强制 DNS 可解或坚持 JSON 合法）；使用 Element 的宽松模式
+- `.well-known` 请求超时不得超过 3 秒，超过后回退到原始 URL（对齐 Element 行为）
+- 禁止为注册引入新的 `cpu_worker::CpuJob` 变体 — 注册 I/O 全是网络，不是 CPU
+- 禁止让用户手动复制粘贴任何回调 code；loopback HTTP server 必须直接接收回调
+
+## Out of Scope
+
+- 移动端（iOS / Android / OpenHarmony）的回调处理和自定义 URL scheme 注册 — 本 spec 只覆盖桌面端 loopback
+- 注册成功后的 E2EE 密钥备份 / 恢复密钥设置 UI
+- 注册后的账号资料编辑（头像、显示名）— 注册成功账号进入主界面后，资料为空，沿用已有 Settings UI
+- 多账号注册（已登录状态下再注册另一个账号）— 本 spec 不覆盖 add-account 注册；只保留 add-account 登录的现有行为
+- 账号找回 / 密码重置 — 独立特性，不属于本 spec
+- Identity Server 绑定 3pid — robrix2 不配置 identity server，完全依赖 homeserver 自己的 `register/email/requestToken` 和 `register/msisdn/requestToken` 端点
+- reCAPTCHA 原生渲染 — 明确委托给系统浏览器经 fallback URL，永远不原生实现
+- 注册漏斗的 telemetry / 分析
+- Wizard 布局的 A/B 测试
+- `login_screen.rs` 的 signup-mode 被**删除**，不保留为"经典模式"切换
+- 注册时通过表单自定义设备名 — 设备名固定为 `"Robrix2 on {OS}"`，用户后续在 Settings 改名
+
+## Completion Criteria
+
+5 个实施阶段各有可观测里程碑；以下 21 条场景覆盖整个 spec。场景名前带 `[Phase X]` 标签标明所属阶段。
+
+Scenario: 登录屏的入口按钮保持不变
+  Test: manual_test_signup_entry_button_layout
+  Given the user is on the login screen
+  When the user visually inspects the "Sign up here" button
+  Then the button text, position, icon, and style match the current pre-change appearance
+  And clicking it navigates to RegisterScreen (not toggling signup mode on login screen)
+
+Scenario: [Phase 1] RegisterScreen 显示 homeserver 选择并完成能力探测
+  Test: manual_test_phase1_hs_discovery
+  Given the user clicks "Sign up here" on the login screen
+  When the user enters a homeserver URL (or leaves empty for matrix.org default)
+  And clicks Next
+  Then RegisterScreen calls DiscoverHomeserverCapabilities
+  And the screen indicates whether the server uses MAS OAuth, UIAA, or disallows registration
+
+Scenario: [Phase 1] 不允许注册的服务器显示友好错误
+  Test: manual_test_phase1_registration_disabled
+  Given a homeserver that returns M_FORBIDDEN on empty /register probe
+  When the user completes HS discovery
+  Then RegisterScreen shows "This server doesn't allow registration"
+  And a "Log in instead" button returns to login screen
+
+Scenario: [Phase 2] 现代 homeserver 把注册路由到系统浏览器
+  Test: manual_test_phase2_oidc_happy_path
+  Given a homeserver advertising MSC3861 / MAS OAuth (e.g. matrix.org)
+  When the user clicks "Continue in browser"
+  Then robrix2 opens the MAS registration page in the system browser
+  And robrix2 shows a "Waiting for completion" modal with a Cancel button
+  And after the user completes registration in the browser
+  Then the loopback callback fires, access_token is obtained
+  And robrix2 transitions to the main app logged in as the new account
+
+Scenario: [Phase 2] OIDC 取消按钮关闭 loopback server
+  Test: manual_test_phase2_oidc_cancel
+  Level: integration
+  Targets: src/register/oidc.rs cancel path; loopback http server lifecycle
+  Given the "Waiting for completion" modal is visible
+  When the user clicks Cancel
+  Then the loopback HTTP server is shut down
+  And the modal closes
+  And RegisterScreen returns to capability-discovery state
+
+Scenario: [Phase 2] OIDC 超时 inline 报错
+  Test: manual_test_phase2_oidc_timeout
+  Level: integration
+  Targets: src/register/oidc.rs timeout path; callback wait budget
+  Given the OIDC modal has been waiting for 5 minutes without a callback
+  When the timeout elapses
+  Then robrix2 closes the loopback server
+  And shows an error inline: "Browser registration timed out. Please try again."
+
+Scenario: [Phase 3] 传统 homeserver 路由到 UIAA wizard
+  Test: manual_test_phase3_uiaa_entry
+  Given a homeserver that does not advertise MAS but allows password registration
+  When the user completes capability discovery
+  Then RegisterScreen renders RegistrationForm with username, password, confirm_password fields
+  And SSO provider buttons matching /v3/login response (if any)
+
+Scenario: [Phase 3] 仅 dummy 的 flow 无可见 stage UI 即完成
+  Test: manual_test_phase3_dummy_only
+  Given a homeserver whose flows contain just [m.login.dummy]
+  When the user submits valid username and password
+  Then UiaaController auto-submits the dummy stage with the session
+  And registration succeeds without showing any stage widget
+  And the user is logged in
+
+Scenario: [Phase 3] Terms flow 显示协议勾选框
+  Test: manual_test_phase3_terms_stage
+  Given a homeserver flow contains m.login.terms with two policies
+  When the user reaches the terms stage
+  Then a checkbox is rendered per policy
+  And each policy name is a clickable link opening the policy URL in system browser
+  And the Continue button is disabled until all checkboxes are checked
+
+Scenario: [Phase 3] Registration token flow 显示 token 输入
+  Test: manual_test_phase3_token_stage
+  Given a homeserver flow requires m.login.registration_token
+  When the user reaches the token stage
+  Then a text input labeled "Registration token" is rendered
+  And entering an invalid token and submitting shows an inline error without clearing the field
+  And entering a valid token advances to the next stage (or completes)
+
+Scenario: [Phase 4] Email stage 使用表单里预采集的 email
+  Test: manual_test_phase4_email_stage
+  Given a homeserver flow requires m.login.email.identity and the RegistrationForm had email collected upfront
+  When the user reaches the email stage
+  Then robrix2 calls register/email/requestToken with the form email
+  And the stage shows "Verification email sent to {email}. Click the link, then press Continue"
+  And pressing Continue without clicking the email link resubmits /register and shows an inline "Not yet verified" message on 401
+  And pressing Continue after clicking the link advances to the next stage
+
+Scenario: [Phase 4] Msisdn stage 显示短信验证码输入
+  Test: manual_test_phase4_msisdn_stage
+  Given a homeserver flow requires m.login.msisdn and the form had phone collected upfront
+  When the user reaches the msisdn stage
+  Then robrix2 calls register/msisdn/requestToken
+  And the stage shows a text input for the SMS code
+  And entering the wrong code and submitting shows inline error without clearing the field
+  And entering the correct code advances the flow
+
+Scenario: [Phase 4] reCAPTCHA stage 通过系统浏览器走 fallback
+  Test: manual_test_phase4_recaptcha_fallback
+  Given a homeserver flow requires m.login.recaptcha
+  When the user reaches the recaptcha stage
+  Then robrix2 opens {homeserver}/_matrix/client/v3/auth/m.login.recaptcha/fallback/web?session={session} in the system browser
+  And the stage UI shows "Complete verification in your browser, then click Continue"
+  And pressing Continue resubmits /register without a new auth field
+  And a successful fallback advances the flow
+
+Scenario: [Phase 4] 未知 stage 类型走系统浏览器兜底
+  Test: manual_test_phase4_unknown_stage_fallback
+  Given a homeserver flow contains a stage type not in {dummy, terms, token, email, msisdn, recaptcha, sso}
+  When the user reaches the unknown stage
+  Then robrix2 opens the /auth/{type}/fallback/web URL in the system browser
+  And the Continue button works identically to the recaptcha case
+
+Scenario: [Phase 4] 多 provider SSO 按钮从服务器动态渲染
+  Test: manual_test_phase4_multi_provider_sso
+  Given a homeserver's /v3/login response contains 3 identity providers (Google, GitHub, Apple)
+  When the user is on RegisterScreen's form
+  Then 3 SSO buttons render, each with the name from the server response
+  And clicking any button launches the existing SSO flow with the corresponding provider_id
+
+Scenario: [Phase 5] 密码强度条使用 zxcvbn
+  Test: manual_test_phase5_password_strength
+  Given the user types "password" into the password field
+  Then a strength bar shows score ≤2 and a hint like "Too weak: avoid common passwords"
+  And the Submit button is disabled
+  When the user types "correcthorsebatterystaple"
+  Then the strength bar shows score ≥3
+  And the Submit button is enabled
+
+Scenario: [Phase 5] 用户名查重有 debounce
+  Test: manual_test_phase5_username_availability
+  Given the user types "alice" in the username field
+  When 500ms elapses without further typing
+  Then robrix2 calls /register/available
+  And the result (Available / Taken / Invalid) shows next to the field
+  And typing more characters cancels the pending check and schedules a new one after another 500ms
+
+Scenario: [Phase 5] 设备名默认按 OS 填入
+  Test: manual_test_phase5_device_name_default
+  Given registration succeeds via either OIDC or UIAA branch
+  When the account is logged in
+  Then the new device is named "Robrix2 on macos" (or appropriate OS string)
+
+Scenario: 登录屏的密码登录行为不变（回归守卫）
+  Test: manual_test_regression_password_login
+  Given the login screen is shown after the register feature is merged
+  When the user enters existing credentials and clicks Sign In
+  Then password login completes as it did before this spec
+
+Scenario: 已有 SSO 登录流程不变（回归守卫）
+  Test: manual_test_regression_sso_login
+  Given the user is on the login screen
+  When the user clicks any SSO provider button
+  Then the existing SSO login flow runs unchanged (no interference from register code)
+
+Scenario: 注册账号的会话持久化
+  Test: manual_test_session_persistence_after_register
+  Given the user successfully registers via OIDC or UIAA branch
+  When the user closes robrix2 and reopens it
+  Then the user is still logged in as the registered account without needing to sign in again

--- a/src/app.rs
+++ b/src/app.rs
@@ -1667,6 +1667,7 @@ impl AppMain for App {
         crate::profile::script_mod(vm);
         crate::home::script_mod(vm);
         crate::login::script_mod(vm);
+        crate::register::script_mod(vm);
         crate::logout::script_mod(vm);
 
         self::script_mod(vm)

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::{
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt, mark_invite_modal_closed}, invite_screen::{InviteScreenWidgetRefExt, LeaveRoomResultAction}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, RoomScreenWidgetRefExt, TimelineUpdate, clear_timeline_states}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, space_lobby::SpaceLobbyScreenWidgetRefExt, spaces_bar::SpacesBarRef
     }, i18n::{AppLanguage, tr_fmt, tr_key}, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
-    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::{user_profile::UserProfile, user_profile_cache::clear_user_profile_cache}, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, file_upload_modal::{FilePreviewerAction, FileUploadModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}, room_filter_input_bar::FilterAction}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, RemoteDirectorySearchKind, RemoteDirectorySearchResult, TimelineKind, AccountSwitchAction, current_user_id, get_client, submit_async_request, get_timeline_update_sender}, updater::{UpdateCheckOutcome, check_for_updates, load_skipped_update_version, save_skipped_update_version, update_release_page_url}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
+    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::{user_profile::UserProfile, user_profile_cache::clear_user_profile_cache}, register::RegisterAction, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, file_upload_modal::{FilePreviewerAction, FileUploadModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}, room_filter_input_bar::FilterAction}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, RemoteDirectorySearchKind, RemoteDirectorySearchResult, TimelineKind, AccountSwitchAction, current_user_id, get_client, submit_async_request, get_timeline_update_sender}, updater::{UpdateCheckOutcome, check_for_updates, load_skipped_update_version, save_skipped_update_version, update_release_page_url}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
     }
@@ -124,6 +124,11 @@ script_mod! {
                         login_screen_view := View {
                             visible: true
                             login_screen := LoginScreen {}
+                        }
+
+                        register_screen_view := View {
+                            visible: false
+                            register_screen := RegisterScreen {}
                         }
 
                         image_viewer_modal := Modal {
@@ -919,6 +924,20 @@ impl MatchEvent for App {
                     continue;
                 }
                 _ => {}
+            }
+
+            if let Some(LoginAction::NavigateToRegister) = action.downcast_ref() {
+                self.ui.view(cx, ids!(login_screen_view)).set_visible(cx, false);
+                self.ui.view(cx, ids!(register_screen_view)).set_visible(cx, true);
+                self.ui.redraw(cx);
+                continue;
+            }
+
+            if let Some(RegisterAction::NavigateToLogin) = action.downcast_ref() {
+                self.ui.view(cx, ids!(register_screen_view)).set_visible(cx, false);
+                self.ui.view(cx, ids!(login_screen_view)).set_visible(cx, true);
+                self.ui.redraw(cx);
+                continue;
             }
 
             if let Some(LoginAction::ShowLoginScreen) = action.downcast_ref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub mod i18n;
 
 /// Login screen
 pub mod login;
+/// Account registration flow
+pub mod register;
 /// Logout confirmation and state management
 pub mod logout;
 /// Core UI content: the main home screen (rooms list), room screen.

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -3,7 +3,7 @@ use std::ops::Not;
 use makepad_widgets::*;
 use url::Url;
 
-use crate::{app::AppState, i18n::{AppLanguage, tr_fmt, tr_key}, sliding_sync::{submit_async_request, AccountSwitchAction, LoginByPassword, LoginRequest, MatrixRequest, RegisterAccount}};
+use crate::{app::AppState, i18n::{AppLanguage, tr_fmt, tr_key}, sliding_sync::{submit_async_request, AccountSwitchAction, LoginByPassword, LoginRequest, MatrixRequest}};
 
 use super::login_status_modal::{LoginStatusModalAction, LoginStatusModalWidgetExt};
 
@@ -162,19 +162,6 @@ script_mod! {
                         }
                     }
 
-                    confirm_password_wrapper := View {
-                        width: 275, height: Fit,
-                        visible: false,
-
-                        confirm_password_input := RobrixTextInput {
-                            width: 275, height: Fit
-                            flow: Right, // do not wrap
-                            padding: 10,
-                            empty_text: "Confirm password"
-                            is_password: true,
-                        }
-                    }
-
                     View {
                         width: 275, height: Fit,
                         flow: Down,
@@ -222,61 +209,54 @@ script_mod! {
                         text: "Login"
                     }
 
-                    login_only_view := View {
-                        width: Fit, height: Fit,
-                        flow: Down,
-                        align: Align{x: 0.5, y: 0.5}
-                        spacing: 15.0
+                    LineH {
+                        width: 275
+                        margin: Inset{bottom: -5}
+                        draw_bg.color: #C8C8C8
+                    }
 
-                        LineH {
-                            width: 275
-                            margin: Inset{bottom: -5}
-                            draw_bg.color: #C8C8C8
+                    sso_prompt_label := Label {
+                        width: Fit, height: Fit
+                        padding: 0,
+                        draw_text +: {
+                            color: (COLOR_TEXT)
+                            text_style: TITLE_TEXT {font_size: 11.0}
                         }
+                        text: "Or, login with an SSO provider:"
+                    }
 
-                        sso_prompt_label := Label {
-                            width: Fit, height: Fit
-                            padding: 0,
-                            draw_text +: {
-                                color: (COLOR_TEXT)
-                                text_style: TITLE_TEXT {font_size: 11.0}
+                    sso_view := View {
+                        width: 275, height: Fit,
+                        margin: Inset{left: 30, right: 5} // make the inner view 240 pixels wide
+                        flow: Flow.Right{wrap: true},
+                        apple_button := mod.widgets.SsoButton {
+                            image := mod.widgets.SsoImage {
+                                src: crate_resource("self://resources/img/apple.png")
                             }
-                            text: "Or, login with an SSO provider:"
                         }
-
-                        sso_view := View {
-                            width: 275, height: Fit,
-                            margin: Inset{left: 30, right: 5} // make the inner view 240 pixels wide
-                            flow: Flow.Right{wrap: true},
-                            apple_button := mod.widgets.SsoButton {
-                                image := mod.widgets.SsoImage {
-                                    src: crate_resource("self://resources/img/apple.png")
-                                }
+                        facebook_button := mod.widgets.SsoButton {
+                            image := mod.widgets.SsoImage {
+                                src: crate_resource("self://resources/img/facebook.png")
                             }
-                            facebook_button := mod.widgets.SsoButton {
-                                image := mod.widgets.SsoImage {
-                                    src: crate_resource("self://resources/img/facebook.png")
-                                }
+                        }
+                        github_button := mod.widgets.SsoButton {
+                            image := mod.widgets.SsoImage {
+                                src: crate_resource("self://resources/img/github.png")
                             }
-                            github_button := mod.widgets.SsoButton {
-                                image := mod.widgets.SsoImage {
-                                    src: crate_resource("self://resources/img/github.png")
-                                }
+                        }
+                        gitlab_button := mod.widgets.SsoButton {
+                            image := mod.widgets.SsoImage {
+                                src: crate_resource("self://resources/img/gitlab.png")
                             }
-                            gitlab_button := mod.widgets.SsoButton {
-                                image := mod.widgets.SsoImage {
-                                    src: crate_resource("self://resources/img/gitlab.png")
-                                }
+                        }
+                        google_button := mod.widgets.SsoButton {
+                            image := mod.widgets.SsoImage {
+                                src: crate_resource("self://resources/img/google.png")
                             }
-                            google_button := mod.widgets.SsoButton {
-                                image := mod.widgets.SsoImage {
-                                    src: crate_resource("self://resources/img/google.png")
-                                }
-                            }
-                            twitter_button := mod.widgets.SsoButton {
-                                image := mod.widgets.SsoImage {
-                                    src: crate_resource("self://resources/img/x.png")
-                                }
+                        }
+                        twitter_button := mod.widgets.SsoButton {
+                            image := mod.widgets.SsoImage {
+                                src: crate_resource("self://resources/img/x.png")
                             }
                         }
                     }
@@ -583,8 +563,6 @@ script_mod! {
 pub struct LoginScreen {
     #[source] source: ScriptObjectRef,
     #[deref] view: View,
-    /// Whether the screen is showing the in-app sign-up flow.
-    #[rust] signup_mode: bool,
     /// Whether the password field is currently showing plaintext.
     #[rust] password_visible: bool,
     /// Boolean to indicate if the SSO login process is still in flight
@@ -637,45 +615,12 @@ impl LoginScreen {
         self.set_sso_pending_state(cx, false);
     }
 
-    fn sync_mode_texts(&mut self, cx: &mut Cx) {
-        self.view.label(cx, ids!(title)).set_text(cx,
-            if self.signup_mode {
-                tr_key(self.app_language, "login.title.create_account")
-            } else {
-                tr_key(self.app_language, "login.title.login_to_robrix")
-            }
-        );
-        self.view.button(cx, ids!(login_button)).set_text(cx,
-            if self.signup_mode {
-                tr_key(self.app_language, "login.button.create_account")
-            } else {
-                tr_key(self.app_language, "login.button.login")
-            }
-        );
-        self.view.label(cx, ids!(account_prompt_label)).set_text(cx,
-            if self.signup_mode {
-                tr_key(self.app_language, "login.account_prompt.already_have")
-            } else {
-                tr_key(self.app_language, "login.account_prompt.no_account")
-            }
-        );
-        self.view.button(cx, ids!(mode_toggle_button)).set_text(cx,
-            if self.signup_mode {
-                tr_key(self.app_language, "login.mode_toggle.back_to_login")
-            } else {
-                tr_key(self.app_language, "login.mode_toggle.sign_up_here")
-            }
-        );
-    }
-
     fn set_app_language(&mut self, cx: &mut Cx, app_language: AppLanguage) {
         self.app_language = app_language;
         self.view.text_input(cx, ids!(user_id_input))
             .set_empty_text(cx, tr_key(self.app_language, "login.input.user_id").to_string());
         self.view.text_input(cx, ids!(password_input))
             .set_empty_text(cx, tr_key(self.app_language, "login.input.password").to_string());
-        self.view.text_input(cx, ids!(confirm_password_input))
-            .set_empty_text(cx, tr_key(self.app_language, "login.input.confirm_password").to_string());
         self.view.text_input(cx, ids!(homeserver_input))
             .set_empty_text(cx, tr_key(self.app_language, "login.input.homeserver").to_string());
         self.view.text_input(cx, ids!(proxy_address_input))
@@ -707,7 +652,12 @@ impl LoginScreen {
         let login_status_modal_inner = self.view.login_status_modal(cx, ids!(login_status_modal_inner));
         login_status_modal_inner.set_title(cx, tr_key(self.app_language, "login_status_modal.title"));
         login_status_modal_inner.button_ref(cx).set_text(cx, tr_key(self.app_language, "login_status_modal.button.cancel"));
-        self.sync_mode_texts(cx);
+        self.view.label(cx, ids!(title))
+            .set_text(cx, tr_key(self.app_language, "login.title.login_to_robrix"));
+        self.view.button(cx, ids!(login_button))
+            .set_text(cx, tr_key(self.app_language, "login.button.login"));
+        self.view.label(cx, ids!(account_prompt_label))
+            .set_text(cx, tr_key(self.app_language, "login.account_prompt.no_account"));
     }
 
     fn set_use_proxy_enabled(&mut self, cx: &mut Cx, enabled: bool) {
@@ -825,18 +775,6 @@ impl LoginScreen {
         Ok(Some(proxy_url))
     }
 
-    fn set_signup_mode(&mut self, cx: &mut Cx, signup_mode: bool) {
-        self.signup_mode = signup_mode;
-        self.view.view(cx, ids!(confirm_password_wrapper)).set_visible(cx, signup_mode);
-        self.view.view(cx, ids!(login_only_view)).set_visible(cx, !signup_mode);
-        self.sync_mode_texts(cx);
-
-        if !signup_mode {
-            self.view.text_input(cx, ids!(confirm_password_input)).set_text(cx, "");
-        }
-
-        self.redraw(cx);
-    }
 }
 
 impl ScriptHook for LoginScreen {
@@ -883,7 +821,6 @@ impl WidgetMatchEvent for LoginScreen {
         let cancel_button = self.view.button(cx, ids!(cancel_button));
         let user_id_input = self.view.text_input(cx, ids!(user_id_input));
         let password_input = self.view.text_input(cx, ids!(password_input));
-        let confirm_password_input = self.view.text_input(cx, ids!(confirm_password_input));
         let homeserver_input = self.view.text_input(cx, ids!(homeserver_input));
 
         let login_status_modal = self.view.modal(cx, ids!(login_status_modal));
@@ -970,12 +907,10 @@ impl WidgetMatchEvent for LoginScreen {
         if login_button.clicked(actions)
             || user_id_input.returned(actions).is_some()
             || password_input.returned(actions).is_some()
-            || (self.signup_mode && confirm_password_input.returned(actions).is_some())
             || homeserver_input.returned(actions).is_some()
         {
             let user_id = user_id_input.text().trim().to_owned();
             let password = password_input.text();
-            let confirm_password = confirm_password_input.text();
             let homeserver = homeserver_input.text().trim().to_owned();
             if user_id.is_empty() {
                 login_status_modal_inner.set_title(cx, tr_key(self.app_language, "login.status.missing_user_id.title"));
@@ -984,10 +919,6 @@ impl WidgetMatchEvent for LoginScreen {
             } else if password.is_empty() {
                 login_status_modal_inner.set_title(cx, tr_key(self.app_language, "login.status.missing_password.title"));
                 login_status_modal_inner.set_status(cx, tr_key(self.app_language, "login.status.missing_password.body"));
-                login_status_modal_inner.button_ref(cx).set_text(cx, tr_key(self.app_language, "login.status.okay"));
-            } else if self.signup_mode && password != confirm_password {
-                login_status_modal_inner.set_title(cx, tr_key(self.app_language, "login.status.password_mismatch.title"));
-                login_status_modal_inner.set_status(cx, tr_key(self.app_language, "login.status.password_mismatch.body"));
                 login_status_modal_inner.button_ref(cx).set_text(cx, tr_key(self.app_language, "login.status.okay"));
             } else {
                 let proxy = match self.build_proxy_url_from_form(cx) {
@@ -1008,36 +939,19 @@ impl WidgetMatchEvent for LoginScreen {
                     warning!("Failed to persist proxy configuration from login screen: {e}");
                 }
                 self.last_failure_message_shown = None;
-                login_status_modal_inner.set_title(cx, if self.signup_mode {
-                    tr_key(self.app_language, "login.status.creating_account.title")
-                } else {
-                    tr_key(self.app_language, "login.status.logging_in.title")
-                });
+                login_status_modal_inner.set_title(cx, tr_key(self.app_language, "login.status.logging_in.title"));
                 login_status_modal_inner.set_status(
                     cx,
-                    if self.signup_mode {
-                        tr_key(self.app_language, "login.status.creating_account.body")
-                    } else {
-                        tr_key(self.app_language, "login.status.logging_in.body")
-                    },
+                    tr_key(self.app_language, "login.status.logging_in.body"),
                 );
                 login_status_modal_inner.button_ref(cx).set_text(cx, tr_key(self.app_language, "login.status.cancel"));
-                submit_async_request(MatrixRequest::Login(if self.signup_mode {
-                    LoginRequest::Register(RegisterAccount {
-                        user_id,
-                        password,
-                        homeserver: homeserver.is_empty().not().then_some(homeserver),
-                        proxy: proxy.clone(),
-                    })
-                } else {
-                    LoginRequest::LoginByPassword(LoginByPassword {
-                        user_id,
-                        password,
-                        homeserver: homeserver.is_empty().not().then_some(homeserver),
-                        proxy: proxy.clone(),
-                        is_add_account: self.adding_account,
-                    })
-                }));
+                submit_async_request(MatrixRequest::Login(LoginRequest::LoginByPassword(LoginByPassword {
+                    user_id,
+                    password,
+                    homeserver: homeserver.is_empty().not().then_some(homeserver),
+                    proxy: proxy.clone(),
+                    is_add_account: self.adding_account,
+                })));
             }
             login_status_modal.open(cx);
             self.redraw(cx);
@@ -1090,11 +1004,9 @@ impl WidgetMatchEvent for LoginScreen {
                     // The main `App` component handles showing the main screen
                     // and hiding the login screen & login status modal.
                     self.last_failure_message_shown = None;
-                    self.set_signup_mode(cx, false);
                     self.adding_account = false;
                     user_id_input.set_text(cx, "");
                     password_input.set_text(cx, "");
-                    confirm_password_input.set_text(cx, "");
                     homeserver_input.set_text(cx, "");
                     // Reset title and buttons in case we were in add-account mode
                     self.view.label(cx, ids!(title)).set_text(cx, tr_key(self.app_language, "login.title.login_to_robrix"));
@@ -1108,11 +1020,7 @@ impl WidgetMatchEvent for LoginScreen {
                         continue;
                     }
                     self.last_failure_message_shown = Some(error.clone());
-                    login_status_modal_inner.set_title(cx, if self.signup_mode {
-                        tr_key(self.app_language, "login.status.account_creation_failed")
-                    } else {
-                        tr_key(self.app_language, "login.status.login_failed")
-                    });
+                    login_status_modal_inner.set_title(cx, tr_key(self.app_language, "login.status.login_failed"));
                     login_status_modal_inner.set_status(cx, error);
                     let login_status_modal_button = login_status_modal_inner.button_ref(cx);
                     login_status_modal_button.set_text(cx, tr_key(self.app_language, "login.status.okay"));

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -964,7 +964,7 @@ impl WidgetMatchEvent for LoginScreen {
         }
 
         if mode_toggle_button.clicked(actions) {
-            self.set_signup_mode(cx, !self.signup_mode);
+            Cx::post_action(LoginAction::NavigateToRegister);
         }
 
         if login_button.clicked(actions)
@@ -1257,6 +1257,9 @@ pub enum LoginAction {
     /// Request to show the login screen in "add account" mode.
     /// This is used when the user wants to add another Matrix account.
     ShowAddAccountScreen,
+    /// User clicked "Sign up here"; the main App should hide the
+    /// login screen and show RegisterScreen.
+    NavigateToRegister,
     /// Request to cancel adding an account and return to the previous screen.
     CancelAddAccount,
     #[default]

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -33,6 +33,12 @@ pub struct HsCapabilities {
     /// Identity providers harvested from `/_matrix/client/v3/login`.
     /// Phase 1 populates but does not render; Phase 4 renders buttons.
     pub sso_providers: Vec<IdentityProviderSummary>,
+
+    /// URL to open in the system browser for MAS registration.
+    /// Populated from `.well-known` `m.authentication.account` (or the
+    /// unstable MSC2965 variant), with fallback to `<issuer>/account/`.
+    /// None when the server is not MAS (non-MasWebOnly modes).
+    pub mas_account_url: Option<String>,
 }
 
 /// Minimal info per identity provider. Full matrix-sdk type is not

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -34,11 +34,14 @@ pub struct HsCapabilities {
     /// Phase 1 populates but does not render; Phase 4 renders buttons.
     pub sso_providers: Vec<IdentityProviderSummary>,
 
-    /// URL to open in the system browser for MAS registration.
-    /// Populated from `.well-known` `m.authentication.account` (or the
-    /// unstable MSC2965 variant), with fallback to `<issuer>/account/`.
-    /// None when the server is not MAS (non-MasWebOnly modes).
-    pub mas_account_url: Option<String>,
+    /// URL to open in the system browser for MAS self-registration.
+    /// Derived as `<issuer>/register` when a MAS issuer is discovered in
+    /// `.well-known` `m.authentication` (stable) or
+    /// `org.matrix.msc2965.authentication` (unstable). None for non-MAS
+    /// servers. Intentionally does NOT use MSC2965's `account` field —
+    /// that URL is for logged-in account management and loops when
+    /// opened unauthenticated.
+    pub mas_signup_url: Option<String>,
 }
 
 /// Minimal info per identity provider. Full matrix-sdk type is not

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -13,3 +13,83 @@ pub fn script_mod(vm: &mut ScriptVm) {
     register_status_modal::script_mod(vm);
     register_screen::script_mod(vm);
 }
+
+use matrix_sdk::ruma::api::client::uiaa::UiaaInfo;
+use makepad_widgets::ActionDefaultRef;
+
+/// Homeserver capabilities discovered before register branching.
+#[derive(Clone, Debug)]
+pub struct HsCapabilities {
+    /// Normalized base URL the client will use.
+    pub base_url: String,
+    /// True iff the server advertises `m.authentication.issuer` in
+    /// `.well-known/matrix/client` (MSC2965 / MAS delegation).
+    pub is_mas_native_oidc: bool,
+    /// True iff `POST /_matrix/client/v3/register` with empty body returns
+    /// 401 with parseable UIAA flows (NOT 403 M_FORBIDDEN).
+    pub registration_enabled: bool,
+    /// Optional UIAA probe result (empty when server requires MAS).
+    pub uiaa_probe: Option<UiaaInfo>,
+    /// Identity providers harvested from `/_matrix/client/v3/login`.
+    /// Phase 1 populates but does not render; Phase 4 renders buttons.
+    pub sso_providers: Vec<IdentityProviderSummary>,
+}
+
+/// Minimal info per identity provider. Full matrix-sdk type is not
+/// used because we only need name + id at this phase.
+#[derive(Clone, Debug)]
+pub struct IdentityProviderSummary {
+    pub id: String,
+    pub name: String,
+    pub icon_url: Option<String>,
+}
+
+/// Outcome classification of capability discovery.
+///
+/// Derived from `HsCapabilities` by `mode()` below; used for UI display.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RegisterMode {
+    /// Server advertises MAS OAuth; register goes through browser.
+    MasWebOnly,
+    /// Server supports direct UIAA register.
+    Uiaa,
+    /// Server explicitly disallows registration.
+    Disabled,
+}
+
+impl HsCapabilities {
+    /// Produce a human-routable mode. Follows element-web `Registration.tsx`:
+    /// MAS presence wins over UIAA even when both are possible.
+    pub fn mode(&self) -> RegisterMode {
+        if self.is_mas_native_oidc {
+            RegisterMode::MasWebOnly
+        } else if self.registration_enabled {
+            RegisterMode::Uiaa
+        } else {
+            RegisterMode::Disabled
+        }
+    }
+}
+
+/// Actions produced by or consumed by the register feature.
+///
+/// `Cx::post_action(RegisterAction::*)` from any widget; handled by `App` and
+/// by `RegisterScreen`.
+#[derive(Clone, Debug, Default)]
+pub enum RegisterAction {
+    /// User clicked the back button on RegisterScreen.
+    NavigateToLogin,
+    /// Sliding-sync reports the result of capability discovery.
+    CapabilitiesDiscovered(HsCapabilities),
+    /// Capability discovery failed (network error, bad URL, 5xx).
+    DiscoveryFailed(String),
+    #[default]
+    None,
+}
+
+impl ActionDefaultRef for RegisterAction {
+    fn default_ref() -> &'static Self {
+        static DEFAULT: RegisterAction = RegisterAction::None;
+        &DEFAULT
+    }
+}

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -1,0 +1,15 @@
+//! Account registration feature.
+//!
+//! Covers the dual-mode register flow (OIDC for MAS-delegated servers,
+//! UIAA wizard for legacy servers). See `specs/task-register-flow.spec.md`.
+
+use makepad_widgets::ScriptVm;
+
+pub mod register_screen;
+pub mod register_status_modal;
+pub mod validation;
+
+pub fn script_mod(vm: &mut ScriptVm) {
+    register_status_modal::script_mod(vm);
+    register_screen::script_mod(vm);
+}

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -19,74 +19,169 @@ script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
 
-    mod.widgets.RegisterScreen = #(RegisterScreen::register_widget(vm)) {
-        width: Fill,
-        height: Fill,
-        flow: Down,
-        padding: Inset { top: 24, right: 32, bottom: 24, left: 32 }
-        spacing: 16
-        show_bg: true
+    mod.widgets.RegisterScreen = set_type_default() do #(RegisterScreen::register_widget(vm)) {
+        ..mod.widgets.SolidView
+
+        width: Fill, height: Fill,
+        flow: Overlay
+        align: Align{x: 0.5, y: 0.5}
+        show_bg: true,
         draw_bg +: {
-            color: (COLOR_SECONDARY)
+            color: COLOR_SECONDARY
         }
 
-        back_button := RobrixIconButton {
-            width: Fit,
-            height: Fit,
-            text: "← Back to Login"
-        }
-
-        title := Label {
-            width: Fit,
-            height: Fit,
-            text: "Create Account"
-            draw_text +: {
-                color: (COLOR_TEXT)
-                text_style: TITLE_TEXT {font_size: 16.0}
-            }
-        }
-
-        homeserver_row := View {
+        ScrollYView {
             width: Fill,
-            height: Fit,
+            height: Fill,
             flow: Down,
-            spacing: 4
+            align: Align{x: 0.5, y: 0.5}
+            show_bg: true,
+            draw_bg.color: (COLOR_SECONDARY)
 
-            Label {
-                text: "Homeserver URL"
-                draw_text +: {
-                    color: (COLOR_TEXT)
-                    text_style: REGULAR_TEXT {font_size: 10.0}
+            scroll_bars: {
+                show_scroll_x: false,
+                show_scroll_y: true,
+                scroll_bar_y: {
+                    bar_size: 0.0
+                    min_handle_size: 0.0
+                    drag_scrolling: true
                 }
             }
 
-            homeserver_input := RobrixTextInput {
-                width: Fill,
-                height: 40,
-                empty_text: "matrix.org"
-            }
-        }
-
-        next_button := RobrixIconButton {
-            width: Fit,
-            height: Fit,
-            text: "Next"
-        }
-
-        status_area := View {
-            width: Fill,
-            height: Fit,
-            flow: Down,
-            spacing: 8,
-            visible: false
-
-            status_label := Label {
+            RoundedView {
+                margin: Inset{top: 50, bottom: 50}
                 width: Fill,
                 height: Fit,
-                text: ""
-                draw_text +: {
-                    color: (COLOR_TEXT)
-                    text_style: REGULAR_TEXT {font_size: 12.0}
+                align: Align{x: 0.5, y: 0.5}
+                flow: Overlay
+
+                View {
+                    width: Fill,
+                    height: Fit,
+                    flow: Down,
+                    align: Align{x: 0.5, y: 0.5}
+                    spacing: 15.0
+
+                    logo_image := Image {
+                        fit: ImageFit.Smallest,
+                        width: 80
+                        src: (mod.widgets.IMG_APP_LOGO),
+                    }
+
+                    title := Label {
+                        width: Fit,
+                        height: Fit,
+                        margin: Inset{bottom: 5}
+                        padding: 0,
+                        draw_text +: {
+                            color: (COLOR_TEXT)
+                            text_style: TITLE_TEXT {font_size: 16.0}
+                        }
+                        text: "Create Account"
+                    }
+
+                    View {
+                        width: 275,
+                        height: Fit,
+                        flow: Down,
+
+                        homeserver_input := RobrixTextInput {
+                            width: 275,
+                            height: Fit,
+                            flow: Right,
+                            padding: Inset{top: 10, bottom: 10, left: 10, right: 10}
+                            empty_text: "matrix.org"
+                        }
+
+                        View {
+                            width: 275,
+                            height: Fit,
+                            flow: Right,
+                            padding: Inset{top: 3, left: 2, right: 2}
+                            spacing: 0.0,
+                            align: Align{x: 0.5, y: 0.5}
+
+                            LineH { draw_bg.color: #C8C8C8 }
+
+                            homeserver_hint_label := Label {
+                                width: Fit,
+                                height: Fit,
+                                padding: 0,
+                                draw_text +: {
+                                    color: #8C8C8C
+                                    text_style: REGULAR_TEXT {font_size: 9}
+                                }
+                                text: "Homeserver URL"
+                            }
+
+                            LineH { draw_bg.color: #C8C8C8 }
+                        }
+                    }
+
+                    next_button := RobrixIconButton {
+                        width: 275,
+                        height: 40
+                        padding: 10
+                        margin: Inset{top: 5, bottom: 10}
+                        align: Align{x: 0.5, y: 0.5}
+                        text: "Next"
+                    }
+
+                    status_area := View {
+                        width: 275,
+                        height: Fit,
+                        flow: Down,
+                        visible: false
+                        padding: Inset{top: 2, bottom: 2, left: 4, right: 4}
+
+                        status_label := Label {
+                            width: Fill,
+                            height: Fit,
+                            draw_text +: {
+                                color: (COLOR_TEXT)
+                                text_style: REGULAR_TEXT {font_size: 10.5}
+                            }
+                            text: ""
+                        }
+                    }
+
+                    LineH {
+                        width: 275
+                        margin: Inset{bottom: -5}
+                        draw_bg.color: #C8C8C8
+                    }
+
+                    View {
+                        width: 275,
+                        height: Fit,
+                        flow: Right,
+                        spacing: 0.0,
+                        align: Align{x: 0.5, y: 0.5}
+
+                        LineH { draw_bg.color: #C8C8C8 }
+
+                        account_prompt_label := Label {
+                            width: Fit,
+                            height: Fit,
+                            padding: Inset{left: 1, right: 1, top: 0, bottom: 0}
+                            draw_text +: {
+                                color: #x6c6c6c
+                                text_style: REGULAR_TEXT {}
+                            }
+                            text: "Already have an account?"
+                        }
+
+                        LineH { draw_bg.color: #C8C8C8 }
+                    }
+
+                    back_button := RobrixIconButton {
+                        width: Fit,
+                        height: Fit,
+                        padding: Inset{left: 15, right: 15, top: 10, bottom: 10}
+                        margin: Inset{bottom: 5}
+                        align: Align{x: 0.5, y: 0.5}
+                        text: "← Back to Login"
+                    }
                 }
             }
         }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -143,12 +143,49 @@ impl WidgetMatchEvent for RegisterScreen {
         for action in actions {
             match action.downcast_ref::<RegisterAction>() {
                 Some(RegisterAction::CapabilitiesDiscovered(caps)) => {
-                    let msg = match caps.mode() {
-                        RegisterMode::MasWebOnly => "This server uses browser-based registration (MAS OAuth). Phase 2 will handle this.",
-                        RegisterMode::Uiaa => "This server allows direct account creation. Phase 3 will handle the form.",
-                        RegisterMode::Disabled => "This server does not allow registration. Please choose a different homeserver or sign in with an existing account.",
-                    };
-                    self.show_status(cx, msg);
+                    match caps.mode() {
+                        RegisterMode::MasWebOnly => {
+                            match caps.mas_account_url.as_deref() {
+                                Some(url) => match robius_open::Uri::new(url).open() {
+                                    Ok(()) => {
+                                        self.show_status(
+                                            cx,
+                                            "Browser opened. Complete registration in your web browser, \
+                                             then click ← Back to Login and sign in with your new account.",
+                                        );
+                                    }
+                                    Err(e) => {
+                                        log!("robius_open failed for MAS signup url {url}: {e:?}");
+                                        self.show_status(
+                                            cx,
+                                            &format!(
+                                                "Could not open the browser automatically. Please visit this URL manually:\n{url}"
+                                            ),
+                                        );
+                                    }
+                                },
+                                None => {
+                                    self.show_status(
+                                        cx,
+                                        "This server advertises browser-based registration but no signup URL was found.",
+                                    );
+                                }
+                            }
+                        }
+                        RegisterMode::Uiaa => {
+                            self.show_status(
+                                cx,
+                                "This server allows direct account creation. Phase 3 will handle the form.",
+                            );
+                        }
+                        RegisterMode::Disabled => {
+                            self.show_status(
+                                cx,
+                                "This server does not allow registration. Please choose a different homeserver \
+                                 or sign in with an existing account.",
+                            );
+                        }
+                    }
                     self.last_discovery = Some(caps.clone());
                 }
                 Some(RegisterAction::DiscoveryFailed(err)) => {

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -145,7 +145,7 @@ impl WidgetMatchEvent for RegisterScreen {
                 Some(RegisterAction::CapabilitiesDiscovered(caps)) => {
                     match caps.mode() {
                         RegisterMode::MasWebOnly => {
-                            match caps.mas_account_url.as_deref() {
+                            match caps.mas_signup_url.as_deref() {
                                 Some(url) => match robius_open::Uri::new(url).open() {
                                     Ok(()) => {
                                         self.show_status(

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -1,0 +1,34 @@
+//! RegisterScreen widget: homeserver picker + capability display.
+//!
+//! The full wizard body is added in later tasks; Task 1 only creates a stub
+//! so the module compiles.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    pub RegisterScreen := {{RegisterScreen}} View {
+        width: Fill,
+        height: Fill,
+        show_bg: true,
+        draw_bg: { color: #x1F2124 }
+
+        // TODO: Task 5 fills in this body.
+    }
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct RegisterScreen {
+    #[deref] view: View,
+}
+
+impl Widget for RegisterScreen {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+    }
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -26,8 +26,8 @@ script_mod! {
         padding: Inset { top: 24, right: 32, bottom: 24, left: 32 }
         spacing: 16
         show_bg: true
-        draw_bg: {
-            color: #x1F2124
+        draw_bg +: {
+            color: (COLOR_SECONDARY)
         }
 
         back_button := RobrixIconButton {
@@ -40,9 +40,9 @@ script_mod! {
             width: Fit,
             height: Fit,
             text: "Create Account"
-            draw_text: {
-                color: #xF1F2F3
-                text_style: { font_size: 22 }
+            draw_text +: {
+                color: (COLOR_TEXT)
+                text_style: TITLE_TEXT {font_size: 16.0}
             }
         }
 
@@ -54,9 +54,9 @@ script_mod! {
 
             Label {
                 text: "Homeserver URL"
-                draw_text: {
-                    color: #xAAB2BE
-                    text_style: { font_size: 12 }
+                draw_text +: {
+                    color: (COLOR_TEXT)
+                    text_style: REGULAR_TEXT {font_size: 10.0}
                 }
             }
 
@@ -84,9 +84,9 @@ script_mod! {
                 width: Fill,
                 height: Fit,
                 text: ""
-                draw_text: {
-                    color: #xE0E3E8
-                    text_style: { font_size: 14 }
+                draw_text +: {
+                    color: (COLOR_TEXT)
+                    text_style: REGULAR_TEXT {font_size: 12.0}
                 }
             }
         }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -63,7 +63,7 @@ script_mod! {
             homeserver_input := RobrixTextInput {
                 width: Fill,
                 height: 40,
-                empty_message: "matrix.org"
+                empty_text: "matrix.org"
             }
         }
 

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -1,34 +1,170 @@
 //! RegisterScreen widget: homeserver picker + capability display.
 //!
-//! The full wizard body is added in later tasks; Task 1 only creates a stub
-//! so the module compiles.
+//! Phase 1 renders:
+//!   - Back button (returns to login)
+//!   - Screen title
+//!   - Homeserver URL input
+//!   - Next button (triggers capability discovery)
+//!   - Three-state status area (MAS / UIAA / Disabled / errors)
+//!
+//! Phases 2-5 fill in OIDC launch / UIAA form / SSO buttons.
 
 use makepad_widgets::*;
+
+use crate::register::{HsCapabilities, RegisterAction, RegisterMode};
+use crate::register::validation::{normalize_homeserver_url, HomeserverUrlError};
+use crate::sliding_sync::{submit_async_request, MatrixRequest};
 
 script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
 
-    pub RegisterScreen := {{RegisterScreen}} View {
+    mod.widgets.RegisterScreen = #(RegisterScreen::register_widget(vm)) {
         width: Fill,
         height: Fill,
-        show_bg: true,
-        draw_bg: { color: #x1F2124 }
+        flow: Down,
+        padding: Inset { top: 24, right: 32, bottom: 24, left: 32 }
+        spacing: 16
+        show_bg: true
+        draw_bg: {
+            color: #x1F2124
+        }
 
-        // TODO: Task 5 fills in this body.
+        back_button := RobrixIconButton {
+            width: Fit,
+            height: Fit,
+            text: "← Back to Login"
+        }
+
+        title := Label {
+            width: Fit,
+            height: Fit,
+            text: "Create Account"
+            draw_text: {
+                color: #xF1F2F3
+                text_style: { font_size: 22 }
+            }
+        }
+
+        homeserver_row := View {
+            width: Fill,
+            height: Fit,
+            flow: Down,
+            spacing: 4
+
+            Label {
+                text: "Homeserver URL"
+                draw_text: {
+                    color: #xAAB2BE
+                    text_style: { font_size: 12 }
+                }
+            }
+
+            homeserver_input := RobrixTextInput {
+                width: Fill,
+                height: 40,
+                empty_message: "matrix.org"
+            }
+        }
+
+        next_button := RobrixIconButton {
+            width: Fit,
+            height: Fit,
+            text: "Next"
+        }
+
+        status_area := View {
+            width: Fill,
+            height: Fit,
+            flow: Down,
+            spacing: 8,
+            visible: false
+
+            status_label := Label {
+                width: Fill,
+                height: Fit,
+                text: ""
+                draw_text: {
+                    color: #xE0E3E8
+                    text_style: { font_size: 14 }
+                }
+            }
+        }
     }
 }
 
 #[derive(Script, ScriptHook, Widget)]
 pub struct RegisterScreen {
     #[deref] view: View,
+    #[rust] last_discovery: Option<HsCapabilities>,
 }
 
 impl Widget for RegisterScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
     }
+
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for RegisterScreen {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        let back = self.view.button(cx, ids!(back_button));
+        let next = self.view.button(cx, ids!(next_button));
+
+        if back.clicked(actions) {
+            Cx::post_action(RegisterAction::NavigateToLogin);
+            return;
+        }
+
+        if next.clicked(actions) {
+            let raw = self.view.text_input(cx, ids!(homeserver_input)).text();
+            match normalize_homeserver_url(&raw) {
+                Ok(url) => {
+                    self.show_status(cx, "Checking server capabilities...");
+                    submit_async_request(MatrixRequest::DiscoverHomeserverCapabilities { url });
+                }
+                Err(HomeserverUrlError::Empty) => {
+                    self.show_status(cx, "Please enter a homeserver URL (e.g. matrix.org).");
+                }
+                Err(HomeserverUrlError::UnsupportedScheme(s)) => {
+                    self.show_status(cx, &format!("Unsupported scheme: {s}. Only http(s) is allowed."));
+                }
+                Err(HomeserverUrlError::Invalid) => {
+                    self.show_status(cx, "That URL looks invalid. Please check and try again.");
+                }
+            }
+        }
+
+        // Capability discovery results.
+        for action in actions {
+            match action.downcast_ref::<RegisterAction>() {
+                Some(RegisterAction::CapabilitiesDiscovered(caps)) => {
+                    let msg = match caps.mode() {
+                        RegisterMode::MasWebOnly => "This server uses browser-based registration (MAS OAuth). Phase 2 will handle this.",
+                        RegisterMode::Uiaa => "This server allows direct account creation. Phase 3 will handle the form.",
+                        RegisterMode::Disabled => "This server does not allow registration. Please choose a different homeserver or sign in with an existing account.",
+                    };
+                    self.show_status(cx, msg);
+                    self.last_discovery = Some(caps.clone());
+                }
+                Some(RegisterAction::DiscoveryFailed(err)) => {
+                    self.show_status(cx, &format!("Could not reach that server: {err}"));
+                    self.last_discovery = None;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl RegisterScreen {
+    fn show_status(&mut self, cx: &mut Cx, message: &str) {
+        self.view.view(cx, ids!(status_area)).set_visible(cx, true);
+        self.view.label(cx, ids!(status_label)).set_text(cx, message);
+        self.view.redraw(cx);
     }
 }

--- a/src/register/register_status_modal.rs
+++ b/src/register/register_status_modal.rs
@@ -8,7 +8,7 @@ script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
 
-    pub RegisterStatusModal := {{RegisterStatusModal}} View {
+    mod.widgets.RegisterStatusModal = #(RegisterStatusModal::register_widget(vm)) {
         width: Fit,
         height: Fit
 

--- a/src/register/register_status_modal.rs
+++ b/src/register/register_status_modal.rs
@@ -1,0 +1,31 @@
+//! Status modal shared by both OIDC and UIAA branches.
+//!
+//! Task 1 scaffolds the widget; full wiring comes in later phases.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    pub RegisterStatusModal := {{RegisterStatusModal}} View {
+        width: Fit,
+        height: Fit
+
+        // TODO: Phase 2 wires title + status text + cancel button.
+    }
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct RegisterStatusModal {
+    #[deref] view: View,
+}
+
+impl Widget for RegisterStatusModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+    }
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}

--- a/src/register/validation.rs
+++ b/src/register/validation.rs
@@ -1,0 +1,3 @@
+//! URL / localpart / password validators for registration.
+
+// Functions are added in Task 2.

--- a/src/register/validation.rs
+++ b/src/register/validation.rs
@@ -1,3 +1,107 @@
 //! URL / localpart / password validators for registration.
 
-// Functions are added in Task 2.
+use url::Url;
+
+/// Errors returned by homeserver URL normalization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HomeserverUrlError {
+    /// Input was empty or whitespace only.
+    Empty,
+    /// Scheme is neither `http` nor `https`.
+    UnsupportedScheme(String),
+    /// URL could not be parsed.
+    Invalid,
+}
+
+/// Normalize a user-entered homeserver URL.
+///
+/// - Bare hostname (e.g. `matrix.org`) becomes `https://matrix.org`.
+/// - Explicit `http(s)://` schemes are kept as-is.
+/// - Any non-`http(s)` scheme is rejected.
+/// - Trailing `/` is stripped.
+/// - Empty string is rejected.
+pub fn normalize_homeserver_url(input: &str) -> Result<String, HomeserverUrlError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(HomeserverUrlError::Empty);
+    }
+
+    // Strip trailing slash from input before adding scheme
+    let trimmed_slash = trimmed.trim_end_matches('/');
+
+    let with_scheme = if trimmed_slash.contains("://") {
+        trimmed_slash.to_string()
+    } else {
+        format!("https://{trimmed_slash}")
+    };
+
+    let url = Url::parse(&with_scheme).map_err(|_| HomeserverUrlError::Invalid)?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(HomeserverUrlError::UnsupportedScheme(other.to_string())),
+    }
+
+    // Return the URL string without trailing slash (url crate always adds one for domain-only URLs)
+    let canonical = url.as_str().trim_end_matches('/').to_string();
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_hostname_gets_https() {
+        let url = normalize_homeserver_url("matrix.org").unwrap();
+        assert_eq!(url.as_str(), "https://matrix.org");
+    }
+
+    #[test]
+    fn explicit_https_is_kept() {
+        let url = normalize_homeserver_url("https://alvin.meldry.com").unwrap();
+        assert_eq!(url.as_str(), "https://alvin.meldry.com");
+    }
+
+    #[test]
+    fn explicit_http_is_kept() {
+        let url = normalize_homeserver_url("http://127.0.0.1:8128").unwrap();
+        assert_eq!(url.as_str(), "http://127.0.0.1:8128");
+    }
+
+    #[test]
+    fn trailing_slash_is_stripped() {
+        let url = normalize_homeserver_url("https://matrix.org/").unwrap();
+        assert_eq!(url.as_str(), "https://matrix.org");
+    }
+
+    #[test]
+    fn whitespace_is_trimmed() {
+        let url = normalize_homeserver_url("  matrix.org  ").unwrap();
+        assert_eq!(url.as_str(), "https://matrix.org");
+    }
+
+    #[test]
+    fn empty_input_is_rejected() {
+        assert_eq!(
+            normalize_homeserver_url(""),
+            Err(HomeserverUrlError::Empty),
+        );
+        assert_eq!(
+            normalize_homeserver_url("   "),
+            Err(HomeserverUrlError::Empty),
+        );
+    }
+
+    #[test]
+    fn non_http_scheme_is_rejected() {
+        let result = normalize_homeserver_url("ftp://example.com");
+        assert!(matches!(result, Err(HomeserverUrlError::UnsupportedScheme(ref s)) if s == "ftp"));
+    }
+
+    #[test]
+    fn malformed_url_is_rejected() {
+        let result = normalize_homeserver_url("http://  /not a url");
+        assert!(matches!(result, Err(HomeserverUrlError::Invalid)));
+    }
+}

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6657,11 +6657,16 @@ async fn discover_homeserver_capabilities(
                 .unwrap_or(raw_url)
                 .trim_end_matches('/')
                 .to_string();
-            let mas = body
-                .get("m.authentication")
-                .and_then(|m: &Value| m.get("issuer"))
-                .and_then(|v: &Value| v.as_str())
-                .is_some();
+            // Accept both the stable key (post-MSC2965 merge, e.g. alvin.meldry.com)
+            // and the unstable key still used by matrix.org and some deployments.
+            let mas = ["m.authentication", "org.matrix.msc2965.authentication"]
+                .iter()
+                .any(|key: &&str| {
+                    body.get(*key)
+                        .and_then(|m: &Value| m.get("issuer"))
+                        .and_then(|v: &Value| v.as_str())
+                        .is_some()
+                });
             (base, mas)
         }
         _ => (raw_url.trim_end_matches('/').to_string(), false),

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -696,6 +696,13 @@ impl std::fmt::Display for TimelineKind {
 pub enum MatrixRequest {
     /// Request from the login screen to log in with the given credentials.
     Login(LoginRequest),
+    /// Probe a homeserver's registration capabilities.
+    /// Sent from RegisterScreen's Next button; result arrives via
+    /// `RegisterAction::CapabilitiesDiscovered` / `DiscoveryFailed`.
+    DiscoverHomeserverCapabilities {
+        /// Already-normalized homeserver URL (has scheme, no trailing slash).
+        url: String,
+    },
     /// Request to switch to a different logged-in account.
     SwitchAccount {
         user_id: OwnedUserId,
@@ -1606,6 +1613,19 @@ async fn matrix_worker_task(
                         )));
                     }
                 }
+            }
+
+            MatrixRequest::DiscoverHomeserverCapabilities { url } => {
+                tokio::spawn(async move {
+                    match discover_homeserver_capabilities(&url).await {
+                        Ok(caps) => {
+                            Cx::post_action(crate::register::RegisterAction::CapabilitiesDiscovered(caps));
+                        }
+                        Err(e) => {
+                            Cx::post_action(crate::register::RegisterAction::DiscoveryFailed(e.to_string()));
+                        }
+                    }
+                });
             }
 
             MatrixRequest::SwitchAccount { user_id } => {
@@ -6595,4 +6615,137 @@ pub async fn clear_app_state(config: &LogoutConfig) -> Result<()> {
         }
         Err(_) => Err(anyhow!("Timed out waiting for UI-side app state cleanup")),
     }
+}
+
+/// Probe a homeserver's registration capabilities.
+///
+/// Fetches in order:
+/// 1. GET `.well-known/matrix/client` — discover base_url and MAS issuer (lenient)
+/// 2. GET `/_matrix/client/versions` — liveness check (fatal)
+/// 3. GET `/_matrix/client/v3/login` — enumerate SSO providers (non-fatal)
+/// 4. POST `/_matrix/client/v3/register` empty body — harvest UIAA flows (fatal)
+///
+/// Note: `matrix_sdk::reqwest::Response` does not expose `.json()`, so all
+/// response bodies are read as text and parsed via `serde_json::from_str`.
+async fn discover_homeserver_capabilities(
+    raw_url: &str,
+) -> anyhow::Result<crate::register::HsCapabilities> {
+    use crate::register::{HsCapabilities, IdentityProviderSummary};
+    use serde_json::Value;
+
+    let http = matrix_sdk::reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    // Helper: read response text and parse as JSON Value, returning Null on any failure.
+    async fn body_json(resp: matrix_sdk::reqwest::Response) -> Value {
+        match resp.text().await {
+            Ok(text) => serde_json::from_str::<Value>(&text).unwrap_or(Value::Null),
+            Err(_) => Value::Null,
+        }
+    }
+
+    // Step 1: .well-known (lenient — default base_url = raw_url on failure).
+    let wk_url = format!("{raw_url}/.well-known/matrix/client");
+    let (base_url, is_mas) = match http.get(&wk_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body = body_json(resp).await;
+            let base = body
+                .get("m.homeserver")
+                .and_then(|m: &Value| m.get("base_url"))
+                .and_then(|v: &Value| v.as_str())
+                .unwrap_or(raw_url)
+                .trim_end_matches('/')
+                .to_string();
+            let mas = body
+                .get("m.authentication")
+                .and_then(|m: &Value| m.get("issuer"))
+                .and_then(|v: &Value| v.as_str())
+                .is_some();
+            (base, mas)
+        }
+        _ => (raw_url.trim_end_matches('/').to_string(), false),
+    };
+
+    // Step 2: versions — liveness (fatal if unreachable).
+    let versions_url = format!("{base_url}/_matrix/client/versions");
+    http.get(&versions_url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| anyhow::anyhow!("homeserver unreachable: {e}"))?;
+
+    // Step 3: /v3/login — SSO providers (non-fatal on failure).
+    let login_url = format!("{base_url}/_matrix/client/v3/login");
+    let sso_providers = match http.get(&login_url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body = body_json(resp).await;
+            body.get("flows")
+                .and_then(|f: &Value| f.as_array())
+                .map(|flows| {
+                    flows
+                        .iter()
+                        .filter(|f: &&Value| {
+                            f.get("type").and_then(|t: &Value| t.as_str()) == Some("m.login.sso")
+                        })
+                        .flat_map(|f: &Value| {
+                            f.get("identity_providers")
+                                .and_then(|ip: &Value| ip.as_array())
+                                .cloned()
+                                .unwrap_or_default()
+                        })
+                        .filter_map(|p: Value| {
+                            Some(IdentityProviderSummary {
+                                id: p.get("id")?.as_str()?.to_string(),
+                                name: p
+                                    .get("name")
+                                    .and_then(|n: &Value| n.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                icon_url: p
+                                    .get("icon")
+                                    .and_then(|v: &Value| v.as_str())
+                                    .map(String::from),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    // Step 4: POST /register empty body — UIAA flow probe.
+    let register_url = format!("{base_url}/_matrix/client/v3/register");
+    let reg_resp = http
+        .post(&register_url)
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = reg_resp.status();
+    let body = body_json(reg_resp).await;
+
+    let (registration_enabled, uiaa_probe) = if status == matrix_sdk::reqwest::StatusCode::UNAUTHORIZED {
+        // Expected UIAA challenge.
+        match serde_json::from_value(body.clone()) {
+            Ok(info) => (true, Some(info)),
+            Err(_) => (true, None),
+        }
+    } else if status == matrix_sdk::reqwest::StatusCode::FORBIDDEN
+        && body.get("errcode").and_then(|v: &Value| v.as_str()) == Some("M_FORBIDDEN")
+    {
+        (false, None)
+    } else {
+        (false, None)
+    };
+
+    Ok(HsCapabilities {
+        base_url,
+        is_mas_native_oidc: is_mas,
+        registration_enabled,
+        uiaa_probe,
+        sso_providers,
+    })
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6647,7 +6647,7 @@ async fn discover_homeserver_capabilities(
 
     // Step 1: .well-known (lenient — default base_url = raw_url on failure).
     let wk_url = format!("{raw_url}/.well-known/matrix/client");
-    let (base_url, is_mas, mas_account_url) = match http.get(&wk_url).send().await {
+    let (base_url, is_mas, mas_signup_url) = match http.get(&wk_url).send().await {
         Ok(resp) if resp.status().is_success() => {
             let body = body_json(resp).await;
             let base = body
@@ -6657,23 +6657,22 @@ async fn discover_homeserver_capabilities(
                 .unwrap_or(raw_url)
                 .trim_end_matches('/')
                 .to_string();
-            // Detect MAS and capture the signup URL in one pass. Prefer stable key.
-            // Fallback to `<issuer>/account/` when `account` field is absent
-            // (alvin.meldry.com currently omits it).
-            let (mas, mas_account_url) = ["m.authentication", "org.matrix.msc2965.authentication"]
+            // Detect MAS and derive the signup URL in one pass. Prefer stable key.
+            // MAS exposes the self-registration form at `<issuer>/register` when
+            // open registration is enabled; closed deployments return a polite
+            // "registration not available" page at the same path. The MSC2965
+            // `account` field is for post-login account management (requires a
+            // session) — opening it while unauthenticated loops between
+            // /account/ and /login, so we do NOT use it here.
+            let (mas, mas_signup_url) = ["m.authentication", "org.matrix.msc2965.authentication"]
                 .iter()
                 .find_map(|key: &&str| {
-                    let block = body.get(*key)?;
-                    let issuer = block.get("issuer").and_then(|v: &Value| v.as_str())?;
-                    let account = block
-                        .get("account")
-                        .and_then(|v: &Value| v.as_str())
-                        .map(String::from)
-                        .unwrap_or_else(|| format!("{}/account/", issuer.trim_end_matches('/')));
-                    Some((true, Some(account)))
+                    let issuer = body.get(*key)?.get("issuer").and_then(|v: &Value| v.as_str())?;
+                    let signup = format!("{}/register", issuer.trim_end_matches('/'));
+                    Some((true, Some(signup)))
                 })
                 .unwrap_or((false, None));
-            (base, mas, mas_account_url)
+            (base, mas, mas_signup_url)
         }
         _ => (raw_url.trim_end_matches('/').to_string(), false, None),
     };
@@ -6758,6 +6757,6 @@ async fn discover_homeserver_capabilities(
         registration_enabled,
         uiaa_probe,
         sso_providers,
-        mas_account_url,
+        mas_signup_url,
     })
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6647,7 +6647,7 @@ async fn discover_homeserver_capabilities(
 
     // Step 1: .well-known (lenient — default base_url = raw_url on failure).
     let wk_url = format!("{raw_url}/.well-known/matrix/client");
-    let (base_url, is_mas) = match http.get(&wk_url).send().await {
+    let (base_url, is_mas, mas_account_url) = match http.get(&wk_url).send().await {
         Ok(resp) if resp.status().is_success() => {
             let body = body_json(resp).await;
             let base = body
@@ -6657,19 +6657,25 @@ async fn discover_homeserver_capabilities(
                 .unwrap_or(raw_url)
                 .trim_end_matches('/')
                 .to_string();
-            // Accept both the stable key (post-MSC2965 merge, e.g. alvin.meldry.com)
-            // and the unstable key still used by matrix.org and some deployments.
-            let mas = ["m.authentication", "org.matrix.msc2965.authentication"]
+            // Detect MAS and capture the signup URL in one pass. Prefer stable key.
+            // Fallback to `<issuer>/account/` when `account` field is absent
+            // (alvin.meldry.com currently omits it).
+            let (mas, mas_account_url) = ["m.authentication", "org.matrix.msc2965.authentication"]
                 .iter()
-                .any(|key: &&str| {
-                    body.get(*key)
-                        .and_then(|m: &Value| m.get("issuer"))
+                .find_map(|key: &&str| {
+                    let block = body.get(*key)?;
+                    let issuer = block.get("issuer").and_then(|v: &Value| v.as_str())?;
+                    let account = block
+                        .get("account")
                         .and_then(|v: &Value| v.as_str())
-                        .is_some()
-                });
-            (base, mas)
+                        .map(String::from)
+                        .unwrap_or_else(|| format!("{}/account/", issuer.trim_end_matches('/')));
+                    Some((true, Some(account)))
+                })
+                .unwrap_or((false, None));
+            (base, mas, mas_account_url)
         }
-        _ => (raw_url.trim_end_matches('/').to_string(), false),
+        _ => (raw_url.trim_end_matches('/').to_string(), false, None),
     };
 
     // Step 2: versions — liveness (fatal if unreachable).
@@ -6752,5 +6758,6 @@ async fn discover_homeserver_capabilities(
         registration_enabled,
         uiaa_probe,
         sso_providers,
+        mas_account_url,
     })
 }


### PR DESCRIPTION
## Summary
- **Phase 1**: dedicated `src/register/` module with dual-mode capability discovery (MAS / UIAA / Disabled), homeserver URL input + validation, error states, back-to-login nav. Signup mode residue removed from LoginScreen.
- **Phase 2**: MAS servers trigger system-browser launch to `<issuer>/register` via `robius_open`; no OAuth callback / token exchange (simple version — Element Desktop's full callback is future Phase 2.5).

## Usable after merge
- **MAS homeservers** (matrix.org, alvin.meldry.com, any MSC2965-compliant) fully supported end-to-end: click "Sign up here" → type server → sign up in system browser → return → log in with the new account via the existing password flow.
- **Non-MAS / UIAA-only / Disabled** servers see an honest static status message; "Back to Login" never breaks.
- **All existing login paths unchanged.**

## Key design choices
- **MAS signup URL derived as `<issuer>/register`** — NOT MSC2965's `account` field, which is for post-login account management and redirect-loops when opened unauthenticated (verified on alvin.meldry.com).
- **MAS detection accepts both stable `m.authentication` and unstable `org.matrix.msc2965.authentication`** — alvin uses stable, matrix.org still uses unstable; missing either key would mis-classify the server as Disabled.
- **Fire-and-forget browser launch** via `robius_open::Uri::new(url).open()` (no callback / custom URI scheme) — user completes signup on web, returns to robrix2, logs in manually.

## Test plan
- [x] alvin.meldry.com (MAS, open registration): browser opens, "Create account" form loads, can complete signup
- [x] matrix.org (MAS, restricted registration): browser opens to MAS, page handled cleanly
- [x] Empty URL input → `"Please enter a homeserver URL..."`
- [x] Bad scheme `ftp://…` → `"Unsupported scheme: ftp. Only http(s) is allowed."`
- [x] Unreachable server → `"Could not reach that server: …"`
- [x] Theme + layout aligns with LoginScreen (light bg, `COLOR_TEXT`, `TITLE_TEXT` / `REGULAR_TEXT`)
- [x] Existing login regression: password login + SSO unaffected

## References
- Spec: `specs/task-register-flow.spec.md`
- Plans: `docs/superpowers/plans/2026-04-21-register-phase-1-skeleton.md`, `docs/superpowers/plans/2026-04-21-register-phase-2-mas-browser.md`
- Future scope (PR#2): Phase 3 UIAA native form, Phase 4 SSO provider buttons, Phase 5 password strength (zxcvbn)