### PR TITLE
fix(space): keep SpaceLobbyEntry selected state in sync

### DIFF
--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1595,6 +1595,17 @@ impl Widget for RoomsList {
         let app_state = scope.data.get::<AppState>().unwrap();
         // Update the currently-selected room from the AppState data.
         self.current_active_room = app_state.selected_room.clone();
+        let is_space_lobby_selected = self.selected_space.as_ref()
+            .is_some_and(|selected_space|
+                self.current_active_room.as_ref()
+                    .is_some_and(|active_room|
+                        matches!(active_room, SelectedRoom::Space { space_name_id }
+                            if space_name_id.room_id() == selected_space.room_id()
+                        )
+                    )
+            );
+        self.view.space_lobby_entry(cx, ids!(space_lobby_entry))
+            .set_selected(cx, is_space_lobby_selected);
         let mut app_state_for_item_scope = app_state.clone();
 
         // Based on the various displayed room lists and is_expanded state of each room header,

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -191,6 +191,25 @@ script_mod! {
                     }
                 }
             }
+            active: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Snap}
+                    apply: {
+                        draw_bg: {active: 0.0}
+                        space_lobby_label: { draw_text: {active: 0.0} }
+                        icon: { draw_icon: {active: 0.0} }
+                    }
+                }
+                on: AnimatorState{
+                    from: {all: Snap}
+                    apply: {
+                        draw_bg: {active: 1.0}
+                        space_lobby_label: { draw_text: {active: 1.0} }
+                        icon: { draw_icon: {active: 1.0} }
+                    }
+                }
+            }
         }
     }
 
@@ -691,6 +710,18 @@ impl Widget for SpaceLobbyEntry {
         self.view.label(cx, ids!(space_lobby_label))
             .set_text(cx, tr_key(app_language, "space_lobby.entry.explore_space"));
         self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl SpaceLobbyEntry {
+    fn set_selected(&mut self, cx: &mut Cx, is_selected: bool) {
+        self.animator_toggle(cx, is_selected, Animate::No, ids!(active.on), ids!(active.off));
+    }
+}
+impl SpaceLobbyEntryRef {
+    pub fn set_selected(&self, cx: &mut Cx, is_selected: bool) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.set_selected(cx, is_selected);
     }
 }
 


### PR DESCRIPTION
## Summary
- add persistent `active` animator states to `SpaceLobbyEntry`
- add `set_selected()` API on `SpaceLobbyEntryRef`
- sync `SpaceLobbyEntry` selected visual state from `RoomsList` based on current space + active room

## Root Cause
`SpaceLobbyEntry` only had hover animation and no persistent selected-state binding, so Space mode could appear visually unselected or inconsistent.

## Validation
- cargo build

## Scope
- src/home/space_lobby.rs
- src/home/rooms_list.rs