### PR TITLE
sync: backport upstream room pill + preview cache set (batch 4)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedRoomId, OwnedUserId, RoomI
 use serde::{Deserialize, Serialize};
 use url::Url;
 use crate::{
-    avatar_cache::{self, clear_avatar_cache}, home::{
+    avatar_cache::{self, clear_avatar_cache}, room_preview_cache::clear_room_preview_cache, home::{
         add_room::{CreateRoomModalAction, CreateRoomModalWidgetRefExt, StartChatModalAction, StartChatModalWidgetRefExt},
         bot_binding_modal::{BotBindingModalAction, BotBindingModalWidgetRefExt},
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt, mark_invite_modal_closed}, invite_screen::{InviteScreenWidgetRefExt, LeaveRoomResultAction}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, RoomScreenWidgetRefExt, TimelineUpdate, clear_timeline_states}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, space_lobby::SpaceLobbyScreenWidgetRefExt, spaces_bar::SpacesBarRef
@@ -344,6 +344,8 @@ script_mod! {
 
                         // Tooltips must be shown in front of all other UI elements,
                         // since they can be shown as a hover atop any other widget.
+                        // This tooltip widget handles TooltipActions directly by itself,
+                        // so we don't need to call show/hide ourselves.
                         app_tooltip := CalloutTooltip {}
                     }
                 } // end of body
@@ -629,19 +631,6 @@ impl MatchEvent for App {
             // Clean up old log files to prevent disk space issues
             cleanup_old_logs(MAX_LOG_FILES_TO_KEEP);
         }
-        // Override Makepad's new default-JSON logger. We just want regular formatting.
-        fn regular_log(file_name: &str, line_start: u32, column_start: u32, _line_end: u32, _column_end: u32, message: String, level: LogLevel) {
-            let l = match level {
-                LogLevel::Panic   => "[!]",
-                LogLevel::Error   => "[E]",
-                LogLevel::Warning => "[W]",
-                LogLevel::Log     => "[I]",
-                LogLevel::Wait    => "[.]",
-            };
-            println!("{l} {file_name}:{}:{}: {message}", line_start + 1, column_start + 1);
-        }
-        *LOG_WITH_LEVEL.write().unwrap() = regular_log;
-
         // Initialize the project directory here from the main UI thread
         // such that background threads/tasks will be able to can access it.
         let _app_data_dir = crate::app_data_dir();
@@ -1300,30 +1289,6 @@ impl MatchEvent for App {
                 _ => {}
             }
 
-            // Handle actions for showing or hiding the tooltip.
-            match action.as_widget_action().cast() {
-                TooltipAction::HoverIn { text, widget_rect, options } => {
-                    // Don't show any tooltips if the message context menu is currently shown.
-                    if self.ui.new_message_context_menu(cx, ids!(new_message_context_menu)).is_currently_shown(cx) {
-                        self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
-                    }
-                    else {
-                        self.ui.callout_tooltip(cx, ids!(app_tooltip)).show_with_options(
-                            cx,
-                            &text,
-                            widget_rect,
-                            options,
-                        );
-                    }
-                    continue;
-                }
-                TooltipAction::HoverOut => {
-                    self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
-                    continue;
-                }
-                _ => {}
-            }
-
             // Handle actions needed to open/close the join/leave room modal.
             match action.downcast_ref() {
                 Some(JoinLeaveRoomModalAction::Open { kind, show_tip }) => {
@@ -1610,6 +1575,7 @@ fn clear_all_app_state(cx: &mut Cx) {
     clear_all_invited_rooms(cx);
     clear_timeline_states(cx);
     clear_avatar_cache(cx);
+    clear_room_preview_cache(cx);
 }
 
 impl AppMain for App {

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -16,7 +16,7 @@ use crate::{
         popup_list::{PopupKind, enqueue_popup_notification},
         styles::COLOR_FG_DANGER_RED,
     },
-    sliding_sync::{DirectMessageRoomAction, MatrixRequest, current_user_id, submit_async_request},
+    sliding_sync::{DirectMessageRoomAction, MatrixRequest, RoomPreviewResponseMode, current_user_id, submit_async_request},
     space_service_sync::SpaceRequest,
     utils::{self, RoomNameId},
 };
@@ -1582,7 +1582,11 @@ impl Widget for AddRoomScreen {
                             room_or_alias_id: room_or_alias_id.clone(),
                             via: via.clone(),
                         };
-                        submit_async_request(MatrixRequest::GetRoomPreview { room_or_alias_id, via });
+                        submit_async_request(MatrixRequest::GetRoomPreview {
+                            room_or_alias_id,
+                            via,
+                            response_mode: RoomPreviewResponseMode::Action,
+                        });
                     }
                     Err(e) => {
                         let error_text = e.to_string();

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -231,6 +231,10 @@ pub struct LinkPreview {
     is_expanded: bool,
     #[rust]
     hidden_links_count: usize,
+    /// Tracks the URLs that were last used to populate this widget's children,
+    /// so we can skip expensive widget recreation when the same links are shown.
+    #[rust]
+    last_populated_links: Vec<String>,
 }
 
 impl Widget for LinkPreview {
@@ -467,17 +471,16 @@ impl LinkPreviewRef {
     {
         const SKIPPED_DOMAINS: &[&str] = &["matrix.to", "matrix.io"];
         const MAX_LINK_PREVIEWS_BY_EXPAND: usize = 2;
-        let mut fully_drawn_count = 0;
-        let mut accepted_link_count = 0;
-        let mut views = Vec::new();
+
+        // Build the list of accepted URLs (after dedup + domain filtering)
+        // to check if we can skip the expensive widget recreation.
+        let mut accepted_urls: Vec<String> = Vec::new();
         let mut seen_urls = std::collections::HashSet::new();
-        
         for link in links {
             let url_string = link.to_string();
             if seen_urls.contains(&url_string) {
                 continue;
             }
-            
             if let Some(domain) = link.host_str() {
                 if SKIPPED_DOMAINS
                     .iter()
@@ -486,12 +489,28 @@ impl LinkPreviewRef {
                     continue;
                 }
             }
-            
             seen_urls.insert(url_string.clone());
-            accepted_link_count += 1;
+            accepted_urls.push(url_string);
+        }
+
+        // If the links haven't changed and children are already populated,
+        // skip the expensive widget recreation entirely.
+        if let Some(inner) = self.borrow() {
+            if accepted_urls == inner.last_populated_links && !inner.children.is_empty() {
+                return true;
+            }
+        }
+
+        let mut fully_drawn_count = 0;
+        let accepted_link_count = accepted_urls.len();
+        let mut views = Vec::with_capacity(accepted_link_count);
+
+        for (url_string, link) in accepted_urls.iter().zip(
+            links.iter().filter(|l| accepted_urls.contains(&l.to_string()))
+        ) {
             let (view_ref, was_image_drawn) = self.populate_view(
                 cx,
-                link_preview_cache.get_or_fetch_link_preview(url_string),
+                link_preview_cache.get_or_fetch_link_preview(url_string.clone()),
                 link,
                 media_cache,
                 |cx, text_or_image_ref, image_info_source, original_source, body, media_cache| {
@@ -504,6 +523,9 @@ impl LinkPreviewRef {
         if views.len() > MAX_LINK_PREVIEWS_BY_EXPAND {
             let hidden_count = views.len() - MAX_LINK_PREVIEWS_BY_EXPAND;
             self.show_collapsible_buttons(cx, hidden_count);
+        }
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.last_populated_links = accepted_urls;
         }
         self.set_children(views);
         fully_drawn_count == accepted_link_count

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -55,7 +55,12 @@ use super::{ContextMenuOpenGesture, event_reaction_list::ReactionData, invite_mo
 const MAX_ITEMS_TO_SEARCH_THROUGH: usize = 100;
 
 /// The max size (width or height) of a blurhash image to decode.
-const BLURHASH_IMAGE_MAX_SIZE: u32 = 500;
+/// Blurhash is a blurred placeholder — it is designed to be decoded at a small
+/// size and then stretched by the GPU. Decoding at large sizes is extremely
+/// expensive (CPU-bound, O(width*height)) and completely unnecessary since the
+/// result is inherently blurry. A 32×32 decode is ~240x faster than 500×500
+/// while being visually indistinguishable when scaled up.
+const BLURHASH_IMAGE_MAX_SIZE: u32 = 32;
 
 /// Use a larger batch when we are trying to fill the initial viewport,
 /// otherwise many short messages can trigger a long chain of tiny paginations.
@@ -3477,6 +3482,11 @@ script_mod! {
 
             auto_tail: true, // set to `true` to lock the view to the last item.
             max_pull_down: 0.0, // set to `0.0` to disable the pulldown bounce animation.
+            // TODO: enable `reuse_items: true` once Makepad's Html/TextFlow widget
+            //   properly resets all internal state during `script_apply(Reload)`.
+            //   Currently, stale TextFlow layout state (particularly related to
+            //   list items) leaks through when a widget is recycled, causing
+            //   excessive whitespace in HTML messages with `<ul>`/`<ol>` lists.
 
             // Below, we must place all of the possible templates (views) that can be used in the portal list.
             Message := mod.widgets.Message {}
@@ -9277,8 +9287,17 @@ fn populate_message_view(
     // Sometimes we need to call this up-front, so we save the result in this variable
     // to avoid having to call it twice.
     let mut set_username_and_get_avatar_retval = None;
+    let has_room_mention = matches!(
+        &msg_like_content.kind,
+        MsgLikeKind::Message(msg) if msg.mentions().is_some_and(|m| m.room)
+    );
     let (item, used_cached_item) = match &msg_like_content.kind {
         MsgLikeKind::Message(msg) => {
+            let room_mention_room_id = if msg.mentions().is_some_and(|m| m.room) {
+                Some(timeline_kind.room_id())
+            } else {
+                None
+            };
             match msg.msgtype() {
                 MessageType::Text(TextMessageEventContent { body, formatted, .. }) => {
                     has_html_body = formatted.as_ref().is_some_and(|f| f.format == MessageFormat::Html);
@@ -9320,6 +9339,7 @@ fn populate_message_view(
                                 app_language,
                                 stream_body,
                                 stream_formatted,
+                                room_mention_room_id,
                                 Some(&mut link_preview_ref),
                                 Some(media_cache),
                                 Some(link_preview_cache),
@@ -9352,6 +9372,7 @@ fn populate_message_view(
                                     app_language,
                                     body,
                                     formatted.as_ref(),
+                                    room_mention_room_id,
                                     Some(&mut link_preview_ref),
                                     Some(media_cache),
                                     Some(link_preview_cache),
@@ -9404,6 +9425,7 @@ fn populate_message_view(
                             app_language,
                             body,
                             formatted.as_ref(),
+                            room_mention_room_id,
                             Some(&mut link_preview_ref),
                             Some(media_cache),
                             Some(link_preview_cache),
@@ -9454,6 +9476,7 @@ fn populate_message_view(
                                 format: MessageFormat::Html,
                                 body: formatted,
                             }),
+                            room_mention_room_id,
                             Some(&mut link_preview_ref),
                             Some(media_cache),
                             Some(link_preview_cache),
@@ -9506,6 +9529,7 @@ fn populate_message_view(
                             app_language,
                             &body,
                             formatted.as_ref(),
+                            room_mention_room_id,
                             Some(&mut link_preview_ref),
                             Some(media_cache),
                             Some(link_preview_cache),
@@ -9666,6 +9690,7 @@ fn populate_message_view(
                             app_language,
                             &verification.body,
                             Some(&formatted),
+                            room_mention_room_id,
                             Some(&mut link_preview_ref),
                             Some(media_cache),
                             Some(link_preview_cache),
@@ -9832,7 +9857,7 @@ fn populate_message_view(
             pinned_events,
             has_html_body,
         ),
-        should_be_highlighted: event_tl_item.is_highlighted(),
+        should_be_highlighted: event_tl_item.is_highlighted() || has_room_mention,
     };
     item.as_message().set_data(message_details);
 
@@ -9964,10 +9989,25 @@ fn populate_text_message_content(
     app_language: AppLanguage,
     body: &str,
     formatted_body: Option<&FormattedBody>,
+    room_mention_room_id: Option<&OwnedRoomId>,
     link_preview_ref: Option<&mut LinkPreviewRef>,
     media_cache: Option<&mut MediaCache>,
     link_preview_cache: Option<&mut LinkPreviewCache>,
 ) -> bool {
+    /// If this is a room mention, replace `@room` text in `html` with a pill
+    /// link to the room so it renders as a red room pill with the room's avatar.
+    fn apply_room_mention<'a>(html: Cow<'a, str>, room_id: Option<&OwnedRoomId>) -> Cow<'a, str> {
+        if let Some(room_id) = room_id {
+            if html.contains("@room") {
+                return Cow::Owned(html.replace(
+                    "@room",
+                    &format!("<a href=\"https://matrix.to/#/{room_id}\">@room</a>"),
+                ));
+            }
+        }
+        html
+    }
+
     // The message was HTML-formatted rich text.
     let mut links = Vec::new();
     if let Some(fb) = formatted_body.as_ref()
@@ -9978,12 +10018,14 @@ fn populate_text_message_content(
             true,
             Some(&mut links),
         );
-        message_content_widget.show_html(cx, linkified_html);
+        let html = apply_room_mention(linkified_html, room_mention_room_id);
+        message_content_widget.show_html(cx, html);
     }
     // The message was non-HTML plaintext.
     else {
         let linkified_html = utils::linkify_get_urls(body, false, Some(&mut links));
-        match linkified_html {
+        let html = apply_room_mention(linkified_html, room_mention_room_id);
+        match html {
             Cow::Owned(linkified_html) => message_content_widget.show_html(cx, &linkified_html),
             Cow::Borrowed(plaintext) => message_content_widget.show_plaintext(cx, plaintext),
         }
@@ -10021,6 +10063,7 @@ fn populate_bot_text_message_content(
     app_language: AppLanguage,
     body: &str,
     formatted_body: Option<&FormattedBody>,
+    room_mention_room_id: Option<&OwnedRoomId>,
     link_preview_ref: Option<&mut LinkPreviewRef>,
     media_cache: Option<&mut MediaCache>,
     link_preview_cache: Option<&mut LinkPreviewCache>,
@@ -10040,6 +10083,7 @@ fn populate_bot_text_message_content(
             app_language,
             body,
             formatted_body,
+            room_mention_room_id,
             link_preview_ref,
             media_cache,
             link_preview_cache,
@@ -10123,6 +10167,7 @@ fn populate_bot_text_message_content(
                 app_language,
                 &render_state.body,
                 formatted_body_for_card.as_ref(),
+                room_mention_room_id,
                 link_preview_ref,
                 media_cache,
                 link_preview_cache,
@@ -10875,7 +10920,7 @@ pub fn populate_preview_of_timeline_item(
         match m.msgtype() {
             MessageType::Text(TextMessageEventContent { body, formatted, .. })
             | MessageType::Notice(NoticeMessageEventContent { body, formatted, .. }) => {
-                let _ = populate_text_message_content(cx, widget_out, app_language, body, formatted.as_ref(), None, None, None);
+                let _ = populate_text_message_content(cx, widget_out, app_language, body, formatted.as_ref(), None, None, None, None);
                 return;
             }
             _ => { } // fall through to the general case for all timeline items below.

--- a/src/home/rooms_list_header.rs
+++ b/src/home/rooms_list_header.rs
@@ -14,6 +14,7 @@ use crate::{
     home::navigation_tab_bar::{NavigationBarAction, SelectedTab},
     i18n::{AppLanguage, tr_key},
     profile::user_profile_cache,
+    room_preview_cache,
     shared::{
         image_viewer::{ImageViewerAction, ImageViewerError, LoadState},
         popup_list::{PopupKind, enqueue_popup_notification},
@@ -194,6 +195,7 @@ impl Widget for RoomsListHeader {
                             // by RoomScreen in response to the StateUpdate action.
                             user_profile_cache::clear_all_pending_requests();
                             avatar_cache::clear_all_pending_and_failed_requests();
+                            room_preview_cache::clear_all_pending_requests();
                             // Now that we're no longer offline, we also need to tell the
                             // ProfileIcon to refresh itself and fetch our own user's profile again.
                             SignalToUI::set_ui_signal();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub mod cpu_worker;
 pub mod sliding_sync;
 pub mod space_service_sync;
 pub mod avatar_cache;
+pub mod room_preview_cache;
 pub mod media_cache;
 pub mod verification;
 pub mod updater;

--- a/src/room_preview_cache.rs
+++ b/src/room_preview_cache.rs
@@ -1,0 +1,202 @@
+//! A cache of resolved room previews, keyed on the room ID or alias used to
+//! reach the room.
+//!
+//! The cache stores a thinned-down [`FetchedRoomPreview`] — currently just
+//! the room's [`RoomNameId`] (ID + display name) and an [`AvatarState`] —
+//! which is the subset needed by `RobrixHtmlLink` widgets to draw room /
+//! alias / event link pills without re-querying the server each time. All
+//! three of `MatrixId::Room`, `MatrixId::RoomAlias`, and `MatrixId::Event`
+//! resolve to room-level metadata via the same `client.get_room_preview()`
+//! call, so they share entries here. User-link pills are served by the user
+//! profile cache and don't go through this cache.
+//!
+//! Entries are good for 24 hours; on read, expired `Loaded` entries are
+//! refetched. The cache is only accessible from the main UI thread.
+
+use crossbeam_queue::SegQueue;
+use hashbrown::hash_map::{HashMap, RawEntryMut};
+use makepad_widgets::{Cx, SignalToUI};
+use matrix_sdk::OwnedServerName;
+use ruma::{OwnedRoomOrAliasId, RoomOrAliasId};
+use std::{
+    cell::RefCell,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    room::{FetchedRoomAvatar, FetchedRoomPreview},
+    shared::avatar::AvatarState,
+    sliding_sync::{submit_async_request, MatrixRequest, RoomPreviewResponseMode},
+    utils::RoomNameId,
+};
+
+/// How long a `Loaded` entry stays valid before being refetched on next read.
+const CACHE_ENTRY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+thread_local! {
+    /// A cache of resolved room previews, indexed by room-or-alias ID.
+    ///
+    /// To be of any use, this cache must only be accessed by the main UI thread.
+    static ROOM_PREVIEW_CACHE: RefCell<HashMap<OwnedRoomOrAliasId, CacheEntry>>
+        = RefCell::new(HashMap::new());
+}
+
+struct CacheEntry {
+    state: CacheEntryState,
+    /// When this entry was inserted into the cache.
+    loaded_at: Instant,
+}
+
+enum CacheEntryState {
+    /// A fetch has been issued and we're waiting for it to complete.
+    Requested,
+    /// The room preview has been successfully loaded.
+    Loaded {
+        room_name_id: RoomNameId,
+        room_avatar: AvatarState,
+    },
+}
+
+/// What the caller of [`get_or_fetch_room_preview`] learns about a room.
+#[derive(Clone, Debug)]
+pub enum CachedRoomPreview {
+    /// Resolved info; safe to display the pill with this name and avatar.
+    Loaded {
+        room_name_id: RoomNameId,
+        room_avatar: AvatarState,
+    },
+    /// A fetch is in flight; the widget should show a fallback in the meantime.
+    Requested,
+}
+
+/// An update sent from the matrix worker thread once a room preview fetch completes.
+///
+/// Carries the full [`FetchedRoomPreview`] for forward-compatibility; the
+/// cache thins it down to [`RoomNameId`] + [`AvatarState`] on insert.
+pub struct RoomPreviewUpdate {
+    pub room_or_alias_id: OwnedRoomOrAliasId,
+    pub fetched: FetchedRoomPreview,
+}
+
+/// The queue of room preview updates waiting to be processed by the UI thread.
+static PENDING_ROOM_PREVIEW_UPDATES: SegQueue<RoomPreviewUpdate> = SegQueue::new();
+
+/// Enqueues a new room preview update and signals the UI that an update is available.
+pub fn enqueue_room_preview_update(update: RoomPreviewUpdate) {
+    PENDING_ROOM_PREVIEW_UPDATES.push(update);
+    SignalToUI::set_ui_signal();
+}
+
+/// Drains all pending room preview updates into the cache.
+///
+/// This function requires passing in a reference to `Cx`, which isn't used,
+/// but acts as a guarantee that this function must only be called by the
+/// main UI thread.
+pub fn process_room_preview_updates(_cx: &mut Cx) {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
+        while let Some(update) = PENDING_ROOM_PREVIEW_UPDATES.pop() {
+            let RoomPreviewUpdate { room_or_alias_id, fetched } = update;
+            cache.insert(
+                room_or_alias_id,
+                CacheEntry {
+                    state: CacheEntryState::Loaded {
+                        room_name_id: fetched.room_name_id,
+                        room_avatar: fetched_room_avatar_to_avatar_state(fetched.room_avatar),
+                    },
+                    loaded_at: Instant::now(),
+                },
+            );
+        }
+    });
+}
+
+/// Maps a [`FetchedRoomAvatar`] (the form returned by the worker, which has
+/// already attempted to fetch any avatar bytes) into an [`AvatarState`] for
+/// the cache. `Image(bytes)` becomes `Loaded(bytes)`; `Text(_)` becomes
+/// `Known(None)` — at this layer we don't distinguish "no avatar set" from
+/// "avatar fetch failed", since the consuming widget renders the same
+/// text fallback either way.
+fn fetched_room_avatar_to_avatar_state(avatar: FetchedRoomAvatar) -> AvatarState {
+    match avatar {
+        FetchedRoomAvatar::Image(bytes) => AvatarState::Loaded(bytes),
+        FetchedRoomAvatar::Text(_) => AvatarState::Known(None),
+    }
+}
+
+/// Returns the cached preview for the given room link, or kicks off a fetch
+/// if absent or expired.
+///
+/// This function requires passing in a reference to `Cx`, which isn't used,
+/// but acts as a guarantee that this function must only be called by the
+/// main UI thread.
+pub fn get_or_fetch_room_preview(
+    _cx: &mut Cx,
+    room_or_alias_id: &RoomOrAliasId,
+    via: &[OwnedServerName],
+) -> CachedRoomPreview {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
+        // `raw_entry_mut().from_key(&borrowed)` looks up by reference, so we
+        // only allocate an owned key on insert (vacant or stale-overwrite).
+        match cache.raw_entry_mut().from_key(room_or_alias_id) {
+            RawEntryMut::Occupied(mut occupied) => {
+                // Fast path: a fresh `Loaded` entry is returned as-is.
+                if let CacheEntryState::Loaded { room_name_id, room_avatar } = &occupied.get().state {
+                    if occupied.get().loaded_at.elapsed() < CACHE_ENTRY_TTL {
+                        return CachedRoomPreview::Loaded {
+                            room_name_id: room_name_id.clone(),
+                            room_avatar: room_avatar.clone(),
+                        };
+                    }
+                }
+                // Otherwise: a stale `Loaded` (refetch + overwrite) or an
+                // already in-flight `Requested` (no-op; prior fetch will land).
+                if matches!(occupied.get().state, CacheEntryState::Loaded { .. }) {
+                    submit_async_request(MatrixRequest::GetRoomPreview {
+                        room_or_alias_id: room_or_alias_id.to_owned(),
+                        via: via.to_vec(),
+                        response_mode: RoomPreviewResponseMode::RoomPreviewCache,
+                    });
+                    occupied.insert(CacheEntry {
+                        state: CacheEntryState::Requested,
+                        loaded_at: Instant::now(),
+                    });
+                }
+                CachedRoomPreview::Requested
+            }
+            RawEntryMut::Vacant(vacant) => {
+                submit_async_request(MatrixRequest::GetRoomPreview {
+                    room_or_alias_id: room_or_alias_id.to_owned(),
+                    via: via.to_vec(),
+                    response_mode: RoomPreviewResponseMode::RoomPreviewCache,
+                });
+                vacant.insert(
+                    room_or_alias_id.to_owned(),
+                    CacheEntry {
+                        state: CacheEntryState::Requested,
+                        loaded_at: Instant::now(),
+                    },
+                );
+                CachedRoomPreview::Requested
+            }
+        }
+    })
+}
+
+/// Removes all `Requested` entries so they can be re-fetched after a network
+/// recovery. Mirrors the same affordance on `user_profile_cache` and
+/// `avatar_cache`: in-flight requests submitted while offline likely failed
+/// silently, leaving stale `Requested` entries that would otherwise block
+/// re-fetching forever.
+pub fn clear_all_pending_requests() {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
+        cache.retain(|_, entry| !matches!(entry.state, CacheEntryState::Requested));
+    });
+}
+
+/// Clears the entire cache. Called on logout.
+///
+/// This function requires passing in a reference to `Cx`, which acts as a
+/// guarantee that this thread-local cache is cleared on the main UI thread.
+pub fn clear_room_preview_cache(_cx: &mut Cx) {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| cache.clear());
+}

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -1,11 +1,13 @@
 //! A `HtmlOrPlaintext` view can display either plaintext or rich HTML content.
 
+use std::sync::Arc;
+
 use makepad_widgets::*;
-use matrix_sdk::{ruma::{matrix_uri::MatrixId, OwnedMxcUri}, OwnedServerName};
+use matrix_sdk::{ruma::{matrix_uri::MatrixId, MatrixToUri, MatrixUri, RoomOrAliasId}, OwnedServerName};
 
-use crate::{avatar_cache::{self, AvatarCacheEntry}, profile::user_profile_cache, sliding_sync::{current_user_id, submit_async_request, MatrixRequest}, utils};
+use crate::{avatar_cache::{self, AvatarCacheEntry}, profile::user_profile_cache, room_preview_cache::{self, CachedRoomPreview}, sliding_sync::current_user_id, utils};
 
-use super::avatar::AvatarWidgetExt;
+use super::avatar::{AvatarState, AvatarWidgetExt};
 
 /// The color of the text used to print the spoiler reason before the hidden text.
 const COLOR_SPOILER_REASON: Vec4 = vec4(0.6, 0.6, 0.6, 1.0);
@@ -15,65 +17,79 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.BaseLinkPill = RoundedView {
-
+    // A pill-shaped widget that displays a Matrix link,
+    // either a link to a user, a room, or a message in a room.
+    //
+    // The outer widget derefs to View (not RoundedView), so we nest a
+    // RoundedView child to get the rounded background + border_radius shader.
+    mod.widgets.MatrixLinkPill = #(MatrixLinkPill::register_widget(vm)) {
         width: Fit, height: Fit,
-        flow: Right,
-        align: Align{ y: 0.5 }
-        padding: Inset{ left: 7, right: 7, bottom: 5, top: 5 }
-        spacing: 5.0,
+        cursor: MouseCursor.Hand,
 
-        show_bg: true,
-        draw_bg +: {
-            color: #000
-            border_radius: 7.0
-        }
+        pill_bg := RoundedView {
+            width: Fit, height: Fit,
+            flow: Right,
+            align: Align{ y: 0.5 }
+            padding: Inset{ left: 6, right: 4, bottom: -3, top: -3 }
+            margin: Inset{ right: 1 }
+            spacing: 1,
 
-        avatar := Avatar {
-            height: 18.0, width: 18.0,
-            text_view +: {
-                text +: {
-                    draw_text +: {
-                        text_style: TITLE_TEXT { font_size: 10.0 }
+            show_bg: true,
+            draw_bg +: {
+                color: #000
+                border_radius: 6.0
+            }
+
+            avatar := Avatar {
+                height: (MESSAGE_FONT_SIZE + 5), width: (MESSAGE_FONT_SIZE + 5),
+                // White bg so transparent avatar images are visible on the
+                // pill's black background.
+                img_view +: {
+                    show_bg: true,
+                    draw_bg +: { color: #fff }
+                }
+                text_view +: {
+                    text +: {
+                        draw_text +: {
+                            text_style: TITLE_TEXT { font_size: (MESSAGE_FONT_SIZE - 2) }
+                        }
                     }
                 }
             }
-        }
 
-        title := Label {
-            flow: Right, // do not wrap
-            draw_text +: {
-                color: #f,
-                text_style: MESSAGE_TEXT_STYLE { font_size: 10.0 },
+            title := Label {
+                flow: Right, // do not wrap
+                draw_text +: {
+                    color: #f,
+                    // line_spacing 1.0 prevents the label's row height from
+                    // inflating the pill vertically (pill is single-line).
+                    text_style: MESSAGE_TEXT_STYLE { font_size: (MESSAGE_FONT_SIZE), line_spacing: 1.0 },
+                }
+                text: "Unknown",
             }
-            text: "Unknown",
         }
     }
-
-    // A pill-shaped widget that displays a Matrix link,
-    // either a link to a user, a room, or a message in a room.
-    mod.widgets.MatrixLinkPill = #(MatrixLinkPill::register_widget(vm)) { }
 
     // A RobrixHtmlLink is either a regular Html link (default) or a Matrix link.
     // The Matrix link is a pill-shaped widget with an avatar and a title.
     //
-    // Layout notes:
-    // * `html_link` is a direct child (not wrapped in an intermediate View).
-    //   Wrapping `HtmlLink` inside a View breaks inline text wrapping, because
-    //   `HtmlLink::draw_walk` draws text directly into the parent `TextFlow`'s
-    //   turtle via `tf.draw_text()`. A surrounding View opens its own turtle
-    //   (via `cx.begin_turtle`), which replaces the turtle that `tf.draw_text`
-    //   reads to compute wrap width — so long links would refuse to break.
-    //   Instead, `RobrixHtmlLink::draw_walk` dispatches in Rust: it calls
-    //   `html_link.draw_walk` DIRECTLY for inline-text mode (no surrounding
-    //   turtle), and falls back to the outer View only for the pill mode.
+    // Drawing notes (see `RobrixHtmlLink::draw_walk` for the full story):
+    // * `html_link` is a direct child, NOT wrapped in an intermediate View.
+    //   `HtmlLink::draw_walk` draws inline text into the parent `TextFlow`'s
+    //   turtle; any surrounding View would open its own turtle and break the
+    //   inline wrap math. So `draw_walk` calls `html_link.draw_walk` directly
+    //   (bypassing `self.view.draw_walk`) for the inline-text path.
+    // * `matrix_link_view` IS a View (a pill is an atomic inline block with its
+    //   own turtle). `draw_walk` calls `matrix_link_view.draw_walk` directly
+    //   (also bypassing `self.view.draw_walk`) for the pill path.
+    // * Neither path goes through `self.view.draw_walk`, which would iterate
+    //   ALL children — and since `HtmlLink` has no `visible` field (so its
+    //   `visible()` is always `true`), it would double-draw alongside the pill.
     mod.widgets.RobrixHtmlLink = #(RobrixHtmlLink::register_widget(vm)) {
         width: Fit, height: Fit,
         align: Align{ y: 0.5 },
-        cursor: MouseCursor.Hand,
 
         html_link := HtmlLink {
-            visible: true,
             hover_color: (COLOR_LINK_HOVER)
             grab_key_focus: false,
             padding: Inset{left: 1.0, right: 1.5},
@@ -100,7 +116,11 @@ script_mod! {
     mod.widgets.MessageHtml = Html {
         padding: 0.0,
         width: Fill, height: Fit, // see comment in `HtmlOrPlaintext`
-        flow: Flow.Right{wrap: true},
+        // `RowAlign.Center` vertically centers each walk on its row. With the
+        // per-row FinishedWalk support in draw_walk_resumable_with, each visual
+        // row of wrapped text gets its own walk entry, so centering applies
+        // correctly even when a pill and multi-row text share the first line.
+        flow: Flow.Right{wrap: true, row_align: RowAlign.Center},
         align: Align{ y: 0.5 }
         font_size: (MESSAGE_FONT_SIZE),
         font_color: (MESSAGE_TEXT_COLOR),
@@ -121,7 +141,11 @@ script_mod! {
             font_size: (MESSAGE_FONT_SIZE)
             line_spacing: (MESSAGE_TEXT_LINE_SPACING)
         }
-        text_style_fixed: mod.widgets.MESSAGE_CODE_TEXT_STYLE { }
+        text_style_fixed: theme.font_code {
+            font_size: (MESSAGE_FONT_SIZE)
+            line_spacing: (MESSAGE_TEXT_LINE_SPACING)
+            top_drop: 0.11
+        }
         draw_block +: {
             line_color: (MESSAGE_TEXT_COLOR)
             sep_color: (MESSAGE_TEXT_COLOR)
@@ -130,12 +154,12 @@ script_mod! {
             quote_fg_color: (MESSAGE_TEXT_COLOR)
         }
 
-        quote_layout: Layout{ spacing: 0, padding: Inset{left: 15, top: 10.0, bottom: 10.0}, }
+        quote_layout: Layout{ flow: Flow.Right{wrap: true, row_align: RowAlign.Center}, spacing: 0, padding: Inset{left: 15, top: 10.0, bottom: 10.0}, }
         quote_walk: Walk{ margin: Inset{ top: 5, bottom: 5, left: 0 } }
 
         sep_walk: Walk{ margin: Inset{ top: 10, bottom: 10 } }
 
-        list_item_layout: Layout{ padding: Inset{left: 5.0, top: 1.0, bottom: 1.0}, }
+        list_item_layout: Layout{ flow: Flow.Right{wrap: true, row_align: RowAlign.Center}, padding: Inset{left: 5.0, top: 1.0, bottom: 1.0}, }
         list_item_marker_pad: 8.0
         list_item_walk: Walk{ margin: Inset{ left: 0, right: 0, top: 1, bottom: 3 } }
         code_layout: Layout{ padding: Inset{top: 15.0, bottom: 15.0, left: 15, right: 5 } }
@@ -243,17 +267,13 @@ impl Widget for RobrixHtmlLink {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        // TODO: pill-mode dispatch is currently disabled because Makepad doesn't
-        // yet support partial vertical alignment of inline block widgets (pills)
-        // with the surrounding text baseline. Once Makepad supports that, we can
-        // re-enable the Matrix URI parsing below to render pills inline.
-        /*
+        // If the URL is a Matrix user/room/event link, render it as a pill.
+        // Otherwise fall back to an inline-wrapping HTML link.
         if let Ok(matrix_to_uri) = MatrixToUri::parse(&self.url) {
             return self.draw_matrix_pill(cx, scope, walk, matrix_to_uri.id(), matrix_to_uri.via());
         } else if let Ok(matrix_uri) = MatrixUri::parse(&self.url) {
             return self.draw_matrix_pill(cx, scope, walk, matrix_uri.id(), matrix_uri.via());
         }
-        */
         self.draw_html_link(cx, scope, walk)
     }
 
@@ -270,11 +290,12 @@ impl Widget for RobrixHtmlLink {
 impl RobrixHtmlLink {
     /// Draws the Matrix link pill as an atomic inline block.
     ///
-    /// The pill is drawn via `self.view.draw_walk`, which opens a turtle and
-    /// renders the visible `matrix_link_view`. From the outer `TextFlow`'s
-    /// perspective, the pill is a single unbreakable inline unit (which is the
-    /// correct behavior — a pill shouldn't wrap internally).
-    #[allow(unused)]
+    /// The pill is drawn via `matrix_link_view.draw_walk` directly (not
+    /// `self.view.draw_walk`). Its turtle allocates the pill's natural height
+    /// in the parent TextFlow. `RowAlign::Center` on the parent `MessageHtml`
+    /// handles vertical centering: at each visual-row boundary, `finish_row`
+    /// shifts shorter items (text) down so their vertical centers align with
+    /// the tallest item (the pill) on that row.
     fn draw_matrix_pill(
         &mut self,
         cx: &mut Cx2d,
@@ -284,11 +305,14 @@ impl RobrixHtmlLink {
         via: &[OwnedServerName],
     ) -> DrawStep {
         if let Some(mut pill) = self.matrix_link_pill(cx, ids!(matrix_link)).borrow_mut() {
-            pill.populate_pill(cx, self.url.clone(), matrix_id, via);
+            pill.populate_pill(cx, self.url.clone(), matrix_id, via, self.text.as_ref());
         }
-        self.view(cx, ids!(matrix_link_view)).set_visible(cx, true);
-        self.html_link(cx, ids!(html_link)).set_visible(cx, false);
-        self.view.draw_walk(cx, scope, walk)
+        let matrix_link_view_ref = self.view(cx, ids!(matrix_link_view));
+        matrix_link_view_ref.set_visible(cx, true);
+        let Some(mut matrix_link_view) = matrix_link_view_ref.borrow_mut() else {
+            return DrawStep::done();
+        };
+        matrix_link_view.draw_walk(cx, scope, walk)
     }
 
     /// Draws the inner `HtmlLink` as inline wrapping text.
@@ -307,10 +331,9 @@ impl RobrixHtmlLink {
         scope: &mut Scope,
         walk: Walk,
     ) -> DrawStep {
-        // Keep subwidget visibility consistent with what's actually drawn, so
-        // `self.view.handle_event` can route events to the right place and
-        // skip the inactive subtree.
-        self.html_link(cx, ids!(html_link)).set_visible(cx, true);
+        // Hide the pill view in case we're switching away from pill mode.
+        // (No-op if it was already hidden.) `HtmlLink` has no `visible` field
+        // so there's nothing analogous to set on it.
         self.view(cx, ids!(matrix_link_view)).set_visible(cx, false);
 
         let mut html_link_ref = self.html_link(cx, ids!(html_link));
@@ -324,54 +347,39 @@ impl RobrixHtmlLink {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub enum MatrixLinkPillState {
-    Requested,
-    Loaded {
-        matrix_id: MatrixId,
-        name: String,
-        avatar_url: Option<OwnedMxcUri>,
-    },
-    #[default]
-    None,
-}
-
 /// A pill-shaped widget that shows a Matrix link as an avatar and a title.
 ///
-/// This can be a link to a user, a room, or a message in a room.
+/// This can be a link to a user, a room, or an event in a room.
 #[derive(Script, ScriptHook, Widget)]
 struct MatrixLinkPill {
     #[deref] view: View,
 
     #[rust] matrix_id: Option<MatrixId>,
     #[rust] via: Vec<OwnedServerName>,
-    #[rust] state: MatrixLinkPillState,
     #[rust] url: String,
 }
 
 impl Widget for MatrixLinkPill {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, _scope: &mut Scope) {
-        if let Event::Actions(actions) = event {
-            for action in actions {
-                if let Some(loaded @ MatrixLinkPillState::Loaded { matrix_id, .. }) = action.downcast_ref() {
-                    if self.matrix_id.as_ref() == Some(matrix_id) {
-                        self.state = loaded.clone();
-                        self.redraw(cx);
-                    }
-                }
+        if matches!(event, Event::Signal) {
+            room_preview_cache::process_room_preview_updates(cx);
+            if self.matrix_id.is_some() {
+                self.redraw(cx);
             }
         }
 
-        // To catch updates Redraw upon a UI Signal in order to catch updates to a user profile.
-        if matches!(event, Event::Signal) && matches!(self.matrix_id, Some(MatrixId::User(_))) {
-            self.redraw(cx);
-        }
-
-        if let Hit::FingerUp(fe) = event.hits_with_capture_overload(cx, self.area(), true) {
-            if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
+        // Handle hover (to set the cursor) and click in a single hit-test,
+        // avoiding the overhead of event-propagation to all child widgets.
+        match event.hits(cx, self.area()) {
+            Hit::FingerHoverIn(_) | Hit::FingerHoverOver(_) => {
+                if let Some(cursor) = self.cursor {
+                    cx.set_cursor(cursor);
+                }
+            }
+            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
                 if let Some(matrix_id) = self.matrix_id.clone() {
                     cx.widget_action(
-                        self.widget_uid(), 
+                        self.widget_uid(),
                         RobrixHtmlLinkAction::ClickedMatrixLink {
                             matrix_id,
                             via: self.via.clone(),
@@ -381,18 +389,12 @@ impl Widget for MatrixLinkPill {
                     );
                 }
             }
+            _ => (),
         }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.view.draw_walk(cx, scope, walk)
-    }
-
-    fn text(&self) -> String {
-        match &self.state {
-            MatrixLinkPillState::Loaded { name, .. } => name.clone(),
-            _ => String::new(),
-        }
     }
 
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
@@ -402,94 +404,115 @@ impl Widget for MatrixLinkPill {
 
 impl MatrixLinkPill {
     /// Populates this pill's info based on the given Matrix ID and via servers.
-    fn populate_pill(&mut self, cx: &mut Cx, url: String, matrix_id: &MatrixId, via: &[OwnedServerName]) {
+    fn populate_pill(&mut self, cx: &mut Cx, url: String, matrix_id: &MatrixId, via: &[OwnedServerName], link_text: &str) {
         self.url = url;
         self.matrix_id = Some(matrix_id.clone());
         self.via = via.to_vec();
 
+        let is_room_mention = link_text == "@room";
+        let is_self_mention = matches!(matrix_id, MatrixId::User(uid) if current_user_id().is_some_and(|u| &u == uid));
+
+        // Reset pill bg to default black, then apply red for mentions.
+        // This prevents stale red from persisting if a cached widget is
+        // reused for a different (non-mention) link after a message edit.
+        {
+            let mut pill_bg = self.view(cx, ids!(pill_bg));
+            if is_room_mention || is_self_mention {
+                script_apply_eval!(cx, pill_bg, { draw_bg +: { color: #d91b38 } });
+            } else {
+                script_apply_eval!(cx, pill_bg, { draw_bg +: { color: #000 } });
+            }
+        }
+
         // Handle a user ID link by querying the user profile cache.
         if let MatrixId::User(user_id) = matrix_id {
-            // Apply red background for current user
-            if current_user_id().is_some_and(|u| &u == user_id) {
-                script_apply_eval!(cx, self, {
-                    draw_bg +: { color: #d91b38}
-                });
-            }
-
-            match user_profile_cache::with_user_profile(
+            let (name, avatar_state) = match user_profile_cache::with_user_profile(
                 cx,
                 user_id.clone(),
                 None,
                 true,
                 |profile, _| { (profile.displayable_name().to_owned(), profile.avatar_state.clone()) }
             ) {
-                Some((name, avatar)) => {
-                    self.set_text(cx, &name);
-                    self.populate_avatar(cx, avatar.uri());
-                }
-                None => {
-                    self.set_text(cx, user_id.as_ref());
-                    self.populate_avatar(cx, None);
-                }
-            }
+                Some(pair) => pair,
+                None => (user_id.to_string(), AvatarState::Unknown),
+            };
+            self.set_text(cx, &name);
+            self.populate_avatar(cx, &avatar_state, &name);
             return;
         }
 
-        // Handle room ID or alias
-        match &self.state {
-            MatrixLinkPillState::Loaded { name, avatar_url, .. } => {
-                self.label(cx, ids!(title)).set_text(cx, name);
-                self.populate_avatar(cx, avatar_url.as_ref());
+        // Handle a room ID, alias, or event link by querying the room preview cache.
+        let room_or_alias_id: Option<&RoomOrAliasId> = match matrix_id {
+            MatrixId::Room(room_id) => Some((&**room_id).into()),
+            MatrixId::RoomAlias(alias) => Some((&**alias).into()),
+            MatrixId::Event(room_or_alias, _) => Some(room_or_alias),
+            _ => None,
+        };
+        if let Some(room_or_alias_id) = room_or_alias_id {
+            if let CachedRoomPreview::Loaded { room_name_id, room_avatar } =
+                room_preview_cache::get_or_fetch_room_preview(cx, room_or_alias_id, via)
+            {
+                // `RoomNameId::Display` would print "Room ID !xyz:server" for
+                // empty names; the pill should show just the bare room ID
+                // instead, matching the pre-cache behavior.
+                let resolved_name = if room_name_id.is_empty() {
+                    room_name_id.room_id().as_str().to_owned()
+                } else {
+                    room_name_id.to_string()
+                };
+                // For @room mentions, show "@room" as the title, not the room name.
+                let display_name = if is_room_mention { "@room" } else { resolved_name.as_str() };
+                self.label(cx, ids!(title)).set_text(cx, display_name);
+                self.populate_avatar(cx, &room_avatar, display_name);
                 return;
             }
-            MatrixLinkPillState::None => {
-                submit_async_request(MatrixRequest::GetMatrixRoomLinkPillInfo {
-                    matrix_id: matrix_id.clone(),
-                    via: via.to_vec(),
-                });
-                self.state = MatrixLinkPillState::Requested;
+        }
+        // While waiting for the async request to complete, show "@room" or the room ID/alias.
+        let fallback_name = if is_room_mention {
+            "@room".to_owned()
+        } else {
+            match matrix_id {
+                MatrixId::Room(room_id) => room_id.as_str().to_owned(),
+                MatrixId::RoomAlias(alias) => alias.as_str().to_owned(),
+                MatrixId::Event(room_or_alias, _) => format!("Message in {}", room_or_alias.as_str()),
+                _ => String::new(),
             }
-            MatrixLinkPillState::Requested => { }
-        }
-        // While waiting for the async request to complete, show the matrix room ID/alias.
-        match matrix_id {
-            MatrixId::Room(room_id) => self.set_text(cx, room_id.as_str()),
-            MatrixId::RoomAlias(alias) => self.set_text(cx, alias.as_str()),
-            MatrixId::Event(room_or_alias, _) => self.set_text(cx, &format!("Message in {}", room_or_alias.as_str())),
-            _ => { }
-        }
-        self.populate_avatar(cx, None);
+        };
+        self.set_text(cx, &fallback_name);
+        self.populate_avatar(cx, &AvatarState::Unknown, &fallback_name);
     }
 
-    fn populate_avatar(&self, cx: &mut Cx, avatar_url: Option<&OwnedMxcUri>) {
+    /// Renders the pill avatar from the given [`AvatarState`], falling back to
+    /// a text avatar built from `display_name` when no image is available.
+    ///
+    /// Handles all paths the pill needs:
+    /// * `Loaded(bytes)` — paint bytes directly (room link cache).
+    /// * `Known(Some(uri))` — fetch bytes via [`avatar_cache`] (user link).
+    /// * `Known(None)` / `Unknown` / `Failed` — text fallback.
+    fn populate_avatar(&self, cx: &mut Cx, avatar: &AvatarState, display_name: &str) {
         let avatar_ref = self.avatar(cx, ids!(avatar));
-        if let Some(avatar_url) = avatar_url {
-            if let AvatarCacheEntry::Loaded(data) = avatar_cache::get_or_fetch_avatar(cx, avatar_url) {
-                let res = avatar_ref.show_image(
-                    cx,
-                    None, // Don't make this avatar clickable
-                    |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, &data),
-                );
-                if res.is_ok() {
-                    return;
-                }
+        let bytes: Option<Arc<[u8]>> = match avatar {
+            AvatarState::Loaded(data) => Some(data.clone()),
+            AvatarState::Known(Some(uri)) => match avatar_cache::get_or_fetch_avatar(cx, uri) {
+                AvatarCacheEntry::Loaded(data) => Some(data),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(data) = bytes {
+            let res = avatar_ref.show_image(
+                cx,
+                None, // Don't make this avatar clickable
+                |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, &data),
+            );
+            if res.is_ok() {
+                return;
             }
         }
-        // Show a text avatar if we couldn't load an image into the avatar.
-        avatar_ref.show_text(cx, None, None, self.text());
-    }
-
-}
-
-impl MatrixLinkPillRef {
-    pub fn get_matrix_id(&self) -> Option<MatrixId> {
-        self.borrow().and_then(|inner| inner.matrix_id.clone())
-    }
-
-    pub fn get_via(&self) -> Vec<OwnedServerName> {
-        self.borrow().map(|inner| inner.via.clone()).unwrap_or_default()
+        avatar_ref.show_text(cx, None, None, display_name);
     }
 }
+
 
 /// A widget used to display a single HTML `<span>` tag or a `<font>` tag.
 #[derive(Script, Widget)]

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -26,7 +26,7 @@ use matrix_sdk::{
             },
             space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
             InitialStateEvent, MessageLikeEventType, StateEventType
-        }, matrix_uri::MatrixId, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, int, uint
+        }, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, int, uint
     }, sliding_sync::VersionBuilder, Client, ClientBuildError, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
 };
 use matrix_sdk_ui::{
@@ -46,11 +46,11 @@ use crate::{
     account_manager::{self, Account},
     app::{AppStateAction, RoomFilterRemoteSearchAction}, app_data_dir, avatar_cache::AvatarUpdate, event_preview::{BeforeText, TextPreview, text_preview_of_raw_timeline_event, text_preview_of_timeline_item}, home::{
         add_room::{CreatableSpacesAction, CreateRoomAction, CreateRoomContext, KnockResultAction}, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::{LinkPreviewData, LinkPreviewDataNonNumeric, LinkPreviewRateLimitResponse}, room_screen::{ActionResponseResultAction, InviteResultAction, ReportRoomResultAction, TimelineUpdate}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate, build_room_search_text, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails
-    }, homeserver::{CapabilityProbeAction, HsCapabilities, IdentityProviderSummary}, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state, take_skip_app_state_restore_once}, profile::{
+    }, homeserver::{CapabilityProbeAction, HsCapabilities, IdentityProviderSummary}, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, room_preview_cache::{enqueue_room_preview_update, RoomPreviewUpdate}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state, take_skip_app_state_restore_once}, profile::{
         user_profile::UserProfile,
         user_profile_cache::{UserProfileUpdate, enqueue_user_profile_update},
     }, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{
-        avatar::AvatarState, html_or_plaintext::MatrixLinkPillState, jump_to_bottom_button::UnreadMessageCount, popup_list::{PopupKind, enqueue_popup_notification}
+        avatar::AvatarState, jump_to_bottom_button::UnreadMessageCount, popup_list::{PopupKind, enqueue_popup_notification}
     }, space_service_sync::space_service_loop, utils::{self, AVATAR_THUMBNAIL_FORMAT, RoomNameId, VecDiff, avatar_from_room_name}, verification::add_verification_event_handlers_and_sync_client
 };
 
@@ -726,6 +726,19 @@ impl std::fmt::Display for TimelineKind {
     }
 }
 
+/// How the worker should deliver the result of a [`MatrixRequest::GetRoomPreview`].
+#[derive(Clone, Debug)]
+pub enum RoomPreviewResponseMode {
+    /// Posts a [`RoomPreviewAction::Fetched`] action with the result, success
+    /// or error. Used by interactive flows like the "join room" UI.
+    Action,
+    /// Stores the result in the [`crate::room_preview_cache`] on success;
+    /// logs and drops on error (the cache entry stays `Requested` until
+    /// `clear_all_pending_requests()` is called on offline→online recovery).
+    /// Used by `RobrixHtmlLink` pills.
+    RoomPreviewCache,
+}
+
 /// The set of requests for async work that can be made to the worker thread.
 #[allow(clippy::large_enum_variant)]
 pub enum MatrixRequest {
@@ -885,10 +898,13 @@ pub enum MatrixRequest {
     /// Request to fetch the preview (basic info) for the given room,
     /// either one that is joined locally or one that is unknown.
     ///
-    /// Emits a [`RoomPreviewAction::Fetched`] when the fetch operation has completed.
+    /// On completion, the result is dispatched according to `response_mode`:
+    /// either as a [`RoomPreviewAction::Fetched`] action, or by enqueueing
+    /// a cache update into the [`crate::room_preview_cache`].
     GetRoomPreview {
         room_or_alias_id: OwnedRoomOrAliasId,
         via: Vec<OwnedServerName>,
+        response_mode: RoomPreviewResponseMode,
     },
     /// Request to search server-side directory for users, rooms, or spaces.
     SearchDirectory {
@@ -1004,8 +1020,6 @@ pub enum MatrixRequest {
         /// * If `None`, the display name will be removed.
         new_display_name: Option<String>,
     },
-    /// Request to resolve a room alias into a room ID and the servers that know about that room.
-    ResolveRoomAlias(OwnedRoomAliasId),
     /// Request to fetch an Avatar image from the server.
     /// Upon completion of the async media request, the `on_fetched` function
     /// will be invoked with the content of an `AvatarUpdate`.
@@ -1143,13 +1157,6 @@ pub enum MatrixRequest {
         timeline_kind: TimelineKind,
         event_id: OwnedEventId,
         pin: bool,
-    },
-    /// Sends a request to obtain the room's pill link info for the given Matrix ID.
-    ///
-    /// The MatrixLinkPillInfo::Loaded variant is sent back to the main UI thread via.
-    GetMatrixRoomLinkPillInfo {
-        matrix_id: MatrixId,
-        via: Vec<OwnedServerName>
     },
     /// Request to fetch URL preview from the Matrix homeserver.
     GetUrlPreview {
@@ -2481,11 +2488,22 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::GetRoomPreview { room_or_alias_id, via } => {
+            MatrixRequest::GetRoomPreview { room_or_alias_id, via, response_mode } => {
                 let Some(client) = get_client() else { continue };
                 let _fetch_task = Handle::current().spawn(async move {
                     let res = fetch_room_preview_with_avatar(&client, &room_or_alias_id, via).await;
-                    Cx::post_action(RoomPreviewAction::Fetched(res));
+                    match response_mode {
+                        RoomPreviewResponseMode::Action => {
+                            Cx::post_action(RoomPreviewAction::Fetched(res));
+                        }
+                        RoomPreviewResponseMode::RoomPreviewCache => match res {
+                            Ok(fetched) => enqueue_room_preview_update(RoomPreviewUpdate {
+                                room_or_alias_id,
+                                fetched,
+                            }),
+                            Err(e) => log!("Failed to get room preview for {room_or_alias_id:?}: {e:?}"),
+                        },
+                    }
                 });
             }
 
@@ -2777,7 +2795,7 @@ async fn matrix_worker_task(
                                     room_member,
                                 });
                             } else {
-                                log!("User profile request: user {user_id} was not a member of room {room_id}");
+                                // log!("User profile request: user {user_id} was not a member of room {room_id}");
                             }
                         } else {
                             log!("User profile request: client could not get room with ID {room_id}");
@@ -3303,16 +3321,6 @@ async fn matrix_worker_task(
 
             MatrixRequest::SpawnSSOServer { brand, homeserver_url, identity_provider_id, proxy } => {
                 spawn_sso_server(brand, homeserver_url, identity_provider_id, proxy, login_sender.clone()).await;
-            }
-
-            MatrixRequest::ResolveRoomAlias(room_alias) => {
-                let Some(client) = get_client() else { continue };
-                let _resolve_task = Handle::current().spawn(async move {
-                    log!("Sending resolve room alias request for {room_alias}...");
-                    let res = client.resolve_room_alias(&room_alias).await;
-                    log!("Resolved room alias {room_alias} to: {res:?}");
-                    todo!("Send the resolved room alias back to the UI thread somehow.");
-                });
             }
 
             MatrixRequest::FetchAvatar { mxc_uri, on_fetched } => {
@@ -3944,33 +3952,6 @@ async fn matrix_worker_task(
                     match sender.send(TimelineUpdate::PinResult { event_id, pin, result }) {
                         Ok(_) => SignalToUI::set_ui_signal(),
                         Err(_) => log!("Failed to send UI update for pin event."),
-                    }
-                });
-            }
-
-            MatrixRequest::GetMatrixRoomLinkPillInfo { matrix_id, via } => {
-                let Some(client) = get_client() else { continue };
-                let _fetch_matrix_link_pill_info_task = Handle::current().spawn(async move {
-                    let room_or_alias_id: Option<&RoomOrAliasId> = match &matrix_id {
-                        MatrixId::Room(room_id) => Some((&**room_id).into()),
-                        MatrixId::RoomAlias(room_alias_id) => Some((&**room_alias_id).into()),
-                        MatrixId::Event(room_or_alias_id, _event_id) => Some(room_or_alias_id),
-                        _ => {
-                            log!("MatrixLinkRoomPillInfoRequest: Unsupported MatrixId type: {matrix_id:?}");
-                            return;
-                        }
-                    };
-                    if let Some(room_or_alias_id) = room_or_alias_id {
-                        match client.get_room_preview(room_or_alias_id, via).await {
-                            Ok(preview) => Cx::post_action(MatrixLinkPillState::Loaded {
-                                matrix_id: matrix_id.clone(),
-                                name: preview.name.unwrap_or_else(|| room_or_alias_id.to_string()),
-                                avatar_url: preview.avatar_url
-                            }),
-                            Err(_e) => {
-                                log!("Failed to get room link pill info for {room_or_alias_id:?}: {_e:?}");
-                            }
-                        };
                     }
                 });
             }


### PR DESCRIPTION
## Summary
This PR backports the next upstream migration batch, keeping implementation aligned with upstream Robrix and minimizing local divergence.

Upstream commits included:
- c1a78b02: room/user pill + full `@room` support
- 22efa4f6: link preview cache + blurhash decode optimization
- 63f01d94: tooltip handles actions directly
- 6027ee2e: room_preview_cache integration

## Changes
- Add `room_preview_cache` module and wire it into app lifecycle and offline->online recovery
- Route room preview fetching in `sliding_sync` via `RoomPreviewResponseMode`
  - action mode for interactive flows
  - cache mode for Matrix link pills
- Remove legacy matrix link pill request paths replaced by room preview cache flow
- Implement full `@room` mention pill rendering path in timeline text rendering
- Include `@room` in highlight behavior (`should_be_highlighted`)
- Optimize link preview rendering by caching `last_populated_links` and skipping expensive re-populate when unchanged
- Reduce blurhash decode max size from `500` to `32`
- Let tooltip widget handle tooltip actions directly (remove app-level manual hover handling)

## Verification
- `cargo build` passes

## Notes
- App settings area intentionally not touched in this batch.
