### PR TITLE
fix: remove clippy large_enum_variant warning in forward modal action

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1398,7 +1398,7 @@ impl MatchEvent for App {
                 Some(ForwardMessageModalAction::Open(content)) => {
                     self.ui
                         .forward_message_modal(cx, ids!(forward_message_modal_inner))
-                        .show(cx, content.clone(), self.app_state.app_language);
+                        .show(cx, (**content).clone(), self.app_state.app_language);
                     self.ui.modal(cx, ids!(forward_message_modal)).open(cx);
                     continue;
                 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -7500,7 +7500,7 @@ impl RoomScreen {
                     if let Some(event_tl_item) = Self::find_event_in_timeline(&tl.items, details, has_encryption_notice)
                         && let Some(content) = Self::forward_message_content(&tl.kind, event_tl_item)
                     {
-                        cx.action(ForwardMessageModalAction::Open(content));
+                        cx.action(ForwardMessageModalAction::Open(Box::new(content)));
                     } else {
                         enqueue_popup_notification(
                             tr_key(self.app_language, "room_screen.popup.message.forward_not_found"),

--- a/src/shared/forward_modal.rs
+++ b/src/shared/forward_modal.rs
@@ -117,7 +117,7 @@ pub struct ForwardMessageContent {
 
 #[derive(Clone, Debug, Default)]
 pub enum ForwardMessageModalAction {
-    Open(ForwardMessageContent),
+    Open(Box<ForwardMessageContent>),
     Close,
     #[default]
     None,
@@ -353,11 +353,11 @@ mod tests {
 
     #[test]
     fn test_forward_modal_opens() {
-        let action = ForwardMessageModalAction::Open(ForwardMessageContent {
+        let action = ForwardMessageModalAction::Open(Box::new(ForwardMessageContent {
             source_room_id: OwnedRoomId::try_from("!source:example.org").unwrap(),
             source_event_id: OwnedEventId::try_from("$event:example.org").unwrap(),
             message: RoomMessageEventContent::text_plain("hello"),
-        });
+        }));
 
         assert!(matches!(action, ForwardMessageModalAction::Open(_)));
     }


### PR DESCRIPTION
## Summary
- box `ForwardMessageModalAction::Open` payload to avoid `clippy::large_enum_variant`
- update forward action emit/consume callsites to use boxed content
- adjust forward modal unit test construction accordingly

## Validation
- `cargo clippy --workspace --all-features`
