### PR TITLE
fix: clear Makepad DSL runtime errors and test-code clippy warnings

### DIFF
--- a/src/home/event_source_modal.rs
+++ b/src/home/event_source_modal.rs
@@ -497,6 +497,20 @@ fn starts_with_chars(chars: &[char], start: usize, needle: &str) -> bool {
     true
 }
 
+impl EventSourceModalRef {
+    /// Shows the modal with the given event details and JSON source.
+    pub fn show(
+        &self,
+        cx: &mut Cx,
+        room_id: OwnedRoomId,
+        event_id: Option<OwnedEventId>,
+        original_json: Option<String>,
+    ) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.show(cx, room_id, event_id, original_json);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::format_event_source_html;
@@ -523,19 +537,5 @@ mod tests {
 
         assert!(html.contains("&lt;b&gt;拿捏中&lt;/b&gt;&lt;br&gt;ok"));
         assert!(!html.contains("<b>拿捏中</b>"));
-    }
-}
-
-impl EventSourceModalRef {
-    /// Shows the modal with the given event details and JSON source.
-    pub fn show(
-        &self,
-        cx: &mut Cx,
-        room_id: OwnedRoomId,
-        event_id: Option<OwnedEventId>,
-        original_json: Option<String>,
-    ) {
-        let Some(mut inner) = self.borrow_mut() else { return };
-        inner.show(cx, room_id, event_id, original_json);
     }
 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1924,11 +1924,9 @@ script_mod! {
 
                         bot_card_body := HtmlOrPlaintext { }
                         bot_card_markdown := mod.widgets.BotTimelineMarkdown {
-                            visible: false
                             body: ""
                         }
                         bot_card_markdown_plain := mod.widgets.BotTimelineMarkdown {
-                            visible: false
                             use_code_block_widget: false
                             body: ""
                         }
@@ -2117,11 +2115,9 @@ script_mod! {
 
                         bot_card_body := HtmlOrPlaintext { }
                         bot_card_markdown := mod.widgets.BotTimelineMarkdown {
-                            visible: false
                             body: ""
                         }
                         bot_card_markdown_plain := mod.widgets.BotTimelineMarkdown {
-                            visible: false
                             use_code_block_widget: false
                             body: ""
                         }
@@ -11000,7 +10996,7 @@ mod tests {
         streaming_messages.insert(missing_event_id.clone(), make_state("missing"));
 
         let event_ids = vec![None, Some(event_id_a.as_ref()), Some(event_id_b.as_ref())];
-        refresh_stream_indices(event_ids.into_iter(), &mut streaming_messages);
+        refresh_stream_indices(event_ids, &mut streaming_messages);
 
         assert_eq!(streaming_messages[&event_id_a].timeline_index, Some(1));
         assert_eq!(streaming_messages[&missing_event_id].timeline_index, None);
@@ -11014,7 +11010,7 @@ mod tests {
         finished.is_live = false;
         finished.last_update_time = Instant::now() - Duration::from_secs(29);
 
-        let timeout = next_stream_timeout([&live, &finished].into_iter()).unwrap();
+        let timeout = next_stream_timeout([&live, &finished]).unwrap();
 
         assert!(timeout <= Duration::from_secs(1));
     }

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -557,7 +557,6 @@ script_mod! {
                         empty_text: "Filter this space..."
                     }
                 }
-                text: ""
             }
             
             parent_space_row := View {

--- a/src/room/member_search.rs
+++ b/src/room/member_search.rs
@@ -1083,7 +1083,7 @@ mod tests {
         assert_eq!(generate_sort_key("@@@"), (2, "@@@".to_string()));
 
         // Test ordering: alphabetic -> numeric -> symbols
-        let mut names = vec![
+        let mut names = [
             ("!!!alice", generate_sort_key("!!!alice")),
             ("0user", generate_sort_key("0user")),
             ("alice", generate_sort_key("alice")),

--- a/src/settings/bot_settings.rs
+++ b/src/settings/bot_settings.rs
@@ -604,8 +604,10 @@ mod tests {
 
     #[test]
     fn test_app_service_health_uses_custom_octos_service_url_when_configured() {
-        let mut bot_settings = BotSettingsState::default();
-        bot_settings.octos_service_url = "https://octos.example.com:9443".into();
+        let bot_settings = BotSettingsState {
+            octos_service_url: "https://octos.example.com:9443".into(),
+            ..Default::default()
+        };
 
         assert_eq!(
             bot_settings.resolved_octos_service_url(),
@@ -692,8 +694,10 @@ mod tests {
 
     #[test]
     fn test_app_service_health_check_is_ui_only() {
-        let mut bot_settings = BotSettingsState::default();
-        bot_settings.enabled = true;
+        let bot_settings = BotSettingsState {
+            enabled: true,
+            ..Default::default()
+        };
         let before = bot_settings.clone();
 
         let mut state = OctosHealthState::default();

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -55,6 +55,10 @@ script_mod! {
         font_size: (10),
     }
 
+    mod.widgets.BOLD_TEXT = theme.font_bold {
+        font_size: (13),
+    }
+
     mod.widgets.TEXT_SUB = theme.font_regular {
         font_size: (10),
     }


### PR DESCRIPTION
## Summary

Fixes the 8 Makepad DSL runtime errors visible in the startup log (`BOLD_TEXT not found in scope`, `property text not defined on type`, `property visible not defined on type`), plus the 6 clippy warnings in test code.

### Root causes

1. **`BOLD_TEXT` token was never declared.** `shared/styles.rs` defines `TITLE_TEXT` / `REGULAR_TEXT` but no bold variant, yet `mentionable_text_input.rs` references `BOLD_TEXT` at 3 sites (UserListItem, RoomMentionListItem, SlashCommandListItem). Added `mod.widgets.BOLD_TEXT = theme.font_bold { font_size: (13) }` alongside the existing tokens.
2. **Orphan `text: \"\"`** on `space_lobby.rs:560` was sitting at the `space_info_row := View {}` level — `View` has no `text` property. Leftover from a refactor; deleted.
3. **`visible: false` on `BotTimelineMarkdown`** (4 sites in `room_screen.rs`). `Markdown` does not expose `visible` in its DSL schema — only `View`-derived widgets do (which is why the sibling `bot_metadata_footer := View { visible: false }` passes fine). The Rust draw path at `room_screen.rs:9348-9350` already calls `set_visible()` on every pass to toggle the three body renderers (`bot_card_body` / `bot_card_markdown` / `bot_card_markdown_plain`), so the DSL default was redundant. Removed.

### Clippy cleanup (test code only)

- `settings/bot_settings.rs`: 2x `field_reassign_with_default` → struct initializer syntax
- `home/event_source_modal.rs`: `items_after_test_module` → moved `impl EventSourceModalRef` above `#[cfg(test)] mod tests`
- `home/room_screen.rs`: 2x `useless_conversion` → dropped redundant `.into_iter()` (params already take `IntoIterator`)
- `room/member_search.rs`: `useless_vec` → array literal for the sort-order fixture

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test --lib settings::bot_settings` — 9/9 pass
- [x] `cargo test --lib home::event_source_modal` — 2/2 pass
- [x] `cargo test --lib room::member_search` — 20/20 pass
- [x] `cargo run --release`: startup log no longer contains any `not found in scope` / `property ... not defined on type` entries