### PR TITLE
Fix non-destructive auto-login restore

### DIFF
--- a/specs/task-restore-session-error-policy.spec.md
+++ b/specs/task-restore-session-error-policy.spec.md
@@ -1,0 +1,131 @@
+spec: task
+name: "Typed Restore Session Error Policy"
+inherits: project
+tags: [bugfix, login, persistence, matrix, restore-session]
+---
+
+## Intent
+
+Make startup auto-login recovery non-destructive unless Robrix has evidence that the saved session is unrecoverable. Today every `restore_session` error deletes both the saved session and `latest_user_id.txt`, so transient homeserver, proxy, Docker, Palpo, endpoint, or Matrix SDK client-build failures become permanent auto-login loss. This task introduces typed restore errors and applies explicit cleanup rules so Robrix keeps retryable sessions while still removing stale pointers, corrupt local files, and confirmed invalid tokens.
+
+## Constraints
+
+- Do not run `cargo fmt` or `rustfmt`.
+- Do not add new dependencies.
+- Do not change explicit logout cleanup behavior.
+- Do not require Palpo to already implement `GET /_matrix/client/v3/account/whoami`; Robrix must treat a `404` from `whoami` as server/endpoint failure, not as token revocation.
+- Do not classify arbitrary HTTP 4xx/5xx responses as invalid tokens. Only `M_UNKNOWN_TOKEN`, `M_MISSING_TOKEN`, or SDK `SessionChange::UnknownToken` prove token invalidity.
+- Do not print or log access tokens, refresh tokens, or session passphrases.
+
+## Decisions
+
+- `persistence::restore_session` returns a typed error enum instead of `anyhow::Error`.
+- The typed enum distinguishes at least these categories: no latest user, missing session file, unreadable session file, corrupt session JSON, Matrix client build failure, SDK restore failure, invalid token, and failure to write `latest_user_id.txt`.
+- Startup restore failure policy lives in `src/sliding_sync.rs`; filesystem classification and archive helpers live in `src/persistence/matrix_state.rs`.
+- `MissingSessionFile` deletes only `latest_user_id.txt` when it points at the missing session user.
+- `CorruptSessionFile` renames the session file to a `.bad` archive path and deletes `latest_user_id.txt` when it points at that user.
+- `ClientBuild`, generic SDK restore errors, non-token `whoami` failures, and sync-service non-token failures preserve the session file, Matrix store, and `latest_user_id.txt`.
+- Startup restore must not require a proactive `whoami()` validation request to succeed; invalid tokens are still handled by SDK restore, `SyncService::build()`, or `SessionChange::UnknownToken`.
+- Confirmed token invalidation still calls the existing `clear_persisted_session(...)` path.
+- UI messaging for retryable restore failures must tell the user that Robrix can retry on the next startup after the server or network issue is fixed.
+
+## Boundaries
+
+### Allowed Changes
+
+- src/persistence/matrix_state.rs
+- src/persistence/mod.rs
+- src/sliding_sync.rs
+- specs/task-restore-session-error-policy.spec.md
+
+### Forbidden
+
+- Cargo.toml
+- Cargo.lock
+- src/logout/**
+- Any Palpo or deployment source under `palpo-and-octos-deploy/**`
+- Running `cargo fmt` or `rustfmt`
+- Replacing the Matrix SDK restore flow with raw HTTP requests
+
+## Out of Scope
+
+- Implementing Palpo's `whoami` endpoint.
+- Changing Matrix SDK source code.
+- Changing explicit logout, account deletion, or user-initiated session reset behavior.
+- Reworking account switching beyond applying the same non-destructive restore policy where it calls `restore_session`.
+- Adding telemetry or remote diagnostics.
+
+## Completion Criteria
+
+Scenario: Startup client-build failure preserves auto-login data
+  Test: restore_session_policy_preserves_data_for_client_build_failure
+  Level: unit
+  Test Double: construct a typed `RestoreSessionError::ClientBuild` or equivalent policy input; do not contact a real homeserver
+  Given a saved session and `latest_user_id.txt` for "@alice:example.org"
+  When startup restore fails with a Matrix client build or homeserver discovery error
+  Then Robrix does not delete the session file
+  And Robrix does not delete the Matrix store directory
+  And Robrix does not delete `latest_user_id.txt`
+  And the UI message says the user can retry after fixing server or network availability
+
+Scenario: Retryable whoami validation failure does not revoke the local session
+  Test: whoami_404_is_retryable_restore_validation_failure
+  Level: unit
+  Test Double: fake validation error carrying HTTP 404 without `M_UNKNOWN_TOKEN` or `M_MISSING_TOKEN`
+  Given a restored client whose `whoami()` validation returns a retryable non-token error such as timeout or HTTP 404
+  When startup validates the restored session
+  Then Robrix treats the error as retryable server or endpoint failure
+  And Robrix does not call `clear_persisted_session`
+  And Robrix does not delete `latest_user_id.txt`
+
+Scenario: Missing session file removes only the stale latest-user pointer
+  Test: restore_session_policy_clears_latest_user_for_missing_session_file
+  Level: filesystem unit
+  Test Double: temporary app data directory or injectable path rooted under a test-only directory
+  Given `latest_user_id.txt` points to "@alice:example.org"
+  And the session file for "@alice:example.org" does not exist
+  When startup restore classifies the error as `MissingSessionFile`
+  Then Robrix deletes `latest_user_id.txt`
+  And Robrix does not attempt to delete a Matrix store path recovered from the missing session file
+
+Scenario: Corrupt session JSON is archived before latest-user pointer removal
+  Test: corrupt_session_file_is_archived_and_latest_user_is_cleared
+  Level: filesystem unit
+  Test Double: temporary app data directory or injectable path rooted under a test-only directory
+  Given `latest_user_id.txt` points to "@alice:example.org"
+  And the session file for "@alice:example.org" contains invalid JSON
+  When startup restore classifies the error as `CorruptSessionFile`
+  Then Robrix renames the original session file to a `.bad` archive path
+  And Robrix deletes `latest_user_id.txt`
+  And Robrix does not delete the Matrix store directory
+
+Scenario: Confirmed invalid token still clears persisted session
+  Test: invalid_token_restore_policy_clears_session_and_latest_user
+  Level: unit
+  Test Double: fake validation, sync-service, or session-change error carrying `M_UNKNOWN_TOKEN` or `M_MISSING_TOKEN`
+  Given a saved session and `latest_user_id.txt` for "@alice:example.org"
+  When `whoami()`, `SyncService::build()`, or `SessionChange::UnknownToken` reports `M_UNKNOWN_TOKEN` or `M_MISSING_TOKEN`
+  Then Robrix calls `clear_persisted_session` for "@alice:example.org"
+  And the session file is deleted
+  And `latest_user_id.txt` is deleted if it points at "@alice:example.org"
+  And the user is asked to log in again
+
+Scenario: Account-switch restore failure is non-destructive for retryable errors
+  Test: account_switch_restore_retryable_error_preserves_target_session
+  Level: unit
+  Test Double: construct a typed retryable restore error for the target account; do not contact a real homeserver
+  Given the user switches to an account with a saved session
+  When `restore_session(Some(target_user_id))` fails with `ClientBuild` or generic SDK restore failure
+  Then Robrix reports account switch failure
+  And Robrix preserves the target account session file
+  And Robrix preserves the target account Matrix store directory
+
+Scenario: Save-latest failure after successful SDK restore does not delete the session
+  Test: save_latest_user_failure_is_reported_without_session_cleanup
+  Level: unit
+  Test Double: construct a typed `RestoreSessionError::SaveLatestUserId` or equivalent policy input
+  Given SDK restore succeeds for "@alice:example.org"
+  When writing `latest_user_id.txt` fails
+  Then `restore_session` returns a typed `SaveLatestUserId` error
+  And Robrix does not delete the session file
+  And Robrix reports a restore failure that includes the latest-user persistence problem without exposing secrets

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -1,11 +1,15 @@
 //! Handles app persistence by saving and restoring client session data to/from the filesystem.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 use anyhow::{anyhow, bail};
 use makepad_widgets::{log, warning, Cx};
 use matrix_sdk::{
     authentication::{AuthSession, matrix::MatrixSession, oauth::{ClientId, OAuthSession, UserSession}},
-    ruma::{OwnedUserId, UserId},
+    ruma::{OwnedUserId, UserId, api::client::error::ErrorKind},
     sliding_sync,
     Client,
 };
@@ -146,6 +150,86 @@ pub fn session_file_path(user_id: &UserId) -> PathBuf {
 
 const LATEST_USER_ID_FILE_NAME: &str = "latest_user_id.txt";
 
+#[derive(Debug)]
+pub enum RestoreSessionError {
+    NoLatestUserId,
+    MissingSessionFile {
+        user_id: OwnedUserId,
+    },
+    ReadSessionFile {
+        user_id: OwnedUserId,
+        path: PathBuf,
+        message: String,
+    },
+    CorruptSessionFile {
+        user_id: OwnedUserId,
+        path: PathBuf,
+        message: String,
+    },
+    ClientBuild {
+        user_id: OwnedUserId,
+        message: String,
+    },
+    RestoreAuth {
+        user_id: OwnedUserId,
+        message: String,
+    },
+    InvalidToken {
+        user_id: OwnedUserId,
+        message: String,
+    },
+    SaveLatestUserId {
+        user_id: OwnedUserId,
+        message: String,
+    },
+}
+
+impl RestoreSessionError {
+    pub fn user_id(&self) -> Option<&UserId> {
+        match self {
+            RestoreSessionError::NoLatestUserId => None,
+            RestoreSessionError::MissingSessionFile { user_id }
+            | RestoreSessionError::ReadSessionFile { user_id, .. }
+            | RestoreSessionError::CorruptSessionFile { user_id, .. }
+            | RestoreSessionError::ClientBuild { user_id, .. }
+            | RestoreSessionError::RestoreAuth { user_id, .. }
+            | RestoreSessionError::InvalidToken { user_id, .. }
+            | RestoreSessionError::SaveLatestUserId { user_id, .. } => Some(user_id.as_ref()),
+        }
+    }
+}
+
+impl fmt::Display for RestoreSessionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RestoreSessionError::NoLatestUserId => write!(f, "could not find previous latest User ID"),
+            RestoreSessionError::MissingSessionFile { user_id } => {
+                write!(f, "could not find previous session file for {user_id}")
+            }
+            RestoreSessionError::ReadSessionFile { path, message, .. } => {
+                write!(f, "failed to read session file {}: {message}", path.display())
+            }
+            RestoreSessionError::CorruptSessionFile { path, message, .. } => {
+                write!(f, "failed to parse session file {}: {message}", path.display())
+            }
+            RestoreSessionError::ClientBuild { user_id, message } => {
+                write!(f, "failed to build Matrix client for {user_id}: {message}")
+            }
+            RestoreSessionError::RestoreAuth { user_id, message } => {
+                write!(f, "failed to restore Matrix auth session for {user_id}: {message}")
+            }
+            RestoreSessionError::InvalidToken { user_id, message } => {
+                write!(f, "saved Matrix token for {user_id} is invalid: {message}")
+            }
+            RestoreSessionError::SaveLatestUserId { user_id, message } => {
+                write!(f, "failed to save latest user id for {user_id}: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RestoreSessionError {}
+
 /// Returns the user ID of the most recently-logged in user session.
 pub async fn most_recent_user_id() -> Option<OwnedUserId> {
     tokio::fs::read_to_string(
@@ -167,6 +251,52 @@ async fn save_latest_user_id(user_id: &UserId) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub async fn delete_latest_user_id_if_matches(user_id: &UserId) -> anyhow::Result<bool> {
+    delete_latest_user_id_if_matches_path(
+        &app_data_dir().join(LATEST_USER_ID_FILE_NAME),
+        user_id,
+    )
+    .await
+}
+
+pub async fn delete_latest_user_id_if_matches_path(
+    latest_user_id_path: &Path,
+    user_id: &UserId,
+) -> anyhow::Result<bool> {
+    let latest_user_id = match tokio::fs::read_to_string(latest_user_id_path).await {
+        Ok(latest_user_id) => latest_user_id,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(anyhow!("Failed to read latest user file: {e}")),
+    };
+
+    let latest_user_id: Result<OwnedUserId, _> = latest_user_id.trim().try_into();
+    let Ok(latest_user_id) = latest_user_id else {
+        return Ok(false);
+    };
+    if latest_user_id.as_str() != user_id.as_str() {
+        return Ok(false);
+    }
+
+    tokio::fs::remove_file(latest_user_id_path).await
+        .map_err(|e| anyhow!("Failed to remove latest user file: {e}"))?;
+    Ok(true)
+}
+
+pub async fn archive_bad_session_file(session_file: &Path) -> anyhow::Result<PathBuf> {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let file_name = session_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("session");
+    let archive_path = session_file.with_file_name(format!("{file_name}.bad.{suffix}"));
+    tokio::fs::rename(session_file, &archive_path).await
+        .map_err(|e| anyhow!("Failed to archive corrupt session file {}: {e}", session_file.display()))?;
+    Ok(archive_path)
+}
+
 
 /// Restores the given user's previous session from the filesystem.
 ///
@@ -174,7 +304,7 @@ async fn save_latest_user_id(user_id: &UserId) -> anyhow::Result<()> {
 /// is retrieved from the filesystem.
 pub async fn restore_session(
     user_id: Option<OwnedUserId>
-) -> anyhow::Result<(Client, Option<String>, ClientSessionPersisted)> {
+) -> Result<(Client, Option<String>, ClientSessionPersisted), RestoreSessionError> {
     let user_id = if let Some(user_id) = user_id {
         Some(user_id)
     } else {
@@ -183,12 +313,19 @@ pub async fn restore_session(
 
     let Some(user_id) = user_id else {
         log!("Could not find previous latest User ID");
-        bail!("Could not find previous latest User ID");
+        return Err(RestoreSessionError::NoLatestUserId);
     };
     let session_file = session_file_path(&user_id);
-    if !session_file.exists() {
-        log!("Could not find previous session file for user {user_id}");
-        bail!("Could not find previous session file");
+    if let Err(e) = tokio::fs::metadata(&session_file).await {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            log!("Could not find previous session file for user {user_id}");
+            return Err(RestoreSessionError::MissingSessionFile { user_id });
+        }
+        return Err(RestoreSessionError::ReadSessionFile {
+            user_id,
+            path: session_file,
+            message: e.to_string(),
+        });
     }
     let status_str = format!("Loading previous session file for {user_id}...");
     log!("{status_str}: '{}'", session_file.display());
@@ -198,9 +335,27 @@ pub async fn restore_session(
     });
 
     // The session was serialized as JSON in a file.
-    let serialized_session = tokio::fs::read_to_string(session_file).await?;
+    let serialized_session = match tokio::fs::read_to_string(&session_file).await {
+        Ok(serialized_session) => serialized_session,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log!("Could not find previous session file for user {user_id}");
+            return Err(RestoreSessionError::MissingSessionFile { user_id });
+        }
+        Err(e) => {
+            return Err(RestoreSessionError::ReadSessionFile {
+                user_id,
+                path: session_file,
+                message: e.to_string(),
+            });
+        }
+    };
     let FullSessionPersisted { client_session, user_session, sync_token, sliding_sync_version } =
-        serde_json::from_str(&serialized_session)?;
+        serde_json::from_str(&serialized_session)
+            .map_err(|e| RestoreSessionError::CorruptSessionFile {
+                user_id: user_id.clone(),
+                path: session_file.clone(),
+                message: e.to_string(),
+            })?;
 
     let status_str = format!(
         "Loaded session file for:\n{user_id}\n\nTrying to connect to homeserver...\n{}",
@@ -228,7 +383,11 @@ pub async fn restore_session(
     if let Some(proxy) = saved_proxy {
         client_builder = client_builder.proxy(proxy);
     }
-    let client = client_builder.build().await?;
+    let client = client_builder.build().await
+        .map_err(|e| RestoreSessionError::ClientBuild {
+            user_id: user_id.clone(),
+            message: e.to_string(),
+        })?;
     let sliding_sync_version = sliding_sync_version.into();
     client.set_sliding_sync_version(sliding_sync_version);
     let restored_user_id = user_session.user_id().to_owned();
@@ -239,8 +398,29 @@ pub async fn restore_session(
         status: status_str,
     });
 
-    client.restore_session(user_session.into_auth_session()).await?;
-    save_latest_user_id(&restored_user_id).await?;
+    client.restore_session(user_session.into_auth_session()).await
+        .map_err(|e| {
+            let message = e.to_string();
+            if matches!(
+                e.client_api_error_kind(),
+                Some(ErrorKind::UnknownToken { .. } | ErrorKind::MissingToken)
+            ) {
+                RestoreSessionError::InvalidToken {
+                    user_id: restored_user_id.clone(),
+                    message,
+                }
+            } else {
+                RestoreSessionError::RestoreAuth {
+                    user_id: restored_user_id.clone(),
+                    message,
+                }
+            }
+        })?;
+    save_latest_user_id(&restored_user_id).await
+        .map_err(|e| RestoreSessionError::SaveLatestUserId {
+            user_id: restored_user_id.clone(),
+            message: e.to_string(),
+        })?;
 
     Ok((client, sync_token, client_session))
 }
@@ -378,13 +558,21 @@ pub async fn delete_session(user_id: &UserId) -> anyhow::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
     use matrix_sdk::{
         SessionMeta, SessionTokens,
         authentication::oauth::UserSession,
         ruma::{device_id, user_id},
     };
 
-    use super::{PersistedAuthSession, PersistedOAuthSession};
+    use super::{
+        PersistedAuthSession, PersistedOAuthSession, archive_bad_session_file,
+        delete_latest_user_id_if_matches_path,
+    };
 
     #[test]
     fn persisted_auth_session_round_trips_oauth_variant() {
@@ -405,5 +593,58 @@ mod tests {
         let json = serde_json::to_string(&persisted).unwrap();
         let restored: PersistedAuthSession = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.user_id().as_str(), "@alice:example.org");
+    }
+
+    fn temp_restore_policy_dir(test_name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("robrix_restore_policy_{test_name}_{}_{}", std::process::id(), nanos));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn restore_session_policy_clears_latest_user_for_missing_session_file() {
+        let dir = temp_restore_policy_dir("missing_session");
+        let latest_user_id_path = dir.join("latest_user_id.txt");
+        tokio::fs::write(&latest_user_id_path, "@alice:example.org").await.unwrap();
+
+        let deleted = delete_latest_user_id_if_matches_path(
+            &latest_user_id_path,
+            user_id!("@alice:example.org"),
+        )
+        .await
+        .unwrap();
+
+        assert!(deleted);
+        assert!(!latest_user_id_path.exists());
+        tokio::fs::remove_dir_all(dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn corrupt_session_file_is_archived_and_latest_user_is_cleared() {
+        let dir = temp_restore_policy_dir("corrupt_session");
+        let latest_user_id_path = dir.join("latest_user_id.txt");
+        let session_file = dir.join("session");
+        tokio::fs::write(&latest_user_id_path, "@alice:example.org").await.unwrap();
+        tokio::fs::write(&session_file, "{not json").await.unwrap();
+
+        let archive_path = archive_bad_session_file(&session_file).await.unwrap();
+        let deleted = delete_latest_user_id_if_matches_path(
+            &latest_user_id_path,
+            user_id!("@alice:example.org"),
+        )
+        .await
+        .unwrap();
+
+        assert!(deleted);
+        assert!(!session_file.exists());
+        assert!(archive_path.exists());
+        assert!(archive_path.file_name().unwrap().to_string_lossy().contains(".bad"));
+        assert!(!latest_user_id_path.exists());
+        tokio::fs::remove_dir_all(dir).await.unwrap();
     }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -264,6 +264,91 @@ async fn clear_persisted_session(user_id: Option<&UserId>) {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RestoreSessionFailureAction {
+    Preserve,
+    DeleteLatestUserId,
+    ArchiveBadSessionAndDeleteLatestUserId,
+    ClearPersistedSession,
+}
+
+fn restore_session_failure_action(error: &persistence::RestoreSessionError) -> RestoreSessionFailureAction {
+    match error {
+        persistence::RestoreSessionError::MissingSessionFile { .. } => {
+            RestoreSessionFailureAction::DeleteLatestUserId
+        }
+        persistence::RestoreSessionError::CorruptSessionFile { .. } => {
+            RestoreSessionFailureAction::ArchiveBadSessionAndDeleteLatestUserId
+        }
+        persistence::RestoreSessionError::InvalidToken { .. } => {
+            RestoreSessionFailureAction::ClearPersistedSession
+        }
+        persistence::RestoreSessionError::NoLatestUserId
+        | persistence::RestoreSessionError::ReadSessionFile { .. }
+        | persistence::RestoreSessionError::ClientBuild { .. }
+        | persistence::RestoreSessionError::RestoreAuth { .. }
+        | persistence::RestoreSessionError::SaveLatestUserId { .. } => {
+            RestoreSessionFailureAction::Preserve
+        }
+    }
+}
+
+fn session_validation_failure_action(is_invalid_token: bool) -> RestoreSessionFailureAction {
+    if is_invalid_token {
+        RestoreSessionFailureAction::ClearPersistedSession
+    } else {
+        RestoreSessionFailureAction::Preserve
+    }
+}
+
+fn restore_session_failure_message(error: &persistence::RestoreSessionError) -> String {
+    match restore_session_failure_action(error) {
+        RestoreSessionFailureAction::ClearPersistedSession => {
+            "Your login token is no longer valid.\n\nPlease log in again.".to_owned()
+        }
+        RestoreSessionFailureAction::DeleteLatestUserId => {
+            "Could not find the saved session file.\n\nPlease log in again.".to_owned()
+        }
+        RestoreSessionFailureAction::ArchiveBadSessionAndDeleteLatestUserId => {
+            "The saved session file is corrupted and was archived.\n\nPlease log in again.".to_owned()
+        }
+        RestoreSessionFailureAction::Preserve => {
+            let detail = if matches!(error, persistence::RestoreSessionError::SaveLatestUserId { .. }) {
+                "Robrix restored the session but could not update the latest user pointer."
+            } else {
+                "Robrix kept your saved session so it can try again after the server or network issue is fixed."
+            };
+            format!("Could not restore previous user session.\n\n{detail}\n\nError: {error}")
+        }
+    }
+}
+
+async fn apply_restore_session_failure_policy(error: &persistence::RestoreSessionError) {
+    match restore_session_failure_action(error) {
+        RestoreSessionFailureAction::Preserve => {}
+        RestoreSessionFailureAction::DeleteLatestUserId => {
+            if let Some(user_id) = error.user_id() {
+                if let Err(e) = persistence::delete_latest_user_id_if_matches(user_id).await {
+                    warning!("Failed to delete stale latest user id for {user_id}: {e}");
+                }
+            }
+        }
+        RestoreSessionFailureAction::ArchiveBadSessionAndDeleteLatestUserId => {
+            if let persistence::RestoreSessionError::CorruptSessionFile { user_id, path, .. } = error {
+                if let Err(e) = persistence::archive_bad_session_file(path).await {
+                    warning!("Failed to archive corrupt session file for {user_id}: {e}");
+                }
+                if let Err(e) = persistence::delete_latest_user_id_if_matches(user_id).await {
+                    warning!("Failed to delete latest user id for corrupt session {user_id}: {e}");
+                }
+            }
+        }
+        RestoreSessionFailureAction::ClearPersistedSession => {
+            clear_persisted_session(error.user_id()).await;
+        }
+    }
+}
+
 enum SessionResetAction {
     Reauthenticate { message: String },
 }
@@ -4084,6 +4169,13 @@ fn worker_shutdown_is_unexpected(logout_in_progress: bool, account_switch_pendin
     !logout_in_progress && !account_switch_pending
 }
 
+fn should_prebuild_default_sso_client(
+    most_recent_user_id: Option<&UserId>,
+    cli_has_valid_username_password: bool,
+) -> bool {
+    most_recent_user_id.is_none() && !cli_has_valid_username_password
+}
+
 async fn attach_room_to_space(client: &Client, child_room: &Room, space_id: &OwnedRoomId) -> Result<()> {
     let user_id = client.user_id().ok_or_else(|| anyhow!("Current user ID not found"))?;
     let space_room = client.get_room(space_id)
@@ -4170,6 +4262,19 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
     // Proactively build a Matrix Client in the background so that the SSO Server
     // can have a quicker start if needed (as it's rather slow to build this client).
     rt_handle.spawn(async move {
+        let cli_has_valid_username_password = Cli::try_parse()
+            .as_ref()
+            .is_ok_and(|cli| !cli.user_id.is_empty() && !cli.password.is_empty());
+        let most_recent_user_id = persistence::most_recent_user_id().await;
+        if !should_prebuild_default_sso_client(
+            most_recent_user_id.as_deref(),
+            cli_has_valid_username_password,
+        ) {
+            DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
+            Cx::post_action(LoginAction::SsoPending(false));
+            return;
+        }
+
         match build_client(&Cli::default(), app_data_dir()).await {
             Ok(client_and_session) => {
                 DEFAULT_SSO_CLIENT.lock().unwrap()
@@ -4607,17 +4712,17 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             specified_username.as_ref().or(most_recent_user_id.as_ref())
         );
         match persistence::restore_session(specified_username.clone()).await {
-            Ok((client, sync_token, session)) => Some((client, sync_token, true, session)),
+            Ok((client, sync_token, session)) => {
+                // Do not make whoami a startup restore gate. Some Matrix-compatible
+                // homeservers may not expose it yet; invalid tokens are still caught
+                // by SDK restore, SyncService::build(), and SessionChange::UnknownToken.
+                Some((client, sync_token, false, session))
+            }
             Err(e) => {
-                let status_err = "Could not restore previous user session.\n\nPlease login again.";
+                let status_err = restore_session_failure_message(&e);
                 log!("{status_err} Error: {e:?}");
-                clear_persisted_session(
-                    specified_username
-                        .as_deref()
-                        .or(most_recent_user_id.as_deref()),
-                )
-                .await;
-                Cx::post_action(LoginAction::LoginFailure(status_err.to_string()));
+                apply_restore_session_failure_policy(&e).await;
+                Cx::post_action(LoginAction::LoginFailure(status_err));
 
                 if let Ok(cli) = &cli_parse_result {
                     log!("Attempting auto-login from CLI arguments as user '{}'...", cli.user_id);
@@ -4690,7 +4795,9 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             if validate_session {
                 match client.whoami().await {
                     Ok(_) => {}
-                    Err(e) if is_invalid_token_http_error(&e) => {
+                    Err(e) if session_validation_failure_action(is_invalid_token_http_error(&e))
+                        == RestoreSessionFailureAction::ClearPersistedSession =>
+                    {
                         clear_persisted_session(client.user_id()).await;
                         let err_msg = "Your login token is no longer valid.\n\nPlease log in again.";
                         Cx::post_action(LoginAction::LoginFailure(err_msg.to_string()));
@@ -5044,6 +5151,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                 }
                 Err(e) => {
                     error!("Failed to restore session for account switch: {e:?}");
+                    apply_restore_session_failure_policy(&e).await;
                     Cx::post_action(AccountSwitchAction::Failed(format!("Failed to restore session: {e}")));
                     enqueue_popup_notification(
                         format!("Account switch failed: {e}"),
@@ -7231,7 +7339,15 @@ async fn discover_homeserver_capabilities(
 
 #[cfg(test)]
 mod tests {
-    use super::{OidcFlowSlot, build_discovery_http_client, worker_shutdown_is_unexpected};
+    use matrix_sdk::ruma::user_id;
+
+    use super::{
+        OidcFlowSlot, RestoreSessionFailureAction, build_discovery_http_client,
+        restore_session_failure_action, restore_session_failure_message,
+        session_validation_failure_action, should_prebuild_default_sso_client,
+        worker_shutdown_is_unexpected,
+    };
+    use crate::persistence::RestoreSessionError;
 
     #[test]
     fn worker_shutdown_is_not_unexpected_during_logout() {
@@ -7285,5 +7401,80 @@ mod tests {
         let err = build_discovery_http_client(Some("ftp://proxy.invalid"))
             .expect_err("invalid proxy scheme should be rejected");
         assert!(err.to_string().contains("Unsupported proxy URL scheme"));
+    }
+
+    #[test]
+    fn default_sso_client_is_not_prebuilt_when_restore_session_is_available() {
+        assert!(!should_prebuild_default_sso_client(
+            Some(user_id!("@bob:192.168.1.58:8128")),
+            false,
+        ));
+    }
+
+    #[test]
+    fn default_sso_client_is_not_prebuilt_during_cli_login() {
+        assert!(!should_prebuild_default_sso_client(None, true));
+    }
+
+    #[test]
+    fn default_sso_client_is_prebuilt_for_idle_login_screen() {
+        assert!(should_prebuild_default_sso_client(None, false));
+    }
+
+    #[test]
+    fn restore_session_policy_preserves_data_for_client_build_failure() {
+        let err = RestoreSessionError::ClientBuild {
+            user_id: user_id!("@alice:example.org").to_owned(),
+            message: "homeserver returned 502".to_owned(),
+        };
+
+        assert_eq!(restore_session_failure_action(&err), RestoreSessionFailureAction::Preserve);
+        assert!(restore_session_failure_message(&err).contains("try again"));
+    }
+
+    #[test]
+    fn whoami_404_is_retryable_restore_validation_failure() {
+        assert_eq!(
+            session_validation_failure_action(false),
+            RestoreSessionFailureAction::Preserve,
+        );
+    }
+
+    #[test]
+    fn invalid_token_restore_policy_clears_session_and_latest_user() {
+        let err = RestoreSessionError::InvalidToken {
+            user_id: user_id!("@alice:example.org").to_owned(),
+            message: "M_UNKNOWN_TOKEN".to_owned(),
+        };
+
+        assert_eq!(
+            restore_session_failure_action(&err),
+            RestoreSessionFailureAction::ClearPersistedSession,
+        );
+        assert_eq!(
+            session_validation_failure_action(true),
+            RestoreSessionFailureAction::ClearPersistedSession,
+        );
+    }
+
+    #[test]
+    fn account_switch_restore_retryable_error_preserves_target_session() {
+        let err = RestoreSessionError::RestoreAuth {
+            user_id: user_id!("@alice:example.org").to_owned(),
+            message: "HTTP 404".to_owned(),
+        };
+
+        assert_eq!(restore_session_failure_action(&err), RestoreSessionFailureAction::Preserve);
+    }
+
+    #[test]
+    fn save_latest_user_failure_is_reported_without_session_cleanup() {
+        let err = RestoreSessionError::SaveLatestUserId {
+            user_id: user_id!("@alice:example.org").to_owned(),
+            message: "permission denied".to_owned(),
+        };
+
+        assert_eq!(restore_session_failure_action(&err), RestoreSessionFailureAction::Preserve);
+        assert!(restore_session_failure_message(&err).contains("latest user"));
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes two startup auto-login restore issues:

- Adds typed restore-session errors and applies non-destructive cleanup policy. Retryable network/server/proxy/client-build/whoami failures now preserve the session file, Matrix store, and latest_user_id.txt; only confirmed invalid tokens clear persisted session.
- Avoids prebuilding the default SSO client while restoring a saved session or using CLI username/password login, preventing unrelated matrix-client.matrix.org discovery requests from appearing during Palpo restore startup.

## Details

Cleanup policy now distinguishes:

- Missing session file: delete only the stale latest_user_id.txt pointer.
- Corrupt session JSON: archive the session file as .bad.* and delete the matching latest-user pointer.
- M_UNKNOWN_TOKEN / M_MISSING_TOKEN / SessionChange::UnknownToken: clear persisted session and ask the user to log in again.
- Client build, generic SDK restore, whoami non-token, save-latest, server, proxy, and transient network failures: preserve local session so the next startup can retry.

Startup restore also no longer requires a proactive whoami validation request to succeed. Token invalidation is still handled by SDK restore, SyncService::build(), and session-change notifications.

## Verification

- agent-spec parse specs/task-restore-session-error-policy.spec.md
- agent-spec lint specs/task-restore-session-error-policy.spec.md --min-score 0.7
- agent-spec lifecycle specs/task-restore-session-error-policy.spec.md --code . --change src/persistence/matrix_state.rs --change src/sliding_sync.rs --change specs/task-restore-session-error-policy.spec.md --format text
- cargo test default_sso_client_is --lib
- cargo test restore_session_policy --lib
- cargo test whoami_404_is_retryable_restore_validation_failure --lib
- cargo test invalid_token_restore_policy_clears_session_and_latest_user --lib
- cargo test account_switch_restore_retryable_error_preserves_target_session --lib
- cargo test save_latest_user_failure_is_reported_without_session_cleanup --lib
- cargo test corrupt_session_file_is_archived_and_latest_user_is_cleared --lib
- cargo build

## Manual Test

Verified locally with Palpo:

1. Start with a fresh Robrix login.
2. Close Robrix.
3. Run cargo run again.
4. Robrix finds latest_user_id.txt, restores @bob:192.168.1.58:8128, starts SyncService, loads rooms, and posts LoginSuccess without returning to the login screen.

## Known Existing Issues

Full cargo test currently has unrelated failures in files this PR does not touch:

- home::room_screen::tests::test_parse_bot_timeline_layers_invalid_metadata_does_not_panic
- room::room_input_bar::tests::test_classified_management_command_prefers_bound_bot_when_parent_config_mismatches
- room::room_input_bar::tests::test_message_bot_mention_suppresses_explicit_bot_target
- room::room_input_bar::tests::test_room_bot_mention_overrides_selected_explicit_bot

There are also unrelated follow-up issues observed during manual testing: profile/avatar fallback can show \"Not logged in\" despite restored login, settings_screen script_apply_eval errors, and release clippy flags ForwardMessageModalAction as a large enum variant.