### PR TITLE
feat(register): Phase 3a — UIAA dummy flow for self-hosted servers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -955,6 +955,9 @@ impl MatchEvent for App {
                 self.app_state.logged_in = true;
                 self.app_state.adding_account = false;
                 self.auth_ui_state = AuthUiState::LoggedIn;
+                // If the user reached this success via the register flow, also hide
+                // register_screen — update_login_visibility only manages login_screen_view.
+                self.ui.view(cx, ids!(register_screen_view)).set_visible(cx, false);
                 self.update_login_visibility(cx);
                 self.ui.redraw(cx);
                 continue;

--- a/src/app.rs
+++ b/src/app.rs
@@ -934,6 +934,7 @@ impl MatchEvent for App {
             }
 
             if let Some(RegisterAction::NavigateToLogin) = action.downcast_ref() {
+                log!("app.rs: RegisterAction::NavigateToLogin received -> showing login_screen");
                 self.ui.view(cx, ids!(register_screen_view)).set_visible(cx, false);
                 self.ui.view(cx, ids!(login_screen_view)).set_visible(cx, true);
                 self.ui.redraw(cx);

--- a/src/app.rs
+++ b/src/app.rs
@@ -934,7 +934,6 @@ impl MatchEvent for App {
             }
 
             if let Some(RegisterAction::NavigateToLogin) = action.downcast_ref() {
-                log!("app.rs: RegisterAction::NavigateToLogin received -> showing login_screen");
                 self.ui.view(cx, ids!(register_screen_view)).set_visible(cx, false);
                 self.ui.view(cx, ids!(login_screen_view)).set_visible(cx, true);
                 self.ui.redraw(cx);

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -4,8 +4,17 @@ use makepad_widgets::*;
 use url::Url;
 
 use crate::{app::AppState, i18n::{AppLanguage, tr_fmt, tr_key}, sliding_sync::{submit_async_request, AccountSwitchAction, LoginByPassword, LoginRequest, MatrixRequest}};
+use crate::register::RegisterAction;
 
 use super::login_status_modal::{LoginStatusModalAction, LoginStatusModalWidgetExt};
+
+fn should_show_login_failure_modal(
+    suppress_login_failure_modal: bool,
+    last_failure_message_shown: Option<&str>,
+    error: &str,
+) -> bool {
+    !suppress_login_failure_modal && last_failure_message_shown != Some(error)
+}
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -571,6 +580,8 @@ pub struct LoginScreen {
     #[rust] sso_redirect_url: Option<String>,
     /// The most recent login failure message shown to the user.
     #[rust] last_failure_message_shown: Option<String>,
+    /// Register flow owns login/setup failures while the login screen is hidden.
+    #[rust] suppress_login_failure_modal: bool,
     #[rust] app_language: AppLanguage,
     /// Boolean to indicate if we're in "add account" mode (adding another Matrix account).
     #[rust] adding_account: bool,
@@ -901,6 +912,9 @@ impl WidgetMatchEvent for LoginScreen {
         }
 
         if mode_toggle_button.clicked(actions) {
+            self.suppress_login_failure_modal = true;
+            self.last_failure_message_shown = None;
+            login_status_modal.close(cx);
             Cx::post_action(LoginAction::NavigateToRegister);
         }
 
@@ -971,8 +985,19 @@ impl WidgetMatchEvent for LoginScreen {
                 login_status_modal.close(cx);
             }
 
+            if let Some(RegisterAction::NavigateToLogin) = action.downcast_ref() {
+                self.suppress_login_failure_modal = false;
+                self.last_failure_message_shown = None;
+                login_status_modal.close(cx);
+            }
+
             // Handle login-related actions received from background async tasks.
             match action.downcast_ref() {
+                Some(LoginAction::ShowLoginScreen) => {
+                    self.suppress_login_failure_modal = false;
+                    self.last_failure_message_shown = None;
+                    login_status_modal.close(cx);
+                }
                 Some(LoginAction::CliAutoLogin { user_id, homeserver }) => {
                     self.last_failure_message_shown = None;
                     user_id_input.set_text(cx, user_id);
@@ -1003,6 +1028,7 @@ impl WidgetMatchEvent for LoginScreen {
                 Some(LoginAction::LoginSuccess) => {
                     // The main `App` component handles showing the main screen
                     // and hiding the login screen & login status modal.
+                    self.suppress_login_failure_modal = false;
                     self.last_failure_message_shown = None;
                     self.adding_account = false;
                     user_id_input.set_text(cx, "");
@@ -1015,8 +1041,17 @@ impl WidgetMatchEvent for LoginScreen {
                     login_status_modal.close(cx);
                     self.redraw(cx);
                 }
+                Some(LoginAction::ClearFailureState) => {
+                    self.last_failure_message_shown = None;
+                    login_status_modal.close(cx);
+                    self.redraw(cx);
+                }
                 Some(LoginAction::LoginFailure(error)) => {
-                    if self.last_failure_message_shown.as_deref() == Some(error.as_str()) {
+                    if !should_show_login_failure_modal(
+                        self.suppress_login_failure_modal,
+                        self.last_failure_message_shown.as_deref(),
+                        error,
+                    ) {
                         continue;
                     }
                     self.last_failure_message_shown = Some(error.clone());
@@ -1036,6 +1071,7 @@ impl WidgetMatchEvent for LoginScreen {
                     self.sso_redirect_url = Some(url.to_string());
                 }
                 Some(LoginAction::ShowAddAccountScreen) => {
+                    self.suppress_login_failure_modal = false;
                     self.adding_account = true;
                     self.reset_sso_state(cx);
                     // Update UI to "add account" mode
@@ -1047,6 +1083,7 @@ impl WidgetMatchEvent for LoginScreen {
                 }
                 Some(LoginAction::AddAccountSuccess) => {
                     // Reset the login screen state
+                    self.suppress_login_failure_modal = false;
                     self.adding_account = false;
                     self.reset_sso_state(cx);
                     user_id_input.set_text(cx, "");
@@ -1138,6 +1175,8 @@ pub enum LoginAction {
     AddAccountSuccess,
     /// A negative response from the backend Matrix task to the login screen.
     LoginFailure(String),
+    /// Clear any hidden login failure UI/state that should not leak across flows.
+    ClearFailureState,
     /// A login-related status message to display to the user.
     Status {
         title: String,
@@ -1172,4 +1211,24 @@ pub enum LoginAction {
     CancelAddAccount,
     #[default]
     None,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_show_login_failure_modal;
+
+    #[test]
+    fn login_failure_modal_is_suppressed_while_register_flow_is_active() {
+        assert!(!should_show_login_failure_modal(true, None, "boom"));
+    }
+
+    #[test]
+    fn duplicate_login_failure_message_is_suppressed() {
+        assert!(!should_show_login_failure_modal(false, Some("boom"), "boom"));
+    }
+
+    #[test]
+    fn fresh_login_failure_message_is_shown_when_not_suppressed() {
+        assert!(should_show_login_failure_modal(false, Some("old"), "boom"));
+    }
 }

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -90,7 +90,7 @@ pub enum RegisterAction {
     /// User clicked the back button on RegisterScreen.
     NavigateToLogin,
     /// `requested_url` is echoed so the screen can drop out-of-order responses.
-    CapabilitiesDiscovered { requested_url: String, caps: HsCapabilities },
+    CapabilitiesDiscovered { requested_url: String, caps: Box<HsCapabilities> },
     /// `requested_url` is echoed so the screen can drop out-of-order responses.
     DiscoveryFailed { requested_url: String, error: String },
     /// User submitted the RegistrationForm; first POST is in flight.

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -89,15 +89,9 @@ impl HsCapabilities {
 pub enum RegisterAction {
     /// User clicked the back button on RegisterScreen.
     NavigateToLogin,
-    /// Sliding-sync reports the result of capability discovery.
-    ///
-    /// `requested_url` echoes the input that initiated this probe, so the
-    /// screen can reject out-of-order responses when the user clicked Next
-    /// against a different homeserver before the previous probe returned.
+    /// `requested_url` is echoed so the screen can drop out-of-order responses.
     CapabilitiesDiscovered { requested_url: String, caps: HsCapabilities },
-    /// Capability discovery failed (network error, bad URL, 5xx).
-    /// `requested_url` is carried for the same out-of-order-drop reason as
-    /// `CapabilitiesDiscovered`.
+    /// `requested_url` is echoed so the screen can drop out-of-order responses.
     DiscoveryFailed { requested_url: String, error: String },
     /// User submitted the RegistrationForm; first POST is in flight.
     RegistrationSubmitted,

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -90,9 +90,15 @@ pub enum RegisterAction {
     /// User clicked the back button on RegisterScreen.
     NavigateToLogin,
     /// Sliding-sync reports the result of capability discovery.
-    CapabilitiesDiscovered(HsCapabilities),
+    ///
+    /// `requested_url` echoes the input that initiated this probe, so the
+    /// screen can reject out-of-order responses when the user clicked Next
+    /// against a different homeserver before the previous probe returned.
+    CapabilitiesDiscovered { requested_url: String, caps: HsCapabilities },
     /// Capability discovery failed (network error, bad URL, 5xx).
-    DiscoveryFailed(String),
+    /// `requested_url` is carried for the same out-of-order-drop reason as
+    /// `CapabilitiesDiscovered`.
+    DiscoveryFailed { requested_url: String, error: String },
     /// User submitted the RegistrationForm; first POST is in flight.
     RegistrationSubmitted,
     /// Registration completed and the client has been persisted via

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -7,6 +7,7 @@ use makepad_widgets::ScriptVm;
 
 pub mod register_screen;
 pub mod register_status_modal;
+pub mod uiaa;
 pub mod validation;
 
 pub fn script_mod(vm: &mut ScriptVm) {

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -92,6 +92,14 @@ pub enum RegisterAction {
     CapabilitiesDiscovered(HsCapabilities),
     /// Capability discovery failed (network error, bad URL, 5xx).
     DiscoveryFailed(String),
+    /// User submitted the RegistrationForm; first POST is in flight.
+    RegistrationSubmitted,
+    /// Registration completed and the client has been persisted via
+    /// `finalize_authenticated_client`. App.rs only needs to switch screens.
+    RegistrationSuccess,
+    /// Registration failed at any stage (network, validation, UIAA error).
+    /// The payload is a user-displayable message.
+    RegistrationFailed(String),
     #[default]
     None,
 }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -241,6 +241,14 @@ script_mod! {
 pub struct RegisterScreen {
     #[deref] view: View,
     #[rust] last_discovery: Option<HsCapabilities>,
+    /// Normalized user-typed URL that produced `last_discovery`.
+    ///
+    /// Stored separately from `caps.base_url` because `.well-known/matrix/client`
+    /// frequently returns a different string than the user typed (e.g. adds a
+    /// trailing slash, rewrites to a federation host). Comparing the current
+    /// input to `caps.base_url` causes false "homeserver changed" errors on
+    /// every well-known-delegated server. We compare against this instead.
+    #[rust] last_discovery_input_url: Option<String>,
     /// True between submit click and the terminal `RegistrationSuccess` /
     /// `RegistrationFailed` action. Gates duplicate submits so repeat-clicking
     /// "Create Account" can't queue multiple requests into `login_sender`
@@ -266,7 +274,6 @@ impl WidgetMatchEvent for RegisterScreen {
         let submit = self.view.button(cx, ids!(submit_button));
 
         if back.clicked(actions) {
-            log!("RegisterScreen: back_button clicked -> NavigateToLogin");
             Cx::post_action(RegisterAction::NavigateToLogin);
             return;
         }
@@ -276,6 +283,11 @@ impl WidgetMatchEvent for RegisterScreen {
             match normalize_homeserver_url(&raw) {
                 Ok(url) => {
                     self.show_status(cx, "Checking server capabilities...");
+                    // Capture the user-intent URL for the stale-cache check at
+                    // submit time. We must NOT compare against caps.base_url —
+                    // .well-known may return a different string for the same
+                    // server (trailing slash, federation host rewrite, etc).
+                    self.last_discovery_input_url = Some(url.clone());
                     submit_async_request(MatrixRequest::DiscoverHomeserverCapabilities { url });
                 }
                 Err(HomeserverUrlError::Empty) => {
@@ -300,14 +312,6 @@ impl WidgetMatchEvent for RegisterScreen {
             || confirm_password_input.returned(actions).is_some();
 
         if submit_triggered {
-            log!(
-                "RegisterScreen: submit_triggered (pending={}) by click={} username_ret={} password_ret={} confirm_ret={}",
-                self.registration_pending,
-                submit.clicked(actions),
-                username_input.returned(actions).is_some(),
-                password_input.returned(actions).is_some(),
-                confirm_password_input.returned(actions).is_some(),
-            );
             if self.registration_pending {
                 return;
             }
@@ -356,16 +360,22 @@ impl WidgetMatchEvent for RegisterScreen {
             };
 
             // Guard against a stale capability cache: if the user edited the
-            // homeserver input after clicking Next, `caps.base_url` no longer
-            // reflects what they typed. Re-normalize the current input and
-            // refuse to submit if it diverges — otherwise we'd silently create
-            // the account on the previously-probed server.
+            // homeserver input after clicking Next, we must re-probe. We compare
+            // the current normalized input against the input that PRODUCED the
+            // discovery (`last_discovery_input_url`), NOT `caps.base_url` — the
+            // latter may have been rewritten by `.well-known/matrix/client`
+            // (trailing slash, federation host) and a strict string compare
+            // would false-trigger on every well-known-delegated server.
+            //
+            // On mismatch we clear the cache + show an error but keep the form
+            // visible so the user can see the message and react — hiding the
+            // form also hides `form_error_label` (it lives inside the form).
             let current_raw = self.view.text_input(cx, ids!(homeserver_input)).text();
             let current_url = match normalize_homeserver_url(&current_raw) {
                 Ok(u) => u,
                 Err(_) => {
-                    self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
                     self.last_discovery = None;
+                    self.last_discovery_input_url = None;
                     self.show_form_error(
                         cx,
                         "The homeserver URL looks invalid. Please fix it and click Next again.",
@@ -373,9 +383,10 @@ impl WidgetMatchEvent for RegisterScreen {
                     return;
                 }
             };
-            if current_url != caps.base_url {
-                self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+            let probed_input = self.last_discovery_input_url.as_deref().unwrap_or("");
+            if current_url != probed_input {
                 self.last_discovery = None;
+                self.last_discovery_input_url = None;
                 self.show_form_error(
                     cx,
                     "The homeserver changed since the last check. Click Next to verify this server before creating an account.",
@@ -385,7 +396,6 @@ impl WidgetMatchEvent for RegisterScreen {
 
             let homeserver_url = caps.base_url.clone();
 
-            log!("RegisterScreen: dispatching MatrixRequest::RegisterViaUiaa {{ username={:?}, homeserver_url={:?} }}", localpart, homeserver_url);
             self.clear_form_error(cx);
             self.show_status(cx, "Creating your account...");
             self.registration_pending = true;
@@ -459,6 +469,7 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.clear_form_error(cx);
                     self.show_status(cx, &format!("Could not reach that server: {err}"));
                     self.last_discovery = None;
+                    self.last_discovery_input_url = None;
                 }
                 Some(RegisterAction::RegistrationSubmitted) => {
                     // Feedback already shown by show_status("Creating your account...")

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -145,6 +145,55 @@ script_mod! {
                         }
                     }
 
+                    registration_form := View {
+                        width: 275,
+                        height: Fit,
+                        flow: Down,
+                        spacing: 10,
+                        visible: false
+
+                        username_input := RobrixTextInput {
+                            width: 275, height: Fit,
+                            flow: Right,
+                            padding: Inset{top: 10, bottom: 10, left: 10, right: 10}
+                            empty_text: "Username"
+                        }
+
+                        password_input := RobrixTextInput {
+                            width: 275, height: Fit,
+                            flow: Right,
+                            padding: Inset{top: 10, bottom: 10, left: 10, right: 10}
+                            empty_text: "Password"
+                            is_password: true,
+                        }
+
+                        confirm_password_input := RobrixTextInput {
+                            width: 275, height: Fit,
+                            flow: Right,
+                            padding: Inset{top: 10, bottom: 10, left: 10, right: 10}
+                            empty_text: "Confirm password"
+                            is_password: true,
+                        }
+
+                        form_error_label := Label {
+                            width: Fill, height: Fit,
+                            visible: false
+                            draw_text +: {
+                                color: (COLOR_FG_DANGER_RED)
+                                text_style: REGULAR_TEXT {font_size: 10.5}
+                            }
+                            text: ""
+                        }
+
+                        submit_button := RobrixIconButton {
+                            width: 275, height: 40
+                            padding: 10
+                            margin: Inset{top: 5}
+                            align: Align{x: 0.5, y: 0.5}
+                            text: "Create Account"
+                        }
+                    }
+
                     LineH {
                         width: 275
                         margin: Inset{bottom: -5}
@@ -209,6 +258,7 @@ impl WidgetMatchEvent for RegisterScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let back = self.view.button(cx, ids!(back_button));
         let next = self.view.button(cx, ids!(next_button));
+        let submit = self.view.button(cx, ids!(submit_button));
 
         if back.clicked(actions) {
             Cx::post_action(RegisterAction::NavigateToLogin);
@@ -234,12 +284,70 @@ impl WidgetMatchEvent for RegisterScreen {
             }
         }
 
+        if submit.clicked(actions) {
+            use crate::register::validation::{
+                validate_localpart, validate_passwords_match, LocalpartError, PasswordError,
+            };
+
+            let username = self.view.text_input(cx, ids!(username_input)).text();
+            let password = self.view.text_input(cx, ids!(password_input)).text();
+            let confirm = self.view.text_input(cx, ids!(confirm_password_input)).text();
+
+            let localpart = match validate_localpart(&username) {
+                Ok(l) => l,
+                Err(LocalpartError::Empty) => {
+                    self.show_form_error(cx, "Please enter a username.");
+                    return;
+                }
+                Err(LocalpartError::TooLong) => {
+                    self.show_form_error(cx, "Username is too long (max 255 characters).");
+                    return;
+                }
+                Err(LocalpartError::InvalidChars) => {
+                    self.show_form_error(
+                        cx,
+                        "Username can contain only lowercase letters, digits, and . _ = - /",
+                    );
+                    return;
+                }
+            };
+
+            if let Err(e) = validate_passwords_match(&password, &confirm) {
+                match e {
+                    PasswordError::Empty => {
+                        self.show_form_error(cx, "Please enter and confirm a password.");
+                    }
+                    PasswordError::Mismatch => {
+                        self.show_form_error(cx, "Passwords don't match. Please re-enter.");
+                    }
+                }
+                return;
+            }
+
+            let Some(caps) = self.last_discovery.as_ref() else {
+                self.show_form_error(cx, "Please check the homeserver first (click Next).");
+                return;
+            };
+            let homeserver_url = caps.base_url.clone();
+
+            self.clear_form_error(cx);
+            self.show_status(cx, "Creating your account...");
+            submit_async_request(MatrixRequest::RegisterViaUiaa {
+                username: localpart,
+                password,
+                homeserver_url,
+            });
+            return;
+        }
+
         // Capability discovery results.
         for action in actions {
             match action.downcast_ref::<RegisterAction>() {
                 Some(RegisterAction::CapabilitiesDiscovered(caps)) => {
                     match caps.mode() {
                         RegisterMode::MasWebOnly => {
+                            self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+                            self.clear_form_error(cx);
                             match caps.mas_signup_url.as_deref() {
                                 Some(url) => match robius_open::Uri::new(url).open() {
                                     Ok(()) => {
@@ -268,12 +376,16 @@ impl WidgetMatchEvent for RegisterScreen {
                             }
                         }
                         RegisterMode::Uiaa => {
+                            self.view.view(cx, ids!(registration_form)).set_visible(cx, true);
+                            self.clear_form_error(cx);
                             self.show_status(
                                 cx,
-                                "This server allows direct account creation. Phase 3 will handle the form.",
+                                "This homeserver allows direct registration. Fill in your details below to create an account.",
                             );
                         }
                         RegisterMode::Disabled => {
+                            self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+                            self.clear_form_error(cx);
                             self.show_status(
                                 cx,
                                 "This server does not allow registration. Please choose a different homeserver \
@@ -284,8 +396,21 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.last_discovery = Some(caps.clone());
                 }
                 Some(RegisterAction::DiscoveryFailed(err)) => {
+                    self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+                    self.clear_form_error(cx);
                     self.show_status(cx, &format!("Could not reach that server: {err}"));
                     self.last_discovery = None;
+                }
+                Some(RegisterAction::RegistrationSubmitted) => {
+                    // Feedback already shown by show_status("Creating your account...")
+                    // at click time; nothing additional to do here.
+                }
+                Some(RegisterAction::RegistrationFailed(err)) => {
+                    self.show_form_error(cx, err);
+                    self.show_status(
+                        cx,
+                        "Registration didn't go through. Please check the error above and retry.",
+                    );
                 }
                 _ => {}
             }
@@ -298,5 +423,15 @@ impl RegisterScreen {
         self.view.view(cx, ids!(status_area)).set_visible(cx, true);
         self.view.label(cx, ids!(status_label)).set_text(cx, message);
         self.view.redraw(cx);
+    }
+
+    fn show_form_error(&mut self, cx: &mut Cx, message: &str) {
+        self.view.label(cx, ids!(form_error_label)).set_text(cx, message);
+        self.view.view(cx, ids!(form_error_label)).set_visible(cx, true);
+        self.view.redraw(cx);
+    }
+
+    fn clear_form_error(&mut self, cx: &mut Cx) {
+        self.view.view(cx, ids!(form_error_label)).set_visible(cx, false);
     }
 }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -282,6 +282,17 @@ impl WidgetMatchEvent for RegisterScreen {
             let raw = self.view.text_input(cx, ids!(homeserver_input)).text();
             match normalize_homeserver_url(&raw) {
                 Ok(url) => {
+                    // Invalidate any prior probe state BEFORE the new request
+                    // goes out. A submit click landing in the window between
+                    // Next and the fresh response must not be allowed to fire
+                    // a register request against the previous server. Fix 1
+                    // already drops the late CapabilitiesDiscovered action;
+                    // this clears the pre-existing cache the user could
+                    // otherwise still submit against.
+                    self.last_discovery = None;
+                    self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+                    self.clear_form_error(cx);
+
                     self.show_status(cx, "Checking server capabilities...");
                     // Capture the user-intent URL for the stale-cache check at
                     // submit time. We must NOT compare against caps.base_url —

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -241,6 +241,11 @@ script_mod! {
 pub struct RegisterScreen {
     #[deref] view: View,
     #[rust] last_discovery: Option<HsCapabilities>,
+    /// True between submit click and the terminal `RegistrationSuccess` /
+    /// `RegistrationFailed` action. Gates duplicate submits so repeat-clicking
+    /// "Create Account" can't queue multiple requests into `login_sender`
+    /// (mirrors the `sso_pending` pattern elsewhere in the app).
+    #[rust] registration_pending: bool,
 }
 
 impl Widget for RegisterScreen {
@@ -285,6 +290,9 @@ impl WidgetMatchEvent for RegisterScreen {
         }
 
         if submit.clicked(actions) {
+            if self.registration_pending {
+                return;
+            }
             use crate::register::validation::{
                 validate_localpart, validate_passwords_match, LocalpartError, PasswordError,
             };
@@ -332,6 +340,7 @@ impl WidgetMatchEvent for RegisterScreen {
 
             self.clear_form_error(cx);
             self.show_status(cx, "Creating your account...");
+            self.registration_pending = true;
             submit_async_request(MatrixRequest::RegisterViaUiaa {
                 username: localpart,
                 password,
@@ -410,10 +419,12 @@ impl WidgetMatchEvent for RegisterScreen {
                     // in the background and LoginAction::LoginSuccess will fire
                     // ~100-200ms later to complete the transition to the main UI.
                     // Show interim feedback so the delay feels intentional.
+                    self.registration_pending = false;
                     self.clear_form_error(cx);
                     self.show_status(cx, "Account created! Loading your account...");
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {
+                    self.registration_pending = false;
                     self.show_form_error(cx, err);
                     self.show_status(
                         cx,

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -336,6 +336,35 @@ impl WidgetMatchEvent for RegisterScreen {
                 self.show_form_error(cx, "Please check the homeserver first (click Next).");
                 return;
             };
+
+            // Guard against a stale capability cache: if the user edited the
+            // homeserver input after clicking Next, `caps.base_url` no longer
+            // reflects what they typed. Re-normalize the current input and
+            // refuse to submit if it diverges — otherwise we'd silently create
+            // the account on the previously-probed server.
+            let current_raw = self.view.text_input(cx, ids!(homeserver_input)).text();
+            let current_url = match normalize_homeserver_url(&current_raw) {
+                Ok(u) => u,
+                Err(_) => {
+                    self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+                    self.last_discovery = None;
+                    self.show_form_error(
+                        cx,
+                        "The homeserver URL looks invalid. Please fix it and click Next again.",
+                    );
+                    return;
+                }
+            };
+            if current_url != caps.base_url {
+                self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
+                self.last_discovery = None;
+                self.show_form_error(
+                    cx,
+                    "The homeserver changed since the last check. Click Next to verify this server before creating an account.",
+                );
+                return;
+            }
+
             let homeserver_url = caps.base_url.clone();
 
             self.clear_form_error(cx);

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -405,6 +405,14 @@ impl WidgetMatchEvent for RegisterScreen {
                     // Feedback already shown by show_status("Creating your account...")
                     // at click time; nothing additional to do here.
                 }
+                Some(RegisterAction::RegistrationSuccess) => {
+                    // Credentials accepted; the sync service is still building
+                    // in the background and LoginAction::LoginSuccess will fire
+                    // ~100-200ms later to complete the transition to the main UI.
+                    // Show interim feedback so the delay feels intentional.
+                    self.clear_form_error(cx);
+                    self.show_status(cx, "Account created! Loading your account...");
+                }
                 Some(RegisterAction::RegistrationFailed(err)) => {
                     self.show_form_error(cx, err);
                     self.show_status(

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -379,6 +379,8 @@ impl WidgetMatchEvent for RegisterScreen {
             self.clear_form_error(cx);
             self.show_status(cx, "Creating your account...");
             self.registration_pending = true;
+            submit.set_text(cx, "Creating...");
+            self.view.redraw(cx);
             submit_async_request(MatrixRequest::RegisterViaUiaa {
                 username: localpart,
                 password,
@@ -458,11 +460,13 @@ impl WidgetMatchEvent for RegisterScreen {
                     // ~100-200ms later to complete the transition to the main UI.
                     // Show interim feedback so the delay feels intentional.
                     self.registration_pending = false;
+                    self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
                     self.clear_form_error(cx);
                     self.show_status(cx, "Account created! Loading your account...");
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {
                     self.registration_pending = false;
+                    self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
                     self.show_form_error(cx, err);
                     self.show_status(
                         cx,

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -289,7 +289,16 @@ impl WidgetMatchEvent for RegisterScreen {
             }
         }
 
-        if submit.clicked(actions) {
+        let username_input = self.view.text_input(cx, ids!(username_input));
+        let password_input = self.view.text_input(cx, ids!(password_input));
+        let confirm_password_input = self.view.text_input(cx, ids!(confirm_password_input));
+
+        let submit_triggered = submit.clicked(actions)
+            || username_input.returned(actions).is_some()
+            || password_input.returned(actions).is_some()
+            || confirm_password_input.returned(actions).is_some();
+
+        if submit_triggered {
             if self.registration_pending {
                 return;
             }
@@ -297,9 +306,9 @@ impl WidgetMatchEvent for RegisterScreen {
                 validate_localpart, validate_passwords_match, LocalpartError, PasswordError,
             };
 
-            let username = self.view.text_input(cx, ids!(username_input)).text();
-            let password = self.view.text_input(cx, ids!(password_input)).text();
-            let confirm = self.view.text_input(cx, ids!(confirm_password_input)).text();
+            let username = username_input.text();
+            let password = password_input.text();
+            let confirm = confirm_password_input.text();
 
             let localpart = match validate_localpart(&username) {
                 Ok(l) => l,

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -266,6 +266,7 @@ impl WidgetMatchEvent for RegisterScreen {
         let submit = self.view.button(cx, ids!(submit_button));
 
         if back.clicked(actions) {
+            log!("RegisterScreen: back_button clicked -> NavigateToLogin");
             Cx::post_action(RegisterAction::NavigateToLogin);
             return;
         }
@@ -299,6 +300,14 @@ impl WidgetMatchEvent for RegisterScreen {
             || confirm_password_input.returned(actions).is_some();
 
         if submit_triggered {
+            log!(
+                "RegisterScreen: submit_triggered (pending={}) by click={} username_ret={} password_ret={} confirm_ret={}",
+                self.registration_pending,
+                submit.clicked(actions),
+                username_input.returned(actions).is_some(),
+                password_input.returned(actions).is_some(),
+                confirm_password_input.returned(actions).is_some(),
+            );
             if self.registration_pending {
                 return;
             }
@@ -376,6 +385,7 @@ impl WidgetMatchEvent for RegisterScreen {
 
             let homeserver_url = caps.base_url.clone();
 
+            log!("RegisterScreen: dispatching MatrixRequest::RegisterViaUiaa {{ username={:?}, homeserver_url={:?} }}", localpart, homeserver_url);
             self.clear_form_error(cx);
             self.show_status(cx, "Creating your account...");
             self.registration_pending = true;

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -412,7 +412,13 @@ impl WidgetMatchEvent for RegisterScreen {
         // Capability discovery results.
         for action in actions {
             match action.downcast_ref::<RegisterAction>() {
-                Some(RegisterAction::CapabilitiesDiscovered(caps)) => {
+                Some(RegisterAction::CapabilitiesDiscovered { requested_url, caps }) => {
+                    // Drop out-of-order responses: the user has since clicked
+                    // Next for a different homeserver, so this probe's answer
+                    // no longer reflects the user's intent.
+                    if self.last_discovery_input_url.as_deref() != Some(requested_url.as_str()) {
+                        continue;
+                    }
                     match caps.mode() {
                         RegisterMode::MasWebOnly => {
                             self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
@@ -463,11 +469,17 @@ impl WidgetMatchEvent for RegisterScreen {
                         }
                     }
                     self.last_discovery = Some(caps.clone());
+                    // last_discovery_input_url was set at click time; keep it
+                    // as the correlation key for future out-of-order drops.
                 }
-                Some(RegisterAction::DiscoveryFailed(err)) => {
+                Some(RegisterAction::DiscoveryFailed { requested_url, error }) => {
+                    // Same out-of-order drop as CapabilitiesDiscovered.
+                    if self.last_discovery_input_url.as_deref() != Some(requested_url.as_str()) {
+                        continue;
+                    }
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
                     self.clear_form_error(cx);
-                    self.show_status(cx, &format!("Could not reach that server: {err}"));
+                    self.show_status(cx, &format!("Could not reach that server: {error}"));
                     self.last_discovery = None;
                     self.last_discovery_input_url = None;
                 }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -274,6 +274,15 @@ impl WidgetMatchEvent for RegisterScreen {
         let submit = self.view.button(cx, ids!(submit_button));
 
         if back.clicked(actions) {
+            // Don't let the user abandon the screen mid-POST. The request is
+            // already in login_sender's queue and can't be cancelled — if it
+            // succeeds after we navigate away, LoginAction::LoginSuccess
+            // would auto-log them into an account they thought they were
+            // walking away from. Swallow the click until we hear the
+            // terminal RegisterAction (Success or Failed).
+            if self.registration_pending {
+                return;
+            }
             Cx::post_action(RegisterAction::NavigateToLogin);
             return;
         }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -255,6 +255,17 @@ pub struct RegisterScreen {
     /// "Create Account" can't queue multiple requests into `login_sender`
     /// (mirrors the `sso_pending` pattern elsewhere in the app).
     #[rust] registration_pending: bool,
+    /// True between `RegistrationSuccess` and the terminal `LoginSuccess` /
+    /// `LoginFailure`. The account already exists on the server at this point;
+    /// what we're waiting on is `SyncService::build()`. If that build fails
+    /// (e.g. network flapped right after register returned 200), it emits
+    /// `LoginAction::LoginFailure`, but `app.rs` only acts on that failure
+    /// when not in `LoggedOut` state — and we haven't reached `LoginSuccess`
+    /// yet. Without a local `LoginFailure` arm the screen would stay stuck on
+    /// "Account created! Loading your account..." forever. This flag gates
+    /// that arm so we only react to failures from OUR own sync-startup phase,
+    /// not unrelated `LoginFailure`s that might reach a visible register screen.
+    #[rust] awaiting_sync_startup: bool,
 }
 
 impl Widget for RegisterScreen {
@@ -430,13 +441,33 @@ impl WidgetMatchEvent for RegisterScreen {
             return;
         }
 
-        // Final cleanup when the sync service finishes building and app.rs
-        // swaps us out for the main UI. Mirrors the register-screen-visible
-        // side of what LoginScreen does in its own LoginSuccess arm.
+        // Terminal handling for LoginAction emitted by the post-register
+        // sync-startup phase. Either LoginSuccess (happy path, app.rs swaps
+        // us out) or LoginFailure (SyncService::build failed; app.rs skips
+        // the failure because state is still LoggedOut, so WE must recover).
         for action in actions {
-            if let Some(LoginAction::LoginSuccess) = action.downcast_ref() {
-                self.view.view(cx, ids!(status_area)).set_visible(cx, false);
-                self.view.label(cx, ids!(status_label)).set_text(cx, "");
+            match action.downcast_ref::<LoginAction>() {
+                Some(LoginAction::LoginSuccess) => {
+                    self.awaiting_sync_startup = false;
+                    self.view.view(cx, ids!(status_area)).set_visible(cx, false);
+                    self.view.label(cx, ids!(status_label)).set_text(cx, "");
+                }
+                Some(LoginAction::LoginFailure(msg)) if self.awaiting_sync_startup => {
+                    // Account WAS created on the server — do not frame this
+                    // as a registration failure. The user's recovery path is
+                    // to go back to the login screen and sign in manually.
+                    // Back button works here because registration_pending
+                    // was cleared on RegistrationSuccess.
+                    self.awaiting_sync_startup = false;
+                    self.show_status(
+                        cx,
+                        &format!(
+                            "Your account was created, but we couldn't start a session:\n{msg}\n\n\
+                             Please click ← Back to Login and sign in with your new account."
+                        ),
+                    );
+                }
+                _ => {}
             }
         }
 
@@ -548,6 +579,10 @@ impl WidgetMatchEvent for RegisterScreen {
                     // the screen would otherwise look frozen. The LoginSuccess
                     // arm below clears it for a clean re-entry state.
                     self.show_status(cx, "Account created! Loading your account...");
+                    // Enter the post-register wait state so a possible
+                    // LoginFailure from SyncService::build() is routed to our
+                    // recovery arm instead of being silently swallowed.
+                    self.awaiting_sync_startup = true;
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {
                     self.registration_pending = false;

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -11,6 +11,7 @@
 
 use makepad_widgets::*;
 
+use crate::login::login_screen::LoginAction;
 use crate::register::{HsCapabilities, RegisterAction, RegisterMode};
 use crate::register::validation::{normalize_homeserver_url, HomeserverUrlError};
 use crate::sliding_sync::{submit_async_request, MatrixRequest};
@@ -429,6 +430,16 @@ impl WidgetMatchEvent for RegisterScreen {
             return;
         }
 
+        // Final cleanup when the sync service finishes building and app.rs
+        // swaps us out for the main UI. Mirrors the register-screen-visible
+        // side of what LoginScreen does in its own LoginSuccess arm.
+        for action in actions {
+            if let Some(LoginAction::LoginSuccess) = action.downcast_ref() {
+                self.view.view(cx, ids!(status_area)).set_visible(cx, false);
+                self.view.label(cx, ids!(status_label)).set_text(cx, "");
+            }
+        }
+
         // Capability discovery results.
         for action in actions {
             match action.downcast_ref::<RegisterAction>() {
@@ -511,10 +522,31 @@ impl WidgetMatchEvent for RegisterScreen {
                     // Credentials accepted; the sync service is still building
                     // in the background and LoginAction::LoginSuccess will fire
                     // ~100-200ms later to complete the transition to the main UI.
-                    // Show interim feedback so the delay feels intentional.
+                    //
+                    // Reset scope is aggressive because this same RegisterScreen
+                    // widget instance will be reused if the user later chooses
+                    // "Sign up here" again (e.g. after a logout). Password input
+                    // values especially must not linger in widget memory.
                     self.registration_pending = false;
                     self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
+
+                    // Clear sensitive + form state. Done before hiding the form
+                    // so the text is gone from the underlying widgets even if
+                    // someone peeks at them via inspector tooling.
+                    self.view.text_input(cx, ids!(password_input)).set_text(cx, "");
+                    self.view.text_input(cx, ids!(confirm_password_input)).set_text(cx, "");
+                    self.view.text_input(cx, ids!(username_input)).set_text(cx, "");
+                    self.view.text_input(cx, ids!(homeserver_input)).set_text(cx, "");
+
+                    self.last_discovery = None;
+                    self.last_discovery_input_url = None;
+                    self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
                     self.clear_form_error(cx);
+
+                    // Keep status_label visible as bridging feedback during the
+                    // ~100-200ms gap before LoginAction::LoginSuccess arrives —
+                    // the screen would otherwise look frozen. The LoginSuccess
+                    // arm below clears it for a clean re-entry state.
                     self.show_status(cx, "Account created! Loading your account...");
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -242,29 +242,15 @@ script_mod! {
 pub struct RegisterScreen {
     #[deref] view: View,
     #[rust] last_discovery: Option<HsCapabilities>,
-    /// Normalized user-typed URL that produced `last_discovery`.
-    ///
-    /// Stored separately from `caps.base_url` because `.well-known/matrix/client`
-    /// frequently returns a different string than the user typed (e.g. adds a
-    /// trailing slash, rewrites to a federation host). Comparing the current
-    /// input to `caps.base_url` causes false "homeserver changed" errors on
-    /// every well-known-delegated server. We compare against this instead.
+    /// Normalized user-typed URL that produced `last_discovery`. Kept
+    /// separate from `caps.base_url` because `.well-known` may rewrite the
+    /// host; comparing current input against `base_url` causes false mismatches.
     #[rust] last_discovery_input_url: Option<String>,
-    /// True between submit click and the terminal `RegistrationSuccess` /
-    /// `RegistrationFailed` action. Gates duplicate submits so repeat-clicking
-    /// "Create Account" can't queue multiple requests into `login_sender`
-    /// (mirrors the `sso_pending` pattern elsewhere in the app).
+    /// Gates duplicate submits; mirrors `sso_pending`.
     #[rust] registration_pending: bool,
-    /// True between `RegistrationSuccess` and the terminal `LoginSuccess` /
-    /// `LoginFailure`. The account already exists on the server at this point;
-    /// what we're waiting on is `SyncService::build()`. If that build fails
-    /// (e.g. network flapped right after register returned 200), it emits
-    /// `LoginAction::LoginFailure`, but `app.rs` only acts on that failure
-    /// when not in `LoggedOut` state — and we haven't reached `LoginSuccess`
-    /// yet. Without a local `LoginFailure` arm the screen would stay stuck on
-    /// "Account created! Loading your account..." forever. This flag gates
-    /// that arm so we only react to failures from OUR own sync-startup phase,
-    /// not unrelated `LoginFailure`s that might reach a visible register screen.
+    /// Gates the `LoginFailure` arm: true only during the post-register
+    /// `SyncService::build()` window, which `app.rs` can't recover from
+    /// because state is still `LoggedOut`.
     #[rust] awaiting_sync_startup: bool,
 }
 
@@ -286,12 +272,8 @@ impl WidgetMatchEvent for RegisterScreen {
         let submit = self.view.button(cx, ids!(submit_button));
 
         if back.clicked(actions) {
-            // Don't let the user abandon the screen mid-POST. The request is
-            // already in login_sender's queue and can't be cancelled — if it
-            // succeeds after we navigate away, LoginAction::LoginSuccess
-            // would auto-log them into an account they thought they were
-            // walking away from. Swallow the click until we hear the
-            // terminal RegisterAction (Success or Failed).
+            // In-flight request can't be cancelled; leaving now would
+            // auto-log the user into the account on its eventual success.
             if self.registration_pending {
                 return;
             }
@@ -303,22 +285,12 @@ impl WidgetMatchEvent for RegisterScreen {
             let raw = self.view.text_input(cx, ids!(homeserver_input)).text();
             match normalize_homeserver_url(&raw) {
                 Ok(url) => {
-                    // Invalidate any prior probe state BEFORE the new request
-                    // goes out. A submit click landing in the window between
-                    // Next and the fresh response must not be allowed to fire
-                    // a register request against the previous server. Fix 1
-                    // already drops the late CapabilitiesDiscovered action;
-                    // this clears the pre-existing cache the user could
-                    // otherwise still submit against.
+                    // Prevent submit-against-stale-server in the Next→response window.
                     self.last_discovery = None;
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
                     self.clear_form_error(cx);
 
                     self.show_status(cx, "Checking server capabilities...");
-                    // Capture the user-intent URL for the stale-cache check at
-                    // submit time. We must NOT compare against caps.base_url —
-                    // .well-known may return a different string for the same
-                    // server (trailing slash, federation host rewrite, etc).
                     self.last_discovery_input_url = Some(url.clone());
                     submit_async_request(MatrixRequest::DiscoverHomeserverCapabilities { url });
                 }
@@ -441,10 +413,6 @@ impl WidgetMatchEvent for RegisterScreen {
             return;
         }
 
-        // Terminal handling for LoginAction emitted by the post-register
-        // sync-startup phase. Either LoginSuccess (happy path, app.rs swaps
-        // us out) or LoginFailure (SyncService::build failed; app.rs skips
-        // the failure because state is still LoggedOut, so WE must recover).
         for action in actions {
             match action.downcast_ref::<LoginAction>() {
                 Some(LoginAction::LoginSuccess) => {
@@ -453,11 +421,7 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.view.label(cx, ids!(status_label)).set_text(cx, "");
                 }
                 Some(LoginAction::LoginFailure(msg)) if self.awaiting_sync_startup => {
-                    // Account WAS created on the server — do not frame this
-                    // as a registration failure. The user's recovery path is
-                    // to go back to the login screen and sign in manually.
-                    // Back button works here because registration_pending
-                    // was cleared on RegistrationSuccess.
+                    // Account already exists on the server; don't frame as registration failure.
                     self.awaiting_sync_startup = false;
                     self.show_status(
                         cx,
@@ -475,9 +439,7 @@ impl WidgetMatchEvent for RegisterScreen {
         for action in actions {
             match action.downcast_ref::<RegisterAction>() {
                 Some(RegisterAction::CapabilitiesDiscovered { requested_url, caps }) => {
-                    // Drop out-of-order responses: the user has since clicked
-                    // Next for a different homeserver, so this probe's answer
-                    // no longer reflects the user's intent.
+                    // Drop out-of-order response from a superseded Next click.
                     if self.last_discovery_input_url.as_deref() != Some(requested_url.as_str()) {
                         continue;
                     }
@@ -531,11 +493,8 @@ impl WidgetMatchEvent for RegisterScreen {
                         }
                     }
                     self.last_discovery = Some(caps.clone());
-                    // last_discovery_input_url was set at click time; keep it
-                    // as the correlation key for future out-of-order drops.
                 }
                 Some(RegisterAction::DiscoveryFailed { requested_url, error }) => {
-                    // Same out-of-order drop as CapabilitiesDiscovered.
                     if self.last_discovery_input_url.as_deref() != Some(requested_url.as_str()) {
                         continue;
                     }
@@ -561,9 +520,7 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.registration_pending = false;
                     self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
 
-                    // Clear sensitive + form state. Done before hiding the form
-                    // so the text is gone from the underlying widgets even if
-                    // someone peeks at them via inspector tooling.
+                    // Clear passwords before hiding so they don't linger in widget memory.
                     self.view.text_input(cx, ids!(password_input)).set_text(cx, "");
                     self.view.text_input(cx, ids!(confirm_password_input)).set_text(cx, "");
                     self.view.text_input(cx, ids!(username_input)).set_text(cx, "");
@@ -574,14 +531,8 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
                     self.clear_form_error(cx);
 
-                    // Keep status_label visible as bridging feedback during the
-                    // ~100-200ms gap before LoginAction::LoginSuccess arrives —
-                    // the screen would otherwise look frozen. The LoginSuccess
-                    // arm below clears it for a clean re-entry state.
+                    // Bridging feedback during the ~100-200ms SyncService::build window.
                     self.show_status(cx, "Account created! Loading your account...");
-                    // Enter the post-register wait state so a possible
-                    // LoginFailure from SyncService::build() is routed to our
-                    // recovery arm instead of being silently swallowed.
                     self.awaiting_sync_startup = true;
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -16,6 +16,10 @@ use crate::register::{HsCapabilities, RegisterAction, RegisterMode};
 use crate::register::validation::{normalize_homeserver_url, HomeserverUrlError};
 use crate::sliding_sync::{submit_async_request, MatrixRequest};
 
+fn can_start_capability_discovery(registration_pending: bool, awaiting_sync_startup: bool) -> bool {
+    !registration_pending && !awaiting_sync_startup
+}
+
 script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
@@ -248,6 +252,8 @@ pub struct RegisterScreen {
     #[rust] last_discovery_input_url: Option<String>,
     /// Gates duplicate submits; mirrors `sso_pending`.
     #[rust] registration_pending: bool,
+    /// Drives next_button "Checking..." feedback during slow `.well-known` probes.
+    #[rust] discovery_pending: bool,
     /// Gates the `LoginFailure` arm: true only during the post-register
     /// `SyncService::build()` window, which `app.rs` can't recover from
     /// because state is still `LoggedOut`.
@@ -277,11 +283,16 @@ impl WidgetMatchEvent for RegisterScreen {
             if self.registration_pending {
                 return;
             }
+            self.discovery_pending = false;
+            self.view.button(cx, ids!(next_button)).set_text(cx, "Next");
             Cx::post_action(RegisterAction::NavigateToLogin);
             return;
         }
 
         if next.clicked(actions) {
+            if !can_start_capability_discovery(self.registration_pending, self.awaiting_sync_startup) {
+                return;
+            }
             let raw = self.view.text_input(cx, ids!(homeserver_input)).text();
             match normalize_homeserver_url(&raw) {
                 Ok(url) => {
@@ -291,6 +302,8 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.clear_form_error(cx);
 
                     self.show_status(cx, "Checking server capabilities...");
+                    self.discovery_pending = true;
+                    self.view.button(cx, ids!(next_button)).set_text(cx, "Checking...");
                     self.last_discovery_input_url = Some(url.clone());
                     submit_async_request(MatrixRequest::DiscoverHomeserverCapabilities { url });
                 }
@@ -363,17 +376,8 @@ impl WidgetMatchEvent for RegisterScreen {
                 return;
             };
 
-            // Guard against a stale capability cache: if the user edited the
-            // homeserver input after clicking Next, we must re-probe. We compare
-            // the current normalized input against the input that PRODUCED the
-            // discovery (`last_discovery_input_url`), NOT `caps.base_url` — the
-            // latter may have been rewritten by `.well-known/matrix/client`
-            // (trailing slash, federation host) and a strict string compare
-            // would false-trigger on every well-known-delegated server.
-            //
-            // On mismatch we clear the cache + show an error but keep the form
-            // visible so the user can see the message and react — hiding the
-            // form also hides `form_error_label` (it lives inside the form).
+            // Stale-cache check: compare current input to the input that PRODUCED
+            // the cache, not `caps.base_url` (which `.well-known` may rewrite).
             let current_raw = self.view.text_input(cx, ids!(homeserver_input)).text();
             let current_url = match normalize_homeserver_url(&current_raw) {
                 Ok(u) => u,
@@ -423,6 +427,7 @@ impl WidgetMatchEvent for RegisterScreen {
                 Some(LoginAction::LoginFailure(msg)) if self.awaiting_sync_startup => {
                     // Account already exists on the server; don't frame as registration failure.
                     self.awaiting_sync_startup = false;
+                    Cx::post_action(LoginAction::ClearFailureState);
                     self.show_status(
                         cx,
                         &format!(
@@ -435,7 +440,6 @@ impl WidgetMatchEvent for RegisterScreen {
             }
         }
 
-        // Capability discovery results.
         for action in actions {
             match action.downcast_ref::<RegisterAction>() {
                 Some(RegisterAction::CapabilitiesDiscovered { requested_url, caps }) => {
@@ -443,6 +447,9 @@ impl WidgetMatchEvent for RegisterScreen {
                     if self.last_discovery_input_url.as_deref() != Some(requested_url.as_str()) {
                         continue;
                     }
+                    self.discovery_pending = false;
+                    self.view.button(cx, ids!(next_button)).set_text(cx, "Next");
+                    let caps = caps.as_ref();
                     match caps.mode() {
                         RegisterMode::MasWebOnly => {
                             self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
@@ -498,29 +505,23 @@ impl WidgetMatchEvent for RegisterScreen {
                     if self.last_discovery_input_url.as_deref() != Some(requested_url.as_str()) {
                         continue;
                     }
+                    self.discovery_pending = false;
+                    self.view.button(cx, ids!(next_button)).set_text(cx, "Next");
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
                     self.clear_form_error(cx);
                     self.show_status(cx, &format!("Could not reach that server: {error}"));
                     self.last_discovery = None;
                     self.last_discovery_input_url = None;
                 }
-                Some(RegisterAction::RegistrationSubmitted) => {
-                    // Feedback already shown by show_status("Creating your account...")
-                    // at click time; nothing additional to do here.
-                }
+                Some(RegisterAction::RegistrationSubmitted) => {}
                 Some(RegisterAction::RegistrationSuccess) => {
-                    // Credentials accepted; the sync service is still building
-                    // in the background and LoginAction::LoginSuccess will fire
-                    // ~100-200ms later to complete the transition to the main UI.
-                    //
-                    // Reset scope is aggressive because this same RegisterScreen
-                    // widget instance will be reused if the user later chooses
-                    // "Sign up here" again (e.g. after a logout). Password input
-                    // values especially must not linger in widget memory.
+                    // Full reset: the same widget instance is reused on re-entry
+                    // (logout → "Sign up here"), so password fields must not linger.
                     self.registration_pending = false;
+                    self.discovery_pending = false;
                     self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
+                    self.view.button(cx, ids!(next_button)).set_text(cx, "Next");
 
-                    // Clear passwords before hiding so they don't linger in widget memory.
                     self.view.text_input(cx, ids!(password_input)).set_text(cx, "");
                     self.view.text_input(cx, ids!(confirm_password_input)).set_text(cx, "");
                     self.view.text_input(cx, ids!(username_input)).set_text(cx, "");
@@ -537,6 +538,7 @@ impl WidgetMatchEvent for RegisterScreen {
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {
                     self.registration_pending = false;
+                    self.awaiting_sync_startup = false;
                     self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
                     self.show_form_error(cx, err);
                     self.show_status(
@@ -558,13 +560,35 @@ impl RegisterScreen {
     }
 
     fn show_form_error(&mut self, cx: &mut Cx, message: &str) {
-        self.view.label(cx, ids!(form_error_label)).set_text(cx, message);
-        self.view.view(cx, ids!(form_error_label)).set_visible(cx, true);
+        let label = self.view.label(cx, ids!(form_error_label));
+        label.set_text(cx, message);
+        label.set_visible(cx, true);
         self.view.redraw(cx);
     }
 
     fn clear_form_error(&mut self, cx: &mut Cx) {
-        self.view.label(cx, ids!(form_error_label)).set_text(cx, "");
-        self.view.view(cx, ids!(form_error_label)).set_visible(cx, false);
+        let label = self.view.label(cx, ids!(form_error_label));
+        label.set_text(cx, "");
+        label.set_visible(cx, false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::can_start_capability_discovery;
+
+    #[test]
+    fn capability_discovery_blocks_while_registration_request_is_in_flight() {
+        assert!(!can_start_capability_discovery(true, false));
+    }
+
+    #[test]
+    fn capability_discovery_blocks_while_waiting_for_post_register_sync_startup() {
+        assert!(!can_start_capability_discovery(false, true));
+    }
+
+    #[test]
+    fn capability_discovery_allows_idle_register_screen() {
+        assert!(can_start_capability_discovery(false, false));
     }
 }

--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -432,6 +432,7 @@ impl RegisterScreen {
     }
 
     fn clear_form_error(&mut self, cx: &mut Cx) {
+        self.view.label(cx, ids!(form_error_label)).set_text(cx, "");
         self.view.view(cx, ids!(form_error_label)).set_visible(cx, false);
     }
 }

--- a/src/register/uiaa.rs
+++ b/src/register/uiaa.rs
@@ -1,0 +1,57 @@
+//! UIAA stage orchestration for Phase 3a (dummy-only).
+//!
+//! `UiaaStage` is the extensibility seam: future `TermsStage`,
+//! `RegistrationTokenStage`, etc. implement this trait and get slotted into
+//! the controller without touching the sliding_sync register handler.
+
+use matrix_sdk::ruma::api::client::uiaa::{AuthData, Dummy};
+
+/// Trait every UIAA stage implements. A stage decides whether it can
+/// auto-advance (like `m.login.dummy`) or needs user input first.
+pub trait UiaaStage: Send + Sync {
+    /// The Matrix stage type string (e.g. `"m.login.dummy"`, `"m.login.terms"`).
+    fn stage_type(&self) -> &'static str;
+
+    /// If this stage requires no user input, return `Some(AuthData)` that
+    /// can be submitted immediately. Otherwise return `None` — the caller
+    /// must render UI and wait for user action.
+    fn auto_submit(&self, session: &str) -> Option<AuthData>;
+}
+
+/// `m.login.dummy` — server wants to keep the UIAA protocol shape but has no
+/// real challenge. We just echo back the session.
+pub struct DummyStage;
+
+impl UiaaStage for DummyStage {
+    fn stage_type(&self) -> &'static str {
+        "m.login.dummy"
+    }
+
+    fn auto_submit(&self, session: &str) -> Option<AuthData> {
+        let mut dummy = Dummy::new();
+        dummy.session = Some(session.to_owned());
+        Some(AuthData::Dummy(dummy))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dummy_stage_auto_submits_with_session() {
+        let stage = DummyStage;
+        let auth = stage.auto_submit("test-session-123");
+        match auth {
+            Some(AuthData::Dummy(d)) => {
+                assert_eq!(d.session.as_deref(), Some("test-session-123"))
+            }
+            other => panic!("expected Some(AuthData::Dummy), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dummy_stage_type_string_matches_matrix_spec() {
+        assert_eq!(DummyStage.stage_type(), "m.login.dummy");
+    }
+}

--- a/src/register/validation.rs
+++ b/src/register/validation.rs
@@ -2,6 +2,53 @@
 
 use url::Url;
 
+/// Errors for Matrix localpart validation. Permissive grammar — matches the
+/// historical Matrix spec (lowercase alnum + `._=-/`), not the stricter
+/// MSC3967 recommendation. Enough for Phase 3a's target servers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalpartError {
+    Empty,
+    TooLong,
+    InvalidChars,
+}
+
+/// Validate a Matrix localpart (the part before `:` in `@alice:example.com`).
+/// Returns the trimmed localpart on success.
+pub fn validate_localpart(input: &str) -> Result<String, LocalpartError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(LocalpartError::Empty);
+    }
+    if trimmed.len() > 255 {
+        return Err(LocalpartError::TooLong);
+    }
+    if !trimmed.chars().all(|c| matches!(c,
+        'a'..='z' | '0'..='9' | '.' | '_' | '=' | '-' | '/'
+    )) {
+        return Err(LocalpartError::InvalidChars);
+    }
+    Ok(trimmed.to_owned())
+}
+
+/// Password validation errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PasswordError {
+    Empty,
+    Mismatch,
+}
+
+/// Validate password + confirm-password pair. Phase 3a uses emptiness +
+/// equality checks; zxcvbn strength scoring is Phase 5 scope.
+pub fn validate_passwords_match(password: &str, confirm: &str) -> Result<(), PasswordError> {
+    if password.is_empty() || confirm.is_empty() {
+        return Err(PasswordError::Empty);
+    }
+    if password != confirm {
+        return Err(PasswordError::Mismatch);
+    }
+    Ok(())
+}
+
 /// Errors returned by homeserver URL normalization.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HomeserverUrlError {
@@ -103,5 +150,53 @@ mod tests {
     fn malformed_url_is_rejected() {
         let result = normalize_homeserver_url("http://  /not a url");
         assert!(matches!(result, Err(HomeserverUrlError::Invalid)));
+    }
+
+    #[test]
+    fn localpart_valid_simple() {
+        assert!(validate_localpart("alice").is_ok());
+        assert!(validate_localpart("bob.smith").is_ok());
+        assert!(validate_localpart("user_123").is_ok());
+    }
+
+    #[test]
+    fn localpart_empty_is_rejected() {
+        assert_eq!(validate_localpart(""), Err(LocalpartError::Empty));
+        assert_eq!(validate_localpart("   "), Err(LocalpartError::Empty));
+    }
+
+    #[test]
+    fn localpart_uppercase_is_rejected() {
+        assert!(matches!(
+            validate_localpart("Alice"),
+            Err(LocalpartError::InvalidChars)
+        ));
+    }
+
+    #[test]
+    fn localpart_too_long_is_rejected() {
+        let long = "a".repeat(256);
+        assert_eq!(validate_localpart(&long), Err(LocalpartError::TooLong));
+    }
+
+    #[test]
+    fn passwords_match_accepts_equal() {
+        assert!(validate_passwords_match("hunter2", "hunter2").is_ok());
+    }
+
+    #[test]
+    fn passwords_match_rejects_empty() {
+        assert_eq!(
+            validate_passwords_match("", ""),
+            Err(PasswordError::Empty),
+        );
+    }
+
+    #[test]
+    fn passwords_match_rejects_mismatch() {
+        assert_eq!(
+            validate_passwords_match("a", "b"),
+            Err(PasswordError::Mismatch),
+        );
     }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1661,7 +1661,7 @@ async fn matrix_worker_task(
                         Ok(caps) => {
                             Cx::post_action(crate::register::RegisterAction::CapabilitiesDiscovered {
                                 requested_url,
-                                caps,
+                                caps: Box::new(caps),
                             });
                         }
                         Err(e) => {
@@ -3843,8 +3843,16 @@ async fn matrix_worker_task(
         }
     }
 
-    error!("matrix_worker_task task ended unexpectedly");
-    bail!("matrix_worker_task task ended unexpectedly")
+    if worker_shutdown_is_unexpected(is_logout_in_progress(), is_account_switch_pending()) {
+        error!("matrix_worker_task task ended unexpectedly");
+        bail!("matrix_worker_task task ended unexpectedly")
+    }
+
+    Ok(())
+}
+
+fn worker_shutdown_is_unexpected(logout_in_progress: bool, account_switch_pending: bool) -> bool {
+    !logout_in_progress && !account_switch_pending
 }
 
 async fn attach_room_to_space(client: &Client, child_room: &Room, space_id: &OwnedRoomId) -> Result<()> {
@@ -6805,10 +6813,6 @@ async fn discover_homeserver_capabilities(
             Ok(info) => (true, Some(info)),
             Err(_) => (true, None),
         }
-    } else if status == matrix_sdk::reqwest::StatusCode::FORBIDDEN
-        && body.get("errcode").and_then(|v: &Value| v.as_str()) == Some("M_FORBIDDEN")
-    {
-        (false, None)
     } else {
         (false, None)
     };
@@ -6821,4 +6825,24 @@ async fn discover_homeserver_capabilities(
         sso_providers,
         mas_signup_url,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::worker_shutdown_is_unexpected;
+
+    #[test]
+    fn worker_shutdown_is_not_unexpected_during_logout() {
+        assert!(!worker_shutdown_is_unexpected(true, false));
+    }
+
+    #[test]
+    fn worker_shutdown_is_not_unexpected_during_account_switch() {
+        assert!(!worker_shutdown_is_unexpected(false, true));
+    }
+
+    #[test]
+    fn worker_shutdown_is_unexpected_without_controlled_teardown() {
+        assert!(worker_shutdown_is_unexpected(false, false));
+    }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1668,7 +1668,6 @@ async fn matrix_worker_task(
             }
 
             MatrixRequest::RegisterViaUiaa { username, password, homeserver_url } => {
-                log!("sliding_sync: MatrixRequest::RegisterViaUiaa received, username={username:?}, homeserver_url={homeserver_url:?}");
                 Cx::post_action(crate::register::RegisterAction::RegistrationSubmitted);
                 let register_request = LoginRequest::Register(RegisterAccount {
                     user_id: username,
@@ -1676,7 +1675,6 @@ async fn matrix_worker_task(
                     homeserver: Some(homeserver_url),
                     proxy: None,
                 });
-                log!("sliding_sync: forwarding LoginRequest::Register via login_sender");
                 if let Err(e) = login_sender.send(register_request).await {
                     error!("Error sending register request to login_sender: {e:?}");
                     Cx::post_action(crate::register::RegisterAction::RegistrationFailed(

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -470,10 +470,14 @@ async fn login(
                             ))
                             .await
                         } else {
-                            bail!(unsupported_registration_flow_message(&uiaa_info.flows));
+                            let msg = unsupported_registration_flow_message(&uiaa_info.flows);
+                            Cx::post_action(crate::register::RegisterAction::RegistrationFailed(msg.clone()));
+                            bail!(msg);
                         }
                     } else {
-                        bail!(registration_uiaa_error_message(&error));
+                        let msg = registration_uiaa_error_message(&error);
+                        Cx::post_action(crate::register::RegisterAction::RegistrationFailed(msg.clone()));
+                        bail!(msg);
                     }
                 }
             }?;
@@ -485,11 +489,16 @@ async fn login(
                 );
                 enqueue_popup_notification(err_msg.clone(), PopupKind::Error, None);
                 enqueue_rooms_list_update(RoomsListUpdate::Status { status: err_msg.clone() });
+                Cx::post_action(crate::register::RegisterAction::RegistrationFailed(err_msg.clone()));
                 bail!(err_msg);
             }
 
-            finalize_authenticated_client(client, client_session, register_result.user_id.as_str(), false)
-                .await
+            let finalized = finalize_authenticated_client(client, client_session, register_result.user_id.as_str(), false)
+                .await;
+            if finalized.is_ok() {
+                Cx::post_action(crate::register::RegisterAction::RegistrationSuccess);
+            }
+            finalized
         }
 
         LoginRequest::LoginBySSOSuccess(client, client_session, is_add_account) => {
@@ -702,6 +711,16 @@ pub enum MatrixRequest {
     DiscoverHomeserverCapabilities {
         /// Already-normalized homeserver URL (has scheme, no trailing slash).
         url: String,
+    },
+    /// Register a new account on a UIAA server using the single-stage
+    /// `m.login.dummy` flow. `homeserver_url` is the already-normalized URL
+    /// from capability discovery. On success the sync service starts
+    /// automatically via the existing login_loop and `LoginAction::LoginSuccess`
+    /// fires. On failure `RegisterAction::RegistrationFailed(message)` fires.
+    RegisterViaUiaa {
+        username: String,
+        password: String,
+        homeserver_url: String,
     },
     /// Request to switch to a different logged-in account.
     SwitchAccount {
@@ -1626,6 +1645,22 @@ async fn matrix_worker_task(
                         }
                     }
                 });
+            }
+
+            MatrixRequest::RegisterViaUiaa { username, password, homeserver_url } => {
+                Cx::post_action(crate::register::RegisterAction::RegistrationSubmitted);
+                let register_request = LoginRequest::Register(RegisterAccount {
+                    user_id: username,
+                    password,
+                    homeserver: Some(homeserver_url),
+                    proxy: None,
+                });
+                if let Err(e) = login_sender.send(register_request).await {
+                    error!("Error sending register request to login_sender: {e:?}");
+                    Cx::post_action(crate::register::RegisterAction::RegistrationFailed(
+                        "Internal error: registration worker is unavailable. Please restart Robrix.".to_owned(),
+                    ));
+                }
             }
 
             MatrixRequest::SwitchAccount { user_id } => {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -434,6 +434,12 @@ async fn login(
         }
 
         LoginRequest::Register(registration) => {
+            // This arm drives BOTH signals intentionally:
+            //   - LoginAction::Status — a no-op when the login screen isn't visible
+            //     (the normal register flow); retained so the login-screen-based
+            //     LoginByCli path can still surface progress if ever re-wired.
+            //   - RegisterAction::* (dispatched at the failure sites and at the
+            //     finalize-success site below) — drives RegisterScreen state.
             let cli = Cli::from(RegisterAccount {
                 user_id: registration.user_id.clone(),
                 password: registration.password.clone(),
@@ -714,9 +720,23 @@ pub enum MatrixRequest {
     },
     /// Register a new account on a UIAA server using the single-stage
     /// `m.login.dummy` flow. `homeserver_url` is the already-normalized URL
-    /// from capability discovery. On success the sync service starts
-    /// automatically via the existing login_loop and `LoginAction::LoginSuccess`
-    /// fires. On failure `RegisterAction::RegistrationFailed(message)` fires.
+    /// from capability discovery.
+    ///
+    /// Success dispatches two actions in sequence:
+    ///   1. `RegisterAction::RegistrationSuccess` — fires immediately after
+    ///      `finalize_authenticated_client` persists the session. The
+    ///      RegisterScreen uses this to clear form state and stop showing
+    ///      the submission spinner.
+    ///   2. `LoginAction::LoginSuccess` — fires ~100-200ms later after the
+    ///      sync service finishes building. App.rs uses this to navigate
+    ///      from the register screen to the main UI, mirroring the login
+    ///      path exactly.
+    ///
+    /// Any failure dispatches a single `RegisterAction::RegistrationFailed(msg)`
+    /// with a user-displayable message.
+    ///
+    /// Proxy support is Phase 5 scope; this variant always uses the process
+    /// default proxy (if any) rather than a per-request override.
     RegisterViaUiaa {
         username: String,
         password: String,

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1656,12 +1656,19 @@ async fn matrix_worker_task(
 
             MatrixRequest::DiscoverHomeserverCapabilities { url } => {
                 tokio::spawn(async move {
+                    let requested_url = url.clone();
                     match discover_homeserver_capabilities(&url).await {
                         Ok(caps) => {
-                            Cx::post_action(crate::register::RegisterAction::CapabilitiesDiscovered(caps));
+                            Cx::post_action(crate::register::RegisterAction::CapabilitiesDiscovered {
+                                requested_url,
+                                caps,
+                            });
                         }
                         Err(e) => {
-                            Cx::post_action(crate::register::RegisterAction::DiscoveryFailed(e.to_string()));
+                            Cx::post_action(crate::register::RegisterAction::DiscoveryFailed {
+                                requested_url,
+                                error: e.to_string(),
+                            });
                         }
                     }
                 });

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1668,6 +1668,7 @@ async fn matrix_worker_task(
             }
 
             MatrixRequest::RegisterViaUiaa { username, password, homeserver_url } => {
+                log!("sliding_sync: MatrixRequest::RegisterViaUiaa received, username={username:?}, homeserver_url={homeserver_url:?}");
                 Cx::post_action(crate::register::RegisterAction::RegistrationSubmitted);
                 let register_request = LoginRequest::Register(RegisterAccount {
                     user_id: username,
@@ -1675,6 +1676,7 @@ async fn matrix_worker_task(
                     homeserver: Some(homeserver_url),
                     proxy: None,
                 });
+                log!("sliding_sync: forwarding LoginRequest::Register via login_sender");
                 if let Err(e) = login_sender.send(register_request).await {
                     error!("Error sending register request to login_sender: {e:?}");
                     Cx::post_action(crate::register::RegisterAction::RegistrationFailed(


### PR DESCRIPTION
## Summary

Phase 3a eliminates the "Phase 3 will handle the form" placeholder on UIAA servers. Adds an inline registration form + single-stage `m.login.dummy` handler so a robrix2 user can create a Matrix account on a UIAA server (e.g. local Palpo at `http://192.168.1.58:8128`) end-to-end and be auto-logged in, without leaving the app.

**Stacked on [#114](https://github.com/Project-Robius-China/robrix2/pull/114) (`fix/register`).** When #114 lands, this PR auto-rebases onto main.

## What landed

- **Inline RegistrationForm** (username, password + confirm, submit) shown only when `mode() == Uiaa`; hidden in MAS / Disabled paths
- **UIAA two-step dance handler** (`MatrixRequest::RegisterViaUiaa`) that repackages the orphan `LoginRequest::Register` branch at `src/sliding_sync.rs:435-501` — first POST gets 401+session, second POST sends `AuthData::Dummy(session)`, 200 returns access_token
- **Screen transition on success** via dual dispatch: `RegisterAction::RegistrationSuccess` (early bridging feedback) then `LoginAction::LoginSuccess` (app.rs swaps to main UI after sync service builds)
- **`UiaaStage` trait + `DummyStage`** as the extensibility seam for Terms / RegistrationToken stages in future phases
- **Validators**: `validate_localpart` (lowercase + `._=-/`), `validate_passwords_match` (empty + equality) with 7 unit tests
- **Enter-key submit** from any input (mirrors LoginScreen)

## Correctness fixes discovered during review (Codex rounds 1 & 2)

- **Out-of-order discovery responses dropped** — echo `requested_url` with `CapabilitiesDiscovered` / `DiscoveryFailed`, compare against `last_discovery_input_url`
- **Stale cache invalidated on new Next click** — clear `last_discovery` + hide form before firing a fresh probe
- **Back blocked during submit** — `registration_pending` gate so users don't get auto-logged-in after navigating away
- **Stale-cache check uses user input, not `caps.base_url`** — `.well-known` rewrites URLs, so strict string compare on `base_url` false-triggers on every well-known-delegated server
- **Post-register sync-startup failure recovery** — `awaiting_sync_startup` flag gates a `LoginFailure` arm on RegisterScreen; `app.rs` can't recover because state is still `LoggedOut`
- **Modal coherence** — `suppress_login_failure_modal` on LoginScreen + `ClearFailureState` action prevent LoginScreen's modal from stacking on top of RegisterScreen's recovery text
- **Full state reset on success** — passwords and all form fields cleared so the same widget instance is clean on re-entry after logout
- **`form_error_label` visibility** — was calling `.view()` on a Label (silently no-op), switched to `.label()` accessor

## UX polish

- **"Creating..." on submit button** while register POST is in flight
- **"Checking..." on next_button** during slow `.well-known` probes (matrix.org can take 3-5s)
- **Pending gates**: duplicate Next during submit / post-register sync window are swallowed
- **Recovery message on sync-startup failure** — "Your account was created, but we couldn't start a session... Please click ← Back to Login and sign in with your new account." (account exists on server; don't frame as registration failure)

## Architecture notes

- Lean reuse: no new matrix-sdk code, no new deps in `Cargo.toml`. Reuses `registration_request()` helper, `finalize_authenticated_client()`, and the `login_sender` channel
- 5 state fields on `RegisterScreen`, each mapped to a specific UX / race-condition concern (no speculative state)
- Box\<HsCapabilities\> shrinks the `RegisterAction` enum so tiny variants don't pay for UiaaInfo + SSO providers
- Worker-loop shutdown no longer logs a spurious error during graceful logout / account switch

## Scope (explicitly deferred)

Phase 3a is **MAS + `m.login.dummy`-only** — Synapse default requires `m.login.terms`, matrix.org requires reCAPTCHA, closed Synapses require `m.login.registration_token`. See "Intentionally Deferred" section of plan.

| Stage | Phase |
|---|---|
| `m.login.terms` | deferred (no accessible test server) |
| `m.login.registration_token` | deferred |
| Email / msisdn 3pid | Phase 4 |
| SSO buttons from `/login` | Phase 4 |
| Username availability debounce (`/register/available`) | Phase 5 |
| zxcvbn password strength | Phase 5 |
| OAuth callback for auto-login-after-MAS-signup | future phase |

## Not element-desktop parity

This PR brings us to ~55-80% of real-world Matrix servers (Palpo/Dendrite/Conduit default + MAS-delegated). It is **not feature-equivalent** to element-web's `Registration.tsx` — see scope table above.

## Test plan

- [x] `cargo test --lib register` — 21 passing (validators + uiaa + register_screen pure-fn tests)
- [x] `cargo test --lib login::login_screen` — 3 passing (modal suppression pure-fn tests)
- [x] `cargo test --lib sliding_sync` — 7 passing (includes `worker_shutdown_is_unexpected`)
- [x] `cargo clippy --lib --no-deps -- -W clippy::all` — 0 new warnings on touched files
- [x] Manual: successful UIAA registration against local Palpo → auto-login to main UI
- [x] Manual: `M_USER_IN_USE` error renders in `form_error_label` after visibility fix
- [x] Manual: regression — MAS path (alvin.meldry.com) still opens browser
- [x] Manual: regression — Disabled path shows the right message
- [x] Manual: Back during submit swallowed; re-entry shows clean screen
- [x] Manual: slow probe (matrix.org) shows "Checking..." on next_button