### PR TITLE
sync: backport upstream low-conflict fixes (batch 1+2)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -246,6 +246,7 @@ script_mod! {
 
                         // Show incoming verification requests in front of the aforementioned UI elements.
                         verification_modal := Modal {
+                            can_dismiss: false,
                             content +: {
                                 verification_modal_inner := VerificationModal {}
                             }

--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -119,11 +119,11 @@ pub fn text_preview_of_timeline_item(
                 )))
         }
         TimelineItemContent::FailedToParseMessageLike { event_type, .. } => TextPreview::from((
-            format!("[Failed to parse <i>{}</i> message]", event_type),
+            format!("[Failed to parse <i>{}</i> message]", htmlize::escape_text(event_type.to_string())),
             BeforeText::UsernameWithColon,
         )),
         TimelineItemContent::FailedToParseState { event_type, .. } => TextPreview::from((
-            format!("[Failed to parse <i>{}</i> state]", event_type),
+            format!("[Failed to parse <i>{}</i> state]", htmlize::escape_text(event_type.to_string())),
             BeforeText::UsernameWithColon,
         )),
         TimelineItemContent::CallInvite => TextPreview::from((

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -9379,11 +9379,20 @@ fn populate_message_view(
                         if !sender_is_bot {
                             let html_or_plaintext_ref = item.html_or_plaintext(cx, ids!(content.message));
                             // Apply gray color to all text styles for notice messages.
+                            // This covers both rendering paths in HtmlOrPlaintext: the rich
+                            // `html_view.html` widget (used when the message has an HTML body)
+                            // and the `plaintext_view.pt_label` (used for plain-text notices).
                             let mut html_widget = html_or_plaintext_ref.html(cx, ids!(html_view.html));
                             script_apply_eval!(cx, html_widget, {
                                 font_color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT,
                                 draw_block +: {
                                     quote_fg_color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT,
+                                }
+                            });
+                            let mut pt_label = html_or_plaintext_ref.label(cx, ids!(plaintext_view.pt_label));
+                            script_apply_eval!(cx, pt_label, {
+                                draw_text +: {
+                                    color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT
                                 }
                             });
                         }

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -1,7 +1,7 @@
 //! A `HtmlOrPlaintext` view can display either plaintext or rich HTML content.
 
 use makepad_widgets::*;
-use matrix_sdk::{ruma::{matrix_uri::{MatrixId, MatrixToUri, MatrixUri}, OwnedMxcUri}, OwnedServerName};
+use matrix_sdk::{ruma::{matrix_uri::MatrixId, OwnedMxcUri}, OwnedServerName};
 
 use crate::{avatar_cache::{self, AvatarCacheEntry}, profile::user_profile_cache, sliding_sync::{current_user_id, submit_async_request, MatrixRequest}, utils};
 
@@ -56,22 +56,27 @@ script_mod! {
 
     // A RobrixHtmlLink is either a regular Html link (default) or a Matrix link.
     // The Matrix link is a pill-shaped widget with an avatar and a title.
+    //
+    // Layout notes:
+    // * `html_link` is a direct child (not wrapped in an intermediate View).
+    //   Wrapping `HtmlLink` inside a View breaks inline text wrapping, because
+    //   `HtmlLink::draw_walk` draws text directly into the parent `TextFlow`'s
+    //   turtle via `tf.draw_text()`. A surrounding View opens its own turtle
+    //   (via `cx.begin_turtle`), which replaces the turtle that `tf.draw_text`
+    //   reads to compute wrap width — so long links would refuse to break.
+    //   Instead, `RobrixHtmlLink::draw_walk` dispatches in Rust: it calls
+    //   `html_link.draw_walk` DIRECTLY for inline-text mode (no surrounding
+    //   turtle), and falls back to the outer View only for the pill mode.
     mod.widgets.RobrixHtmlLink = #(RobrixHtmlLink::register_widget(vm)) {
         width: Fit, height: Fit,
-        flow: Flow.Right{wrap: true}, // ensure the link text can wrap
         align: Align{ y: 0.5 },
         cursor: MouseCursor.Hand,
 
-        html_link_view := View {
+        html_link := HtmlLink {
             visible: true,
-            width: Fit, height: Fit,
-            flow: Flow.Right{wrap: true},
-
-            html_link := HtmlLink {
-                hover_color: (COLOR_LINK_HOVER)
-                grab_key_focus: false,
-                padding: Inset{left: 1.0, right: 1.5},
-            }
+            hover_color: (COLOR_LINK_HOVER)
+            grab_key_focus: false,
+            padding: Inset{left: 1.0, right: 1.5},
         }
 
         matrix_link_view := View {
@@ -238,17 +243,18 @@ impl Widget for RobrixHtmlLink {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        // Try to render Matrix mention pills for matrix:// URIs.
-        // Note: vertical alignment with surrounding text may not be perfect
-        // (known Makepad limitation with inline Html subwidgets).
+        // TODO: pill-mode dispatch is currently disabled because Makepad doesn't
+        // yet support partial vertical alignment of inline block widgets (pills)
+        // with the surrounding text baseline. Once Makepad supports that, we can
+        // re-enable the Matrix URI parsing below to render pills inline.
+        /*
         if let Ok(matrix_to_uri) = MatrixToUri::parse(&self.url) {
-            self.draw_matrix_pill(cx, matrix_to_uri.id(), matrix_to_uri.via());
+            return self.draw_matrix_pill(cx, scope, walk, matrix_to_uri.id(), matrix_to_uri.via());
         } else if let Ok(matrix_uri) = MatrixUri::parse(&self.url) {
-            self.draw_matrix_pill(cx, matrix_uri.id(), matrix_uri.via());
-        } else {
-            self.draw_html_link(cx);
+            return self.draw_matrix_pill(cx, scope, walk, matrix_uri.id(), matrix_uri.via());
         }
-        self.view.draw_walk(cx, scope, walk)
+        */
+        self.draw_html_link(cx, scope, walk)
     }
 
     fn text(&self) -> String {
@@ -262,39 +268,59 @@ impl Widget for RobrixHtmlLink {
 }
 
 impl RobrixHtmlLink {
+    /// Draws the Matrix link pill as an atomic inline block.
+    ///
+    /// The pill is drawn via `self.view.draw_walk`, which opens a turtle and
+    /// renders the visible `matrix_link_view`. From the outer `TextFlow`'s
+    /// perspective, the pill is a single unbreakable inline unit (which is the
+    /// correct behavior — a pill shouldn't wrap internally).
     #[allow(unused)]
-    fn draw_matrix_pill(&mut self, cx: &mut Cx, matrix_id: &MatrixId, via: &[OwnedServerName]) {
-        {
-            let matrix_link_pill = self.matrix_link_pill(cx, ids!(matrix_link));
-            let Some(mut pill) = matrix_link_pill.borrow_mut() else {
-                self.draw_html_link(cx);
-                return;
-            };
+    fn draw_matrix_pill(
+        &mut self,
+        cx: &mut Cx2d,
+        scope: &mut Scope,
+        walk: Walk,
+        matrix_id: &MatrixId,
+        via: &[OwnedServerName],
+    ) -> DrawStep {
+        if let Some(mut pill) = self.matrix_link_pill(cx, ids!(matrix_link)).borrow_mut() {
             pill.populate_pill(cx, self.url.clone(), matrix_id, via);
         }
-        let matrix_link_view = self.view(cx, ids!(matrix_link_view));
-        let html_link_view = self.view(cx, ids!(html_link_view));
-        let visibility_changed = !matrix_link_view.visible() || html_link_view.visible();
-        matrix_link_view.set_visible(cx, true);
-        html_link_view.set_visible(cx, false);
-        if visibility_changed {
-            self.redraw(cx);
-        }
+        self.view(cx, ids!(matrix_link_view)).set_visible(cx, true);
+        self.html_link(cx, ids!(html_link)).set_visible(cx, false);
+        self.view.draw_walk(cx, scope, walk)
     }
 
-    /// Shows the inner plain HTML link and hides the Matrix link pill view.
-    fn draw_html_link(&mut self, cx: &mut Cx) {
-        let html_link_view = self.view(cx, ids!(html_link_view));
-        let matrix_link_view = self.view(cx, ids!(matrix_link_view));
-        let visibility_changed = !html_link_view.visible() || matrix_link_view.visible();
-        html_link_view.set_visible(cx, true);
-        matrix_link_view.set_visible(cx, false);
-        if visibility_changed {
-            self.redraw(cx);
-        }
-        let mut html_link = self.html_link(cx, ids!(html_link));
-        html_link.set_url(&self.url);
-        html_link.set_text(cx, self.text.as_ref());
+    /// Draws the inner `HtmlLink` as inline wrapping text.
+    ///
+    /// We invoke `HtmlLink::draw_walk` directly rather than going through
+    /// `self.view.draw_walk`. Going through the outer View would open a new
+    /// turtle, which in turn would become the turtle that `tf.draw_text()`
+    /// reads inside `HtmlLink::draw_walk` — that turtle has `width: Fit` and
+    /// therefore no wrap bound, so the link text would refuse to break across
+    /// lines. By calling `draw_walk` directly on the `HtmlLink`, the current
+    /// turtle remains the parent Html widget's `TextFlow` turtle, which has
+    /// the full message width and wraps correctly.
+    fn draw_html_link(
+        &mut self,
+        cx: &mut Cx2d,
+        scope: &mut Scope,
+        walk: Walk,
+    ) -> DrawStep {
+        // Keep subwidget visibility consistent with what's actually drawn, so
+        // `self.view.handle_event` can route events to the right place and
+        // skip the inactive subtree.
+        self.html_link(cx, ids!(html_link)).set_visible(cx, true);
+        self.view(cx, ids!(matrix_link_view)).set_visible(cx, false);
+
+        let mut html_link_ref = self.html_link(cx, ids!(html_link));
+        html_link_ref.set_url(&self.url);
+        html_link_ref.set_text(cx, self.text.as_ref());
+
+        let Some(mut html_link) = html_link_ref.borrow_mut() else {
+            return DrawStep::done();
+        };
+        html_link.draw_walk(cx, scope, walk)
     }
 }
 

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// The timeout for hiding the UI overlays after no user mouse/tap activity.
-const SHOW_UI_DURATION: f64 = 3.0;
+const SHOW_UI_DURATION: f64 = 2.5;
 
 /// Loads the given image `data` into an `ImageBuffer` as either a PNG or JPEG, using the `imghdr` library to determine which format it is.
 ///
@@ -1220,4 +1220,3 @@ pub struct ImageViewerMetaData {
     // Image size in bytes
     pub image_file_size: u64,
 }
-

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::sync::Arc;
 use futures_util::StreamExt;
 use makepad_widgets::{log, Cx};
@@ -76,13 +77,13 @@ async fn dump_devices(user_id: &UserId, client: &Client) -> String {
     let mut devices = String::new();
     for device in client.encryption().get_user_devices(user_id).await.unwrap().devices() {
         let current = client.device_id().is_some_and(|id| id == device.device_id());
-        devices.push_str(&format!(
-            "    {:<10} {:<30} {:<}{}\n",
+        let _ = writeln!(&mut devices,
+            "    {:<10} {:<30} {:<}{}",
             device.device_id(),
             device.display_name().unwrap_or("(unknown name)"),
             if device.is_verified() { "✅" } else { "❌" },
             if current { " <-- this device" } else { "" },
-        ));
+        );
     }
     format!("Currently-known devices of user {user_id}:\n{}",
         if devices.is_empty() { "    (none)" } else { &devices },


### PR DESCRIPTION
## Summary
Backport a first slice of low-conflict upstream alignment changes from `project-robius/robrix` into `robrix2`, focusing on safety and UI behavior fixes.

## Included Changes
- Security hardening
  - Escape failed-parse event types in timeline previews to prevent HTML injection in rendered preview strings.
- Verification UX + perf
  - Prevent verification modal from accidental dismiss.
  - Optimize device dump string building in verification flow (`writeln!` into target buffer).
- Notice rendering
  - Ensure notice-message gray text style applies to both HTML and plaintext render paths.
- HTML link wrapping
  - Rework `RobrixHtmlLink` wrapper so bare links can line-wrap correctly in message flow.
- Image viewer parity
  - Align overlay auto-hide duration with upstream behavior (`2.5s`).

## Upstream References
Primarily aligned from these upstream commits:
- `f8b151b7` (sanitize failed-parse preview rendering)
- `4bde63a8` (verification dump_devices optimization)
- `46791aef` (verification modal cannot auto-dismiss)
- `87cebafc` (Html link wrapping fix)
- `6a2f07e9` (notice text grayscale consistency)
- `b554ea60` / `4cfc67cb` / `bfe986c4` (image viewer behavior set; this PR only needed a final constant alignment)

## Validation
- `cargo build` passed locally on this branch.

## Scope Notes
- No formatting-only changes.
- Kept changes minimal and conflict-averse for iterative batch migration.
