### PR TITLE
proxy: unify GUI-saved proxy as the single source of truth for HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -5725,20 +5725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "robius-proxy"
-version = "0.2.0"
-source = "git+https://github.com/Project-Robius-China/robius2.git#f05fdf168ee4407977f11d57d99a5bc34b0f92f1"
-dependencies = [
- "cfg-if",
- "core-foundation 0.9.4",
- "jni",
- "robius-android-env",
- "system-configuration 0.7.0",
- "system-configuration-sys",
- "windows 0.56.0",
-]
-
-[[package]]
 name = "robius-use-makepad"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5787,7 +5773,6 @@ dependencies = [
  "robius-directories",
  "robius-location",
  "robius-open",
- "robius-proxy",
  "robius-use-makepad",
  "ruma",
  "sanitize-filename",
@@ -6871,17 +6856,6 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ robius-use-makepad = "0.1.1"
 robius-open = { git = "https://github.com/Project-Robius-China/robius2.git" }
 robius-directories = { git = "https://github.com/Project-Robius-China/robius2.git" }
 robius-location = { git = "https://github.com/Project-Robius-China/robius2.git" }
-robius-proxy = { git = "https://github.com/Project-Robius-China/robius2.git" }
 
 
 anyhow = "1.0"

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -39,7 +39,7 @@
   "settings.preferences.proxy.input.port": "7890",
   "settings.preferences.proxy.input.account": "",
   "settings.preferences.proxy.input.password": "",
-  "settings.preferences.proxy.popup.saved": "Saved proxy settings. Re-login to apply to the current Matrix session.",
+  "settings.preferences.proxy.popup.saved": "Proxy settings saved. Restart Robrix to apply the new proxy to the current session.",
   "settings.preferences.proxy.popup.cleared": "Cleared proxy settings.",
   "settings.preferences.proxy.popup.invalid": "Invalid proxy URL.",
   "settings.preferences.proxy.popup.clear_failed": "Failed to clear proxy settings.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -39,7 +39,7 @@
   "settings.preferences.proxy.input.port": "7890",
   "settings.preferences.proxy.input.account": "",
   "settings.preferences.proxy.input.password": "",
-  "settings.preferences.proxy.popup.saved": "代理设置已保存。请重新登录以应用到当前 Matrix 会话。",
+  "settings.preferences.proxy.popup.saved": "代理设置已保存。请重启 Robrix 让新代理生效。",
   "settings.preferences.proxy.popup.cleared": "代理设置已清除。",
   "settings.preferences.proxy.popup.invalid": "代理 URL 无效。",
   "settings.preferences.proxy.popup.clear_failed": "清除代理设置失败。",

--- a/specs/task-proxy-policy.spec.md
+++ b/specs/task-proxy-policy.spec.md
@@ -13,10 +13,16 @@ tags: [proxy, network, matrix, persistence]
 - Source of truth: `proxy_state.json` / GUI 保存值优先于 shell 或系统继承的 `http_proxy`、`https_proxy`、`all_proxy`、`NO_PROXY`
 - `proxy_url = null` 表示强制无代理，Robrix 创建的 reqwest / Matrix HTTP client 必须显式调用 `no_proxy()`，不依赖也不修改进程环境变量
 - `proxy_url = Some(...)` 表示启用代理，Robrix 创建的 reqwest / Matrix HTTP client 必须显式设置该 proxy URL 和统一 bypass 规则，不通过环境变量传播
-- Proxy bypass baseline: 只包含通用 loopback: `localhost`、`127.0.0.1`、`::1`
-- 本地 homeserver 地址不在代码中硬编码，也不从 homeserver URL 隐式追加 bypass；如未来需要配置非 loopback bypass，应作为 GUI 配置项进入 `proxy_state.json`
+- Proxy bypass baseline:
+  - Loopback: `localhost`、`127.0.0.1`、`::1`
+  - IPv4 RFC 1918 私有网段: `10.0.0.0/8`、`172.16.0.0/12`、`192.168.0.0/16`
+  - IPv4 link-local: `169.254.0.0/16`
+  - IPv6 ULA (RFC 4193): `fc00::/7`
+  - IPv6 link-local: `fe80::/10`
+- Bypass 是 best-effort，目的是让 GUI 填了公网 HTTP proxy（如 `127.0.0.1:7890` 的 Clash）的同时仍能直连 LAN 上的 self-hosted homeserver/Palpo。Trade-off: 公司 VPN 将公网 homeserver 解析到 RFC 1918 时也会走直连——这是预期行为（VPN 已提供加密传输），目前不提供 GUI 例外配置
+- 不硬编码具体 LAN IP；只硬编码标准化网段。如未来需要非 RFC 1918 的额外 bypass（如 CGNAT、自定义 LAN），应作为 GUI 配置项进入 `proxy_state.json`
 - Matrix SDK client、homeserver discovery reqwest client、直接下载 reqwest client、updater reqwest client 必须复用同一 proxy policy helper
-- TSP 使用不同 reqwest 版本，必须镜像同一 proxy policy: TLS 1.2、loopback bypass、无 GUI proxy 时显式禁用 system proxy
+- TSP 使用不同 reqwest 版本，必须镜像同一 proxy policy: TLS 1.2、共享 `DEFAULT_NO_PROXY_BYPASS`、无 GUI proxy 时显式禁用 system proxy
 - 显式 reqwest proxy 必须带相同 no-proxy bypass 规则；无 GUI proxy 时显式禁用 reqwest system proxy
 - 不新增 Cargo 依赖，不运行 `cargo fmt`
 
@@ -72,7 +78,7 @@ Scenario: 显式 reqwest client 遵循无代理策略
   Then client builder 显式禁用 system proxy
   And 本地 homeserver 请求不会被旧环境代理污染
 
-Scenario: 显式 reqwest proxy 只包含最小 loopback bypass
+Scenario: 显式 reqwest proxy 包含 loopback + 私有网段 bypass
   Test: build_policy_reqwest_client_attaches_no_proxy_bypass_for_local_addresses
   Level: unit
   Test Double: reqwest proxy debug representation
@@ -81,7 +87,9 @@ Scenario: 显式 reqwest proxy 只包含最小 loopback bypass
   When Robrix 构建 homeserver discovery、下载、restore session 或 updater 使用的 reqwest client
   Then 显式 proxy 使用相同代理 URL
   And no-proxy bypass 包含 localhost、127.0.0.1、::1
-  And 不包含硬编码私有网段或具体局域网 homeserver IP
+  And no-proxy bypass 包含 RFC 1918 网段（10.0.0.0/8、172.16.0.0/12、192.168.0.0/16）
+  And no-proxy bypass 包含 link-local 与 IPv6 ULA（169.254.0.0/16、fc00::/7、fe80::/10）
+  And 不包含硬编码的具体局域网 homeserver IP
 
 Scenario: 非 Matrix reqwest 路径遵循同一代理策略
   Test: updater_http_client_disables_system_proxy_when_proxy_is_none

--- a/specs/task-proxy-policy.spec.md
+++ b/specs/task-proxy-policy.spec.md
@@ -6,16 +6,17 @@ tags: [proxy, network, matrix, persistence]
 
 ## Intent
 
-统一 Robrix2 的网络代理策略，消除 GUI 保存配置与进程继承环境变量同时生效导致的请求路径不一致。GUI 保存的 `proxy_state.json` 是唯一来源：关闭代理必须强制无代理，开启代理必须通过同一套策略影响 Robrix 发起的 HTTP/Matrix 请求，并且本地 homeserver 不能被外部代理环境劫持。
+统一 Robrix2 的网络代理策略，消除 GUI 保存配置与进程继承环境变量同时生效导致的请求路径不一致。GUI 保存的 `proxy_state.json` 是唯一来源：关闭代理必须让 Robrix 自己创建的 HTTP client 显式禁用系统代理，开启代理必须通过同一套显式策略影响 Robrix 发起的 HTTP/Matrix 请求，并且本地 homeserver 不能被外部代理环境劫持。
 
 ## Decisions
 
 - Source of truth: `proxy_state.json` / GUI 保存值优先于 shell 或系统继承的 `http_proxy`、`https_proxy`、`all_proxy`、`NO_PROXY`
-- `proxy_url = null` 表示强制无代理，启动和保存时都必须清理进程代理环境
-- `proxy_url = Some(...)` 表示启用代理，必须设置 `http_proxy`、`https_proxy`、`all_proxy` 与 `NO_PROXY`/`no_proxy`
+- `proxy_url = null` 表示强制无代理，Robrix 创建的 reqwest / Matrix HTTP client 必须显式调用 `no_proxy()`，不依赖也不修改进程环境变量
+- `proxy_url = Some(...)` 表示启用代理，Robrix 创建的 reqwest / Matrix HTTP client 必须显式设置该 proxy URL 和统一 bypass 规则，不通过环境变量传播
 - Proxy bypass baseline: 只包含通用 loopback: `localhost`、`127.0.0.1`、`::1`
 - 本地 homeserver 地址不在代码中硬编码，也不从 homeserver URL 隐式追加 bypass；如未来需要配置非 loopback bypass，应作为 GUI 配置项进入 `proxy_state.json`
-- Matrix SDK client、homeserver discovery reqwest client、直接下载 reqwest client 必须复用同一 proxy policy helper
+- Matrix SDK client、homeserver discovery reqwest client、直接下载 reqwest client、updater reqwest client 必须复用同一 proxy policy helper
+- TSP 使用不同 reqwest 版本，必须镜像同一 proxy policy: TLS 1.2、loopback bypass、无 GUI proxy 时显式禁用 system proxy
 - 显式 reqwest proxy 必须带相同 no-proxy bypass 规则；无 GUI proxy 时显式禁用 reqwest system proxy
 - 不新增 Cargo 依赖，不运行 `cargo fmt`
 
@@ -39,45 +40,35 @@ tags: [proxy, network, matrix, persistence]
 
 ## Completion Criteria
 
-Scenario: 启动时无保存代理会清理继承环境
-  Test: proxy_state_none_clears_inherited_env_proxy_vars
+Scenario: 保存关闭代理不会修改进程环境
+  Test: save_proxy_url_none_persists_direct_policy
   Level: unit
-  Test Double: serialized process env snapshot
+  Test Double: temp proxy_state file
   Targets: src/proxy_config.rs
-  Given 进程环境里存在旧的 `http_proxy`、`https_proxy`、`all_proxy` 和 `NO_PROXY`
-  And `proxy_state.json` 不存在或 `proxy_url` 为 null
-  When Robrix 启动并应用保存的代理配置
-  Then 旧代理环境变量被清理
-  And 后续 HTTP client 不会自动继承 system proxy
-
-Scenario: 保存关闭代理会立即强制无代理
-  Test: save_proxy_url_none_clears_env_proxy_vars
-  Level: unit
-  Test Double: temp proxy_state file and serialized process env snapshot
-  Targets: src/proxy_config.rs
-  Given 进程环境里存在旧的代理变量
+  Given GUI proxy policy 为 None
   When GUI 保存 `proxy_url = null`
   Then `proxy_state.json` 保存 null
-  And 进程代理环境变量被清理
+  And Robrix 不提供任何运行期写入代理环境变量的 production API
+  And 强制无代理由后续 HTTP client 的显式 `no_proxy()` 实现
 
-Scenario: 保存开启代理会设置统一环境和 bypass
-  Test: save_proxy_url_some_sets_proxy_env_and_bypass_rules
+Scenario: 保存开启代理不会通过环境变量传播
+  Test: save_proxy_url_some_persists_proxy_policy
   Level: unit
-  Test Double: temp proxy_state file and serialized process env snapshot
+  Test Double: temp proxy_state file
   Targets: src/proxy_config.rs
   Given GUI 输入代理 "http://127.0.0.1:7890"
   When 保存代理配置
-  Then `http_proxy`、`https_proxy`、`all_proxy` 都等于该代理
-  And `NO_PROXY` 或 `no_proxy` 包含 localhost 和 loopback bypass 规则
+  Then `proxy_state.json` 保存该代理
+  And Robrix 不提供任何运行期写入代理环境变量的 production API
+  And 代理传播由后续 HTTP client 的显式 proxy builder 实现
 
 Scenario: 显式 reqwest client 遵循无代理策略
   Test: build_policy_reqwest_client_disables_system_proxy_when_proxy_is_none
   Level: unit
-  Test Double: serialized process env snapshot
+  Test Double: in-memory client builder construction
   Targets: src/proxy_config.rs, src/sliding_sync.rs
-  Given shell 环境中存在 `http_proxy`
-  And GUI proxy policy 为 None
-  When Robrix 构建 homeserver discovery 或下载使用的 reqwest client
+  Given GUI proxy policy 为 None
+  When Robrix 构建 homeserver discovery、下载、restore session 或 updater 使用的 reqwest client
   Then client builder 显式禁用 system proxy
   And 本地 homeserver 请求不会被旧环境代理污染
 
@@ -87,10 +78,22 @@ Scenario: 显式 reqwest proxy 只包含最小 loopback bypass
   Test Double: reqwest proxy debug representation
   Targets: src/proxy_config.rs, src/sliding_sync.rs
   Given GUI proxy policy 为 "http://127.0.0.1:7890"
-  When Robrix 构建 homeserver discovery 或下载使用的 reqwest client
+  When Robrix 构建 homeserver discovery、下载、restore session 或 updater 使用的 reqwest client
   Then 显式 proxy 使用相同代理 URL
   And no-proxy bypass 包含 localhost、127.0.0.1、::1
   And 不包含硬编码私有网段或具体局域网 homeserver IP
+
+Scenario: 非 Matrix reqwest 路径遵循同一代理策略
+  Test: updater_http_client_disables_system_proxy_when_proxy_is_none
+  Test: tsp_proxy_policy_disables_system_proxy_when_proxy_is_none
+  Test: tsp_proxy_policy_attaches_no_proxy_bypass_for_local_addresses
+  Level: unit
+  Test Double: code path inspection and shared helper construction
+  Targets: src/updater.rs, src/tsp/mod.rs
+  Given GUI proxy policy 为 None
+  When updater 或 TSP 创建 reqwest client
+  Then updater 复用 `build_policy_reqwest_client`
+  And TSP 镜像同一 policy 并显式调用 `no_proxy()`
 
 Scenario: 无效代理 URL 被拒绝
   Test: discovery_http_client_rejects_invalid_proxy_override

--- a/specs/task-proxy-policy.spec.md
+++ b/specs/task-proxy-policy.spec.md
@@ -24,6 +24,7 @@ tags: [proxy, network, matrix, persistence]
 - Matrix SDK client、homeserver discovery reqwest client、直接下载 reqwest client、updater reqwest client 必须复用同一 proxy policy helper
 - TSP 使用不同 reqwest 版本，必须镜像同一 proxy policy: TLS 1.2、共享 `DEFAULT_NO_PROXY_BYPASS`、无 GUI proxy 时显式禁用 system proxy
 - 显式 reqwest proxy 必须带相同 no-proxy bypass 规则；无 GUI proxy 时显式禁用 reqwest system proxy
+- 加载已保存的 proxy 时，遇到当前 `validate_proxy_url` 不再支持的 scheme（如旧版 `socks5://`）必须降级为 None 并 `warning!`，不让陈旧记录在 HTTP client 构造期才以不透明错误浮出
 - 不新增 Cargo 依赖，不运行 `cargo fmt`
 
 ## Boundaries
@@ -111,6 +112,16 @@ Scenario: 无效代理 URL 被拒绝
   Given GUI 或登录页输入代理 "ftp://proxy.invalid"
   When Robrix 构建 discovery HTTP client
   Then 构建失败并报告不支持的 proxy scheme
+
+Scenario: 加载旧版 socks5 保存会降级为无代理
+  Test: load_saved_proxy_url_ignores_legacy_socks_scheme
+  Level: unit
+  Test Double: temp proxy_state file with legacy socks5 entry
+  Targets: src/proxy_config.rs
+  Given `proxy_state.json` 中保留了旧版本写入的 `socks5://127.0.0.1:1080`
+  When Robrix 启动并调用 `load_saved_proxy_url`
+  Then 返回 None 而非透传 socks5 URL
+  And 记录 warning 提示用户重新在 Settings 中保存支持的 scheme
 
 Scenario: cargo build passes
   Test: cargo_build

--- a/specs/task-proxy-policy.spec.md
+++ b/specs/task-proxy-policy.spec.md
@@ -1,0 +1,117 @@
+spec: task
+name: "Proxy Policy Unified Source Of Truth"
+inherits: project
+tags: [proxy, network, matrix, persistence]
+---
+
+## Intent
+
+统一 Robrix2 的网络代理策略，消除 GUI 保存配置与进程继承环境变量同时生效导致的请求路径不一致。GUI 保存的 `proxy_state.json` 是唯一来源：关闭代理必须强制无代理，开启代理必须通过同一套策略影响 Robrix 发起的 HTTP/Matrix 请求，并且本地 homeserver 不能被外部代理环境劫持。
+
+## Decisions
+
+- Source of truth: `proxy_state.json` / GUI 保存值优先于 shell 或系统继承的 `http_proxy`、`https_proxy`、`all_proxy`、`NO_PROXY`
+- `proxy_url = null` 表示强制无代理，启动和保存时都必须清理进程代理环境
+- `proxy_url = Some(...)` 表示启用代理，必须设置 `http_proxy`、`https_proxy`、`all_proxy` 与 `NO_PROXY`/`no_proxy`
+- Proxy bypass baseline: 只包含通用 loopback: `localhost`、`127.0.0.1`、`::1`
+- 本地 homeserver 地址不在代码中硬编码，也不从 homeserver URL 隐式追加 bypass；如未来需要配置非 loopback bypass，应作为 GUI 配置项进入 `proxy_state.json`
+- Matrix SDK client、homeserver discovery reqwest client、直接下载 reqwest client 必须复用同一 proxy policy helper
+- 显式 reqwest proxy 必须带相同 no-proxy bypass 规则；无 GUI proxy 时显式禁用 reqwest system proxy
+- 不新增 Cargo 依赖，不运行 `cargo fmt`
+
+## Boundaries
+
+### Allowed Changes
+- src/proxy_config.rs
+- src/sliding_sync.rs
+- src/persistence/matrix_state.rs
+- src/login/login_screen.rs
+- src/settings/settings_screen.rs
+- src/tsp/mod.rs
+- src/updater.rs
+- specs/task-proxy-policy.spec.md
+
+### Forbidden
+- 不要修改 Matrix session 删除策略或 token 失效判断
+- 不要重构登录、设置页的 UI 布局
+- 不要添加新的 Cargo 依赖
+- 不要运行 `cargo fmt` 或 `rustfmt`
+
+## Completion Criteria
+
+Scenario: 启动时无保存代理会清理继承环境
+  Test: proxy_state_none_clears_inherited_env_proxy_vars
+  Level: unit
+  Test Double: serialized process env snapshot
+  Targets: src/proxy_config.rs
+  Given 进程环境里存在旧的 `http_proxy`、`https_proxy`、`all_proxy` 和 `NO_PROXY`
+  And `proxy_state.json` 不存在或 `proxy_url` 为 null
+  When Robrix 启动并应用保存的代理配置
+  Then 旧代理环境变量被清理
+  And 后续 HTTP client 不会自动继承 system proxy
+
+Scenario: 保存关闭代理会立即强制无代理
+  Test: save_proxy_url_none_clears_env_proxy_vars
+  Level: unit
+  Test Double: temp proxy_state file and serialized process env snapshot
+  Targets: src/proxy_config.rs
+  Given 进程环境里存在旧的代理变量
+  When GUI 保存 `proxy_url = null`
+  Then `proxy_state.json` 保存 null
+  And 进程代理环境变量被清理
+
+Scenario: 保存开启代理会设置统一环境和 bypass
+  Test: save_proxy_url_some_sets_proxy_env_and_bypass_rules
+  Level: unit
+  Test Double: temp proxy_state file and serialized process env snapshot
+  Targets: src/proxy_config.rs
+  Given GUI 输入代理 "http://127.0.0.1:7890"
+  When 保存代理配置
+  Then `http_proxy`、`https_proxy`、`all_proxy` 都等于该代理
+  And `NO_PROXY` 或 `no_proxy` 包含 localhost 和 loopback bypass 规则
+
+Scenario: 显式 reqwest client 遵循无代理策略
+  Test: build_policy_reqwest_client_disables_system_proxy_when_proxy_is_none
+  Level: unit
+  Test Double: serialized process env snapshot
+  Targets: src/proxy_config.rs, src/sliding_sync.rs
+  Given shell 环境中存在 `http_proxy`
+  And GUI proxy policy 为 None
+  When Robrix 构建 homeserver discovery 或下载使用的 reqwest client
+  Then client builder 显式禁用 system proxy
+  And 本地 homeserver 请求不会被旧环境代理污染
+
+Scenario: 显式 reqwest proxy 只包含最小 loopback bypass
+  Test: build_policy_reqwest_client_attaches_no_proxy_bypass_for_local_addresses
+  Level: unit
+  Test Double: reqwest proxy debug representation
+  Targets: src/proxy_config.rs, src/sliding_sync.rs
+  Given GUI proxy policy 为 "http://127.0.0.1:7890"
+  When Robrix 构建 homeserver discovery 或下载使用的 reqwest client
+  Then 显式 proxy 使用相同代理 URL
+  And no-proxy bypass 包含 localhost、127.0.0.1、::1
+  And 不包含硬编码私有网段或具体局域网 homeserver IP
+
+Scenario: 无效代理 URL 被拒绝
+  Test: discovery_http_client_rejects_invalid_proxy_override
+  Level: unit
+  Test Double: in-memory client builder construction
+  Targets: src/proxy_config.rs, src/sliding_sync.rs
+  Given GUI 或登录页输入代理 "ftp://proxy.invalid"
+  When Robrix 构建 discovery HTTP client
+  Then 构建失败并报告不支持的 proxy scheme
+
+Scenario: cargo build passes
+  Test: cargo_build
+  Level: integration
+  Targets: cargo build
+  Given proxy policy 统一化改动完成
+  When 运行 `cargo build`
+  Then 构建通过
+
+## Out of Scope
+
+- Palpo 服务端配置或部署修改
+- auto-login PR 的 session 删除策略修改
+- 代理认证 UI 的视觉调整
+- 支持 PAC、WPAD 或平台系统代理发现

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     app_data_dir,
     login::login_screen::LoginAction,
+    proxy_config::{build_policy_reqwest_client, resolve_effective_proxy_url},
 };
 
 /// The data needed to re-build a client.
@@ -212,22 +213,23 @@ pub async fn restore_session(
         status: status_str,
     });
     // Build the client with the previous settings from the session.
-    let mut client_builder = Client::builder()
+    // Use the same resolver as build_client so a CLI `--proxy` override at
+    // startup is honored on session restore. Match build_client's 60s reqwest
+    // timeout so restored sessions don't hang indefinitely on slow homeservers.
+    let effective_proxy = resolve_effective_proxy_url(None);
+    let http_client = build_policy_reqwest_client(
+        effective_proxy.as_deref(),
+        Some(std::time::Duration::from_secs(60)),
+    )
+        .map_err(|e| anyhow!("Failed to build Matrix HTTP client with proxy policy: {e}"))?;
+    let client_builder = Client::builder()
         .homeserver_url(client_session.homeserver.clone())
         .sqlite_store(client_session.db_path.clone(), Some(&client_session.passphrase))
         .with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
             with_subscriptions: true,
         })
+        .http_client(http_client)
         .handle_refresh_tokens();
-    let saved_proxy = crate::proxy_config::load_saved_proxy_url();
-    if let Some(proxy) = saved_proxy.as_deref() {
-        if let Err(e) = crate::proxy_config::apply_proxy_to_process_env(Some(proxy)) {
-            warning!("Failed to apply proxy env before restoring Matrix session: {e}");
-        }
-    }
-    if let Some(proxy) = saved_proxy {
-        client_builder = client_builder.proxy(proxy);
-    }
     let client = client_builder.build().await?;
     let sliding_sync_version = sliding_sync_version.into();
     client.set_sliding_sync_version(sliding_sync_version);

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -1,14 +1,39 @@
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::{Path, PathBuf}, sync::{Mutex, OnceLock}, time::Duration};
 
 use makepad_widgets::{error, warning};
+use matrix_sdk::reqwest::{Client, ClientBuilder, NoProxy, Proxy, tls};
 use robius_proxy::ProxyConfig;
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+const POLICY_USER_AGENT: &str = concat!(
+    "Robrix/", env!("CARGO_PKG_VERSION"), " (matrix-rust-sdk)"
+);
 
 use crate::app_data_dir;
 
 
 const PROXY_STATE_FILE_NAME: &str = "proxy_state.json";
+pub const DEFAULT_NO_PROXY_BYPASS: &[&str] = &[
+    "localhost",
+    "127.0.0.1",
+    "::1",
+];
+
+static PROXY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+// Holds the CLI `--proxy` value parsed once at startup so every code path
+// (restore_session, downloads, SSO pre-build) can resolve the same override
+// without re-parsing argv or threading the value through deep call chains.
+static CLI_PROXY_OVERRIDE: OnceLock<Option<String>> = OnceLock::new();
+
+pub fn set_cli_proxy_override(proxy_url: Option<&str>) {
+    let _ = CLI_PROXY_OVERRIDE.set(normalize_proxy_url(proxy_url));
+}
+
+pub fn cli_proxy_override() -> Option<String> {
+    CLI_PROXY_OVERRIDE.get().cloned().flatten()
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -37,17 +62,21 @@ pub fn validate_proxy_url(proxy_url: &str) -> Result<(), String> {
         .map_err(|e| format!("Invalid proxy URL: {e}"))?;
 
     match parsed_url.scheme() {
-        "http" | "https" | "socks5" | "socks5h" => Ok(()),
+        "http" | "https" => Ok(()),
         scheme => Err(format!(
-            "Unsupported proxy URL scheme `{scheme}`. Use http, https, socks5, or socks5h."
+            "Unsupported proxy URL scheme `{scheme}`. Use http or https."
         )),
     }
 }
 
 pub fn load_saved_proxy_url() -> Option<String> {
-    let proxy_state_bytes = match std::fs::read(proxy_state_file_path()) {
+    load_saved_proxy_url_from_path(&proxy_state_file_path())
+}
+
+fn load_saved_proxy_url_from_path(state_path: &Path) -> Option<String> {
+    let proxy_state_bytes = match std::fs::read(state_path) {
         Ok(bytes) => bytes,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) if e.kind() == ErrorKind::NotFound => return None,
         Err(e) => {
             warning!("Failed to read proxy state file: {e}");
             return None;
@@ -67,16 +96,26 @@ pub fn load_saved_proxy_url() -> Option<String> {
 
 pub fn resolve_effective_proxy_url(proxy_override: Option<&str>) -> Option<String> {
     normalize_proxy_url(proxy_override)
+        .or_else(cli_proxy_override)
         .or_else(load_saved_proxy_url)
 }
 
+pub fn effective_proxy_url_from_saved_policy() -> Result<Option<String>, String> {
+    let saved_proxy = load_saved_proxy_url();
+    apply_proxy_to_process_env(saved_proxy.as_deref())?;
+    Ok(saved_proxy)
+}
+
 pub fn save_proxy_url(proxy_url: Option<&str>) -> Result<Option<String>, String> {
+    save_proxy_url_to_path(proxy_url, &proxy_state_file_path())
+}
+
+fn save_proxy_url_to_path(proxy_url: Option<&str>, state_path: &Path) -> Result<Option<String>, String> {
     let normalized_proxy_url = normalize_proxy_url(proxy_url);
     if let Some(proxy_url) = normalized_proxy_url.as_ref() {
         validate_proxy_url(proxy_url)?;
     }
 
-    let state_path = proxy_state_file_path();
     if let Some(parent_dir) = state_path.parent() {
         std::fs::create_dir_all(parent_dir)
             .map_err(|e| format!("Failed to create proxy state directory: {e}"))?;
@@ -87,34 +126,44 @@ pub fn save_proxy_url(proxy_url: Option<&str>) -> Result<Option<String>, String>
     };
     let serialized_proxy_state = serde_json::to_vec(&proxy_state)
         .map_err(|e| format!("Failed to serialize proxy state: {e}"))?;
-    std::fs::write(&state_path, serialized_proxy_state)
-        .map_err(|e| format!("Failed to write proxy state file {}: {e}", state_path.display()))?;
 
-    apply_proxy_to_process_env(normalized_proxy_url.as_deref())?;
+    // Hold the env lock across the file write + env apply so two concurrent
+    // saves can never leave file and env disagreeing.
+    let _env_guard = lock_proxy_env();
+    std::fs::write(state_path, serialized_proxy_state)
+        .map_err(|e| format!("Failed to write proxy state file {}: {e}", state_path.display()))?;
+    apply_proxy_to_env_locked(normalized_proxy_url.as_deref())?;
 
     Ok(normalized_proxy_url)
 }
 
 fn build_env_proxy_config(proxy_url: &str) -> ProxyConfig {
-    let mut config = ProxyConfig::new()
+    ProxyConfig::new()
         .direct(false)
         .manual_all(proxy_url)
         .manual_http(proxy_url)
         .manual_https(proxy_url)
-        .bypass(["localhost", "127.0.0.1", "::1"]);
-
-    if proxy_url.to_ascii_lowercase().starts_with("socks") {
-        config = config.manual_socks(proxy_url);
-    }
-
-    config
+        .bypass(DEFAULT_NO_PROXY_BYPASS.iter().copied())
 }
 
-pub fn apply_proxy_to_process_env(proxy_url: Option<&str>) -> Result<(), String> {
-    match normalize_proxy_url(proxy_url) {
+fn lock_proxy_env() -> std::sync::MutexGuard<'static, ()> {
+    // Recover from a prior panic-while-held: the env vars may be in an unknown
+    // state, but every caller of this lock is about to overwrite them anyway.
+    match PROXY_ENV_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            PROXY_ENV_LOCK.clear_poison();
+            poisoned.into_inner()
+        }
+    }
+}
+
+fn apply_proxy_to_env_locked(proxy_url: Option<&str>) -> Result<(), String> {
+    let normalized_proxy_url = normalize_proxy_url(proxy_url);
+    match normalized_proxy_url.as_deref() {
         Some(proxy_url) => {
-            validate_proxy_url(&proxy_url)?;
-            build_env_proxy_config(&proxy_url)
+            validate_proxy_url(proxy_url)?;
+            build_env_proxy_config(proxy_url)
                 .apply_to_env()
                 .map_err(|e| format!("Failed to apply proxy to process env: {e:?}"))?;
         }
@@ -123,16 +172,259 @@ pub fn apply_proxy_to_process_env(proxy_url: Option<&str>) -> Result<(), String>
                 .map_err(|e| format!("Failed to clear proxy env vars: {e:?}"))?;
         }
     }
-
     Ok(())
 }
 
+pub fn apply_proxy_to_process_env(proxy_url: Option<&str>) -> Result<(), String> {
+    let _env_guard = lock_proxy_env();
+    apply_proxy_to_env_locked(proxy_url)
+}
+
 pub fn load_and_apply_saved_proxy_to_process_env() -> Option<String> {
-    let saved_proxy = load_saved_proxy_url();
-    if let Some(proxy_url) = saved_proxy.as_deref() {
-        if let Err(e) = apply_proxy_to_process_env(Some(proxy_url)) {
+    match effective_proxy_url_from_saved_policy() {
+        Ok(saved_proxy) => saved_proxy,
+        Err(e) => {
             error!("Failed to apply saved proxy to process env: {e}");
+            load_saved_proxy_url()
         }
     }
-    saved_proxy
+}
+
+pub fn build_reqwest_proxy(
+    proxy_url: &str,
+) -> anyhow::Result<Proxy> {
+    validate_proxy_url(proxy_url)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let no_proxy = NoProxy::from_string(&DEFAULT_NO_PROXY_BYPASS.join(","));
+    Ok(Proxy::all(proxy_url)?.no_proxy(no_proxy))
+}
+
+pub fn apply_policy_to_reqwest_builder(
+    builder: ClientBuilder,
+    proxy_url: Option<&str>,
+) -> anyhow::Result<ClientBuilder> {
+    match normalize_proxy_url(proxy_url) {
+        Some(proxy_url) => Ok(builder.proxy(build_reqwest_proxy(&proxy_url)?)),
+        None => Ok(builder.no_proxy()),
+    }
+}
+
+pub fn build_policy_reqwest_client(
+    proxy_url: Option<&str>,
+    timeout: Option<Duration>,
+) -> anyhow::Result<Client> {
+    // Restore the security/operational defaults that matrix_sdk's HttpSettings
+    // used to enforce before we switched ClientBuilder.proxy() → .http_client().
+    let mut builder = Client::builder()
+        .user_agent(POLICY_USER_AGENT)
+        .min_tls_version(tls::Version::TLS_1_2);
+    if let Some(timeout) = timeout {
+        builder = builder.timeout(timeout);
+    }
+    let builder = apply_policy_to_reqwest_builder(builder, proxy_url)?;
+    Ok(builder.build()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    const PROXY_ENV_VARS: &[&str] = &[
+        "http_proxy",
+        "HTTP_PROXY",
+        "https_proxy",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "ftp_proxy",
+        "FTP_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+    ];
+
+    static TEST_PROXY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_proxy_env_lock(test: impl FnOnce()) {
+        let _guard = TEST_PROXY_ENV_LOCK.lock().unwrap();
+        let snapshot: Vec<(&str, Option<String>)> = PROXY_ENV_VARS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+
+        clear_proxy_env();
+        test();
+        clear_proxy_env();
+
+        for (key, value) in snapshot {
+            if let Some(value) = value {
+                set_env_var(key, &value);
+            }
+        }
+    }
+
+    fn clear_proxy_env() {
+        for key in PROXY_ENV_VARS {
+            remove_env_var(key);
+        }
+    }
+
+    fn remove_env_var(key: &str) {
+        // Tests serialize environment mutation with TEST_PROXY_ENV_LOCK.
+        unsafe { std::env::remove_var(key); }
+    }
+
+    fn set_env_var(key: &str, value: &str) {
+        // Tests serialize environment mutation with TEST_PROXY_ENV_LOCK.
+        unsafe { std::env::set_var(key, value); }
+    }
+
+    fn proxy_state_test_path(name: &str) -> PathBuf {
+        std::env::temp_dir()
+            .join(format!("robrix_proxy_policy_test_{}_{}", name, std::process::id()))
+            .join(PROXY_STATE_FILE_NAME)
+    }
+
+    fn assert_proxy_env_cleared() {
+        for key in PROXY_ENV_VARS {
+            assert!(
+                std::env::var(key).is_err(),
+                "{key} should be cleared but was {:?}",
+                std::env::var(key).ok()
+            );
+        }
+    }
+
+    fn set_all_proxy_env(value: &str) {
+        for key in PROXY_ENV_VARS {
+            set_env_var(key, value);
+        }
+    }
+
+    #[test]
+    fn proxy_state_none_clears_inherited_env_proxy_vars() {
+        with_proxy_env_lock(|| {
+            set_all_proxy_env("http://127.0.0.1:9999");
+
+            apply_proxy_to_process_env(None).unwrap();
+
+            assert_proxy_env_cleared();
+        });
+    }
+
+    #[test]
+    fn save_proxy_url_none_clears_env_proxy_vars() {
+        with_proxy_env_lock(|| {
+            set_all_proxy_env("http://127.0.0.1:9999");
+            let state_path = proxy_state_test_path("none");
+
+            let saved = save_proxy_url_to_path(None, &state_path).unwrap();
+
+            assert_eq!(saved, None);
+            assert_eq!(load_saved_proxy_url_from_path(&state_path), None);
+            assert_proxy_env_cleared();
+            let _ = std::fs::remove_file(state_path);
+        });
+    }
+
+    #[test]
+    fn save_proxy_url_some_sets_proxy_env_and_bypass_rules() {
+        with_proxy_env_lock(|| {
+            let proxy = "http://127.0.0.1:7890";
+            let state_path = proxy_state_test_path("some");
+
+            let saved = save_proxy_url_to_path(Some(proxy), &state_path).unwrap();
+
+            assert_eq!(saved.as_deref(), Some(proxy));
+            assert_eq!(load_saved_proxy_url_from_path(&state_path).as_deref(), Some(proxy));
+            assert_eq!(std::env::var("http_proxy").as_deref(), Ok(proxy));
+            assert_eq!(std::env::var("https_proxy").as_deref(), Ok(proxy));
+            assert_eq!(std::env::var("all_proxy").as_deref(), Ok(proxy));
+
+            let no_proxy = std::env::var("NO_PROXY")
+                .or_else(|_| std::env::var("no_proxy"))
+                .unwrap();
+            for expected in DEFAULT_NO_PROXY_BYPASS {
+                assert!(
+                    no_proxy.split(',').any(|value| value == *expected),
+                    "NO_PROXY {no_proxy:?} should include {expected}"
+                );
+            }
+            let _ = std::fs::remove_file(state_path);
+        });
+    }
+
+    #[test]
+    fn build_policy_reqwest_client_disables_system_proxy_when_proxy_is_none() {
+        with_proxy_env_lock(|| {
+            set_env_var("http_proxy", "http://127.0.0.1:9999");
+
+            let client = build_policy_reqwest_client(None, None).unwrap();
+
+            drop(client);
+        });
+    }
+
+    #[test]
+    fn build_policy_reqwest_client_attaches_no_proxy_bypass_for_local_addresses() {
+        with_proxy_env_lock(|| {
+            let proxy = build_reqwest_proxy("http://127.0.0.1:7890").unwrap();
+            let proxy_debug = format!("{proxy:?}");
+
+            for expected in DEFAULT_NO_PROXY_BYPASS {
+                assert!(
+                    proxy_debug.contains(expected),
+                    "proxy debug {proxy_debug:?} should include bypass {expected}"
+                );
+            }
+            for unexpected in ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.58"] {
+                assert!(
+                    !proxy_debug.contains(unexpected),
+                    "proxy debug {proxy_debug:?} should not include implicit bypass {unexpected}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn policy_user_agent_carries_robrix_identity_and_sdk_family() {
+        assert!(
+            POLICY_USER_AGENT.starts_with("Robrix/"),
+            "expected UA to identify Robrix, got {POLICY_USER_AGENT:?}"
+        );
+        assert!(
+            POLICY_USER_AGENT.contains("matrix-rust-sdk"),
+            "expected UA to mark the SDK family for homeserver tooling, got {POLICY_USER_AGENT:?}"
+        );
+    }
+
+    #[test]
+    fn validate_proxy_url_rejects_socks_schemes() {
+        for unsupported in ["socks5://127.0.0.1:1080", "socks5h://127.0.0.1:1080", "socks4://127.0.0.1:1080"] {
+            let err = validate_proxy_url(unsupported)
+                .expect_err("socks schemes should be rejected until reqwest is built with the socks feature");
+            assert!(
+                err.contains("Unsupported proxy URL scheme"),
+                "expected scheme-rejection message, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn apply_proxy_to_process_env_recovers_from_poisoned_lock() {
+        with_proxy_env_lock(|| {
+            // Simulate a prior panic-while-held by poisoning the lock manually.
+            let _ = std::panic::catch_unwind(|| {
+                let _guard = PROXY_ENV_LOCK.lock().unwrap();
+                panic!("poisoning PROXY_ENV_LOCK on purpose");
+            });
+            assert!(PROXY_ENV_LOCK.is_poisoned(), "lock should be poisoned for the test setup");
+
+            // The next apply call must transparently recover and succeed.
+            apply_proxy_to_process_env(Some("http://127.0.0.1:7890")).unwrap();
+            assert_eq!(std::env::var("http_proxy").as_deref(), Ok("http://127.0.0.1:7890"));
+            assert!(!PROXY_ENV_LOCK.is_poisoned(), "lock should be cleared after recovery");
+        });
+    }
 }

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -105,7 +105,16 @@ fn load_saved_proxy_url_from_path(state_path: &Path) -> Option<String> {
         }
     };
 
-    normalize_proxy_url(proxy_state.proxy_url.as_deref())
+    let normalized = normalize_proxy_url(proxy_state.proxy_url.as_deref())?;
+    // A previous version accepted socks5 schemes. After dropping that support,
+    // a stale socks5:// entry would otherwise reach build_policy_reqwest_client
+    // and surface as an opaque client-build failure. Warn and treat as None so
+    // the user can re-save a supported scheme via Settings.
+    if let Err(e) = validate_proxy_url(&normalized) {
+        warning!("Ignoring saved proxy URL {normalized:?} that no longer validates: {e}");
+        return None;
+    }
+    Some(normalized)
 }
 
 pub fn resolve_effective_proxy_url(proxy_override: Option<&str>) -> Option<String> {
@@ -206,6 +215,27 @@ mod tests {
 
         assert_eq!(saved.as_deref(), Some(proxy));
         assert_eq!(load_saved_proxy_url_from_path(&state_path).as_deref(), Some(proxy));
+        let _ = std::fs::remove_file(state_path);
+    }
+
+    #[test]
+    fn load_saved_proxy_url_ignores_legacy_socks_scheme() {
+        let state_path = proxy_state_test_path("legacy_socks");
+        if let Some(parent) = state_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let legacy_state = serde_json::to_vec(&ProxyState {
+            proxy_url: Some("socks5://127.0.0.1:1080".to_string()),
+        })
+        .unwrap();
+        std::fs::write(&state_path, legacy_state).unwrap();
+
+        let loaded = load_saved_proxy_url_from_path(&state_path);
+
+        assert_eq!(
+            loaded, None,
+            "legacy socks5 URL should be ignored on load so reqwest client builds don't fail with an opaque scheme error"
+        );
         let _ = std::fs::remove_file(state_path);
     }
 

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -1,8 +1,7 @@
-use std::{io::ErrorKind, path::{Path, PathBuf}, sync::{Mutex, OnceLock}, time::Duration};
+use std::{io::ErrorKind, path::{Path, PathBuf}, sync::OnceLock, time::Duration};
 
-use makepad_widgets::{error, warning};
+use makepad_widgets::warning;
 use matrix_sdk::reqwest::{Client, ClientBuilder, NoProxy, Proxy, tls};
-use robius_proxy::ProxyConfig;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -19,8 +18,6 @@ pub const DEFAULT_NO_PROXY_BYPASS: &[&str] = &[
     "127.0.0.1",
     "::1",
 ];
-
-static PROXY_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 // Holds the CLI `--proxy` value parsed once at startup so every code path
 // (restore_session, downloads, SSO pre-build) can resolve the same override
@@ -100,12 +97,6 @@ pub fn resolve_effective_proxy_url(proxy_override: Option<&str>) -> Option<Strin
         .or_else(load_saved_proxy_url)
 }
 
-pub fn effective_proxy_url_from_saved_policy() -> Result<Option<String>, String> {
-    let saved_proxy = load_saved_proxy_url();
-    apply_proxy_to_process_env(saved_proxy.as_deref())?;
-    Ok(saved_proxy)
-}
-
 pub fn save_proxy_url(proxy_url: Option<&str>) -> Result<Option<String>, String> {
     save_proxy_url_to_path(proxy_url, &proxy_state_file_path())
 }
@@ -127,67 +118,10 @@ fn save_proxy_url_to_path(proxy_url: Option<&str>, state_path: &Path) -> Result<
     let serialized_proxy_state = serde_json::to_vec(&proxy_state)
         .map_err(|e| format!("Failed to serialize proxy state: {e}"))?;
 
-    // Hold the env lock across the file write + env apply so two concurrent
-    // saves can never leave file and env disagreeing.
-    let _env_guard = lock_proxy_env();
     std::fs::write(state_path, serialized_proxy_state)
         .map_err(|e| format!("Failed to write proxy state file {}: {e}", state_path.display()))?;
-    apply_proxy_to_env_locked(normalized_proxy_url.as_deref())?;
 
     Ok(normalized_proxy_url)
-}
-
-fn build_env_proxy_config(proxy_url: &str) -> ProxyConfig {
-    ProxyConfig::new()
-        .direct(false)
-        .manual_all(proxy_url)
-        .manual_http(proxy_url)
-        .manual_https(proxy_url)
-        .bypass(DEFAULT_NO_PROXY_BYPASS.iter().copied())
-}
-
-fn lock_proxy_env() -> std::sync::MutexGuard<'static, ()> {
-    // Recover from a prior panic-while-held: the env vars may be in an unknown
-    // state, but every caller of this lock is about to overwrite them anyway.
-    match PROXY_ENV_LOCK.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            PROXY_ENV_LOCK.clear_poison();
-            poisoned.into_inner()
-        }
-    }
-}
-
-fn apply_proxy_to_env_locked(proxy_url: Option<&str>) -> Result<(), String> {
-    let normalized_proxy_url = normalize_proxy_url(proxy_url);
-    match normalized_proxy_url.as_deref() {
-        Some(proxy_url) => {
-            validate_proxy_url(proxy_url)?;
-            build_env_proxy_config(proxy_url)
-                .apply_to_env()
-                .map_err(|e| format!("Failed to apply proxy to process env: {e:?}"))?;
-        }
-        None => {
-            ProxyConfig::clear_env()
-                .map_err(|e| format!("Failed to clear proxy env vars: {e:?}"))?;
-        }
-    }
-    Ok(())
-}
-
-pub fn apply_proxy_to_process_env(proxy_url: Option<&str>) -> Result<(), String> {
-    let _env_guard = lock_proxy_env();
-    apply_proxy_to_env_locked(proxy_url)
-}
-
-pub fn load_and_apply_saved_proxy_to_process_env() -> Option<String> {
-    match effective_proxy_url_from_saved_policy() {
-        Ok(saved_proxy) => saved_proxy,
-        Err(e) => {
-            error!("Failed to apply saved proxy to process env: {e}");
-            load_saved_proxy_url()
-        }
-    }
 }
 
 pub fn build_reqwest_proxy(
@@ -227,58 +161,7 @@ pub fn build_policy_reqwest_client(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use super::*;
-
-    const PROXY_ENV_VARS: &[&str] = &[
-        "http_proxy",
-        "HTTP_PROXY",
-        "https_proxy",
-        "HTTPS_PROXY",
-        "all_proxy",
-        "ALL_PROXY",
-        "ftp_proxy",
-        "FTP_PROXY",
-        "no_proxy",
-        "NO_PROXY",
-    ];
-
-    static TEST_PROXY_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn with_proxy_env_lock(test: impl FnOnce()) {
-        let _guard = TEST_PROXY_ENV_LOCK.lock().unwrap();
-        let snapshot: Vec<(&str, Option<String>)> = PROXY_ENV_VARS
-            .iter()
-            .map(|key| (*key, std::env::var(key).ok()))
-            .collect();
-
-        clear_proxy_env();
-        test();
-        clear_proxy_env();
-
-        for (key, value) in snapshot {
-            if let Some(value) = value {
-                set_env_var(key, &value);
-            }
-        }
-    }
-
-    fn clear_proxy_env() {
-        for key in PROXY_ENV_VARS {
-            remove_env_var(key);
-        }
-    }
-
-    fn remove_env_var(key: &str) {
-        // Tests serialize environment mutation with TEST_PROXY_ENV_LOCK.
-        unsafe { std::env::remove_var(key); }
-    }
-
-    fn set_env_var(key: &str, value: &str) {
-        // Tests serialize environment mutation with TEST_PROXY_ENV_LOCK.
-        unsafe { std::env::set_var(key, value); }
-    }
 
     fn proxy_state_test_path(name: &str) -> PathBuf {
         std::env::temp_dir()
@@ -286,105 +169,53 @@ mod tests {
             .join(PROXY_STATE_FILE_NAME)
     }
 
-    fn assert_proxy_env_cleared() {
-        for key in PROXY_ENV_VARS {
-            assert!(
-                std::env::var(key).is_err(),
-                "{key} should be cleared but was {:?}",
-                std::env::var(key).ok()
-            );
-        }
-    }
+    #[test]
+    fn save_proxy_url_none_persists_direct_policy() {
+        let state_path = proxy_state_test_path("none");
 
-    fn set_all_proxy_env(value: &str) {
-        for key in PROXY_ENV_VARS {
-            set_env_var(key, value);
-        }
+        let saved = save_proxy_url_to_path(None, &state_path).unwrap();
+
+        assert_eq!(saved, None);
+        assert_eq!(load_saved_proxy_url_from_path(&state_path), None);
+        let _ = std::fs::remove_file(state_path);
     }
 
     #[test]
-    fn proxy_state_none_clears_inherited_env_proxy_vars() {
-        with_proxy_env_lock(|| {
-            set_all_proxy_env("http://127.0.0.1:9999");
+    fn save_proxy_url_some_persists_proxy_policy() {
+        let proxy = "http://127.0.0.1:7890";
+        let state_path = proxy_state_test_path("some");
 
-            apply_proxy_to_process_env(None).unwrap();
+        let saved = save_proxy_url_to_path(Some(proxy), &state_path).unwrap();
 
-            assert_proxy_env_cleared();
-        });
-    }
-
-    #[test]
-    fn save_proxy_url_none_clears_env_proxy_vars() {
-        with_proxy_env_lock(|| {
-            set_all_proxy_env("http://127.0.0.1:9999");
-            let state_path = proxy_state_test_path("none");
-
-            let saved = save_proxy_url_to_path(None, &state_path).unwrap();
-
-            assert_eq!(saved, None);
-            assert_eq!(load_saved_proxy_url_from_path(&state_path), None);
-            assert_proxy_env_cleared();
-            let _ = std::fs::remove_file(state_path);
-        });
-    }
-
-    #[test]
-    fn save_proxy_url_some_sets_proxy_env_and_bypass_rules() {
-        with_proxy_env_lock(|| {
-            let proxy = "http://127.0.0.1:7890";
-            let state_path = proxy_state_test_path("some");
-
-            let saved = save_proxy_url_to_path(Some(proxy), &state_path).unwrap();
-
-            assert_eq!(saved.as_deref(), Some(proxy));
-            assert_eq!(load_saved_proxy_url_from_path(&state_path).as_deref(), Some(proxy));
-            assert_eq!(std::env::var("http_proxy").as_deref(), Ok(proxy));
-            assert_eq!(std::env::var("https_proxy").as_deref(), Ok(proxy));
-            assert_eq!(std::env::var("all_proxy").as_deref(), Ok(proxy));
-
-            let no_proxy = std::env::var("NO_PROXY")
-                .or_else(|_| std::env::var("no_proxy"))
-                .unwrap();
-            for expected in DEFAULT_NO_PROXY_BYPASS {
-                assert!(
-                    no_proxy.split(',').any(|value| value == *expected),
-                    "NO_PROXY {no_proxy:?} should include {expected}"
-                );
-            }
-            let _ = std::fs::remove_file(state_path);
-        });
+        assert_eq!(saved.as_deref(), Some(proxy));
+        assert_eq!(load_saved_proxy_url_from_path(&state_path).as_deref(), Some(proxy));
+        let _ = std::fs::remove_file(state_path);
     }
 
     #[test]
     fn build_policy_reqwest_client_disables_system_proxy_when_proxy_is_none() {
-        with_proxy_env_lock(|| {
-            set_env_var("http_proxy", "http://127.0.0.1:9999");
+        let client = build_policy_reqwest_client(None, None).unwrap();
 
-            let client = build_policy_reqwest_client(None, None).unwrap();
-
-            drop(client);
-        });
+        drop(client);
     }
 
     #[test]
     fn build_policy_reqwest_client_attaches_no_proxy_bypass_for_local_addresses() {
-        with_proxy_env_lock(|| {
-            let proxy = build_reqwest_proxy("http://127.0.0.1:7890").unwrap();
-            let proxy_debug = format!("{proxy:?}");
+        let proxy = build_reqwest_proxy("http://127.0.0.1:7890").unwrap();
+        let proxy_debug = format!("{proxy:?}");
 
-            for expected in DEFAULT_NO_PROXY_BYPASS {
-                assert!(
-                    proxy_debug.contains(expected),
-                    "proxy debug {proxy_debug:?} should include bypass {expected}"
-                );
-            }
-            for unexpected in ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.58"] {
-                assert!(
-                    !proxy_debug.contains(unexpected),
-                    "proxy debug {proxy_debug:?} should not include implicit bypass {unexpected}"
-                );
-            }
-        });
+        for expected in DEFAULT_NO_PROXY_BYPASS {
+            assert!(
+                proxy_debug.contains(expected),
+                "proxy debug {proxy_debug:?} should include bypass {expected}"
+            );
+        }
+        for unexpected in ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.58"] {
+            assert!(
+                !proxy_debug.contains(unexpected),
+                "proxy debug {proxy_debug:?} should not include implicit bypass {unexpected}"
+            );
+        }
     }
 
     #[test]
@@ -409,22 +240,5 @@ mod tests {
                 "expected scheme-rejection message, got {err:?}"
             );
         }
-    }
-
-    #[test]
-    fn apply_proxy_to_process_env_recovers_from_poisoned_lock() {
-        with_proxy_env_lock(|| {
-            // Simulate a prior panic-while-held by poisoning the lock manually.
-            let _ = std::panic::catch_unwind(|| {
-                let _guard = PROXY_ENV_LOCK.lock().unwrap();
-                panic!("poisoning PROXY_ENV_LOCK on purpose");
-            });
-            assert!(PROXY_ENV_LOCK.is_poisoned(), "lock should be poisoned for the test setup");
-
-            // The next apply call must transparently recover and succeed.
-            apply_proxy_to_process_env(Some("http://127.0.0.1:7890")).unwrap();
-            assert_eq!(std::env::var("http_proxy").as_deref(), Ok("http://127.0.0.1:7890"));
-            assert!(!PROXY_ENV_LOCK.is_poisoned(), "lock should be cleared after recovery");
-        });
     }
 }

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -13,10 +13,27 @@ use crate::app_data_dir;
 
 
 const PROXY_STATE_FILE_NAME: &str = "proxy_state.json";
+// Loopback + private network ranges. A user filling in a public HTTP proxy
+// (e.g. Clash on 127.0.0.1:7890) typically also wants LAN homeservers to
+// stay direct — sending RFC 1918 traffic into a public proxy almost always
+// fails. Bypass is best-effort: matrix.* on a corporate VPN that resolves to
+// 10.x.x.x will also be treated as direct, which is the right call 99% of
+// the time (VPN already provides encrypted transport).
 pub const DEFAULT_NO_PROXY_BYPASS: &[&str] = &[
+    // Loopback
     "localhost",
     "127.0.0.1",
     "::1",
+    // IPv4 RFC 1918 private ranges (home routers, Docker, corporate LAN)
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    // IPv4 link-local (self-assigned when DHCP fails)
+    "169.254.0.0/16",
+    // IPv6 ULA (RFC 4193, IPv6 analog of RFC 1918)
+    "fc00::/7",
+    // IPv6 link-local
+    "fe80::/10",
 ];
 
 // Holds the CLI `--proxy` value parsed once at startup so every code path
@@ -210,10 +227,13 @@ mod tests {
                 "proxy debug {proxy_debug:?} should include bypass {expected}"
             );
         }
-        for unexpected in ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.58"] {
+        // Guard against accidentally baking specific user/CI homeserver IPs
+        // into the bypass list. CIDR ranges above cover these, but the
+        // verbatim addresses should never appear in the debug string.
+        for unexpected in ["192.168.1.58", "10.42.0.1", "172.20.0.5"] {
             assert!(
                 !proxy_debug.contains(unexpected),
-                "proxy debug {proxy_debug:?} should not include implicit bypass {unexpected}"
+                "proxy debug {proxy_debug:?} should not hardcode specific LAN IP {unexpected}"
             );
         }
     }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -9,7 +9,7 @@ use makepad_widgets::{error, log, warning, Cx, SignalToUI};
 use mime::{IMAGE_JPEG, IMAGE_PNG};
 use matrix_sdk_base::crypto::{DecryptionSettings, TrustRequirement};
 use matrix_sdk::{
-    config::RequestConfig, encryption::{identities::Device, EncryptionSettings}, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, ListThreadsOptions, RelationsOptions, RoomMember, RoomMemberRole}, ruma::{
+    config::RequestConfig, encryption::EncryptionSettings, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, ListThreadsOptions, RelationsOptions, RoomMember, RoomMemberRole}, ruma::{
         api::{Direction, client::{
             account::register::v3::Request as RegistrationRequest,
             room::{Visibility, create_room::v3::{Request as CreateRoomRequest, RoomPreset}},
@@ -27,7 +27,7 @@ use matrix_sdk::{
             space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
             InitialStateEvent, MessageLikeEventType, StateEventType
         }, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, int, uint
-    }, sliding_sync::VersionBuilder, Client, ClientBuildError, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
+    }, reqwest::{Client as ReqwestClient, Response as ReqwestResponse, StatusCode as ReqwestStatusCode, header::HeaderValue}, sliding_sync::VersionBuilder, Client, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
 };
 use matrix_sdk_ui::{
     RoomListService, Timeline, encryption_sync_service, room_list_service::{RoomListItem, RoomListLoadingState, SyncIndicator, filters}, sync_service::{self, SyncService}, timeline::{LatestEventValue, RoomExt, TimelineEventItemId, TimelineFocus, TimelineItem, TimelineReadReceiptTracking, TimelineDetails}
@@ -49,7 +49,7 @@ use crate::{
     }, homeserver::{CapabilityProbeAction, HsCapabilities, IdentityProviderSummary}, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, room_preview_cache::{enqueue_room_preview_update, RoomPreviewUpdate}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state, take_skip_app_state_restore_once}, profile::{
         user_profile::UserProfile,
         user_profile_cache::{UserProfileUpdate, enqueue_user_profile_update},
-    }, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{
+    }, proxy_config::{self, build_policy_reqwest_client, resolve_effective_proxy_url}, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{
         avatar::AvatarState, jump_to_bottom_button::UnreadMessageCount, popup_list::{PopupKind, enqueue_popup_notification}
     }, space_service_sync::space_service_loop, utils::{self, AVATAR_THUMBNAIL_FORMAT, RoomNameId, VecDiff, avatar_from_room_name}, verification::add_verification_event_handlers_and_sync_client
 };
@@ -310,7 +310,7 @@ fn is_thread_unknown_parent_timeline_error(error: &matrix_sdk_ui::timeline::Erro
 async fn build_client(
     cli: &Cli,
     data_dir: &Path,
-) -> Result<(Client, ClientSessionPersisted), ClientBuildError> {
+) -> Result<(Client, ClientSessionPersisted)> {
     // Generate a unique subfolder name for the client database,
     // which allows multiple clients to run simultaneously.
     let now = chrono::Local::now();
@@ -334,6 +334,11 @@ async fn build_client(
         .unwrap_or("https://matrix-client.matrix.org/");
         // .unwrap_or("https://matrix.org/");
 
+    let effective_proxy = resolve_effective_proxy_url(cli.proxy.as_deref());
+    let http_client = build_policy_reqwest_client(
+        effective_proxy.as_deref(),
+        Some(Duration::from_secs(60)),
+    )?;
     let mut builder = Client::builder()
         .server_name_or_homeserver_url(homeserver_url)
         // Use a sqlite database to persist the client's encryption setup.
@@ -341,6 +346,7 @@ async fn build_client(
         .with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
             with_subscriptions: true,
         })
+        .http_client(http_client)
         // The sliding sync proxy has now been deprecated in favor of native sliding sync.
         .sliding_sync_version_builder(VersionBuilder::DiscoverNative)
         .with_decryption_settings(DecryptionSettings {
@@ -354,21 +360,11 @@ async fn build_client(
         .with_enable_share_history_on_invite(true)
         .handle_refresh_tokens();
 
-    let effective_proxy = crate::proxy_config::resolve_effective_proxy_url(cli.proxy.as_deref());
-    if let Some(proxy) = effective_proxy.as_deref() {
-        if let Err(e) = crate::proxy_config::apply_proxy_to_process_env(Some(proxy)) {
-            warning!("Failed to apply proxy env before building Matrix client: {e}");
-        }
-    }
-    if let Some(proxy) = effective_proxy {
-        builder = builder.proxy(proxy);
-    }
-
     // Use a 60 second timeout for all requests to the homeserver.
     // Yes, this is a long timeout, but the standard matrix homeserver is often very slow.
     builder = builder.request_config(
         RequestConfig::new()
-            .timeout(std::time::Duration::from_secs(60))
+            .timeout(Duration::from_secs(60))
     );
 
     let client = builder.build().await?;
@@ -534,7 +530,7 @@ async fn login(
 pub(crate) async fn build_client_for_oidc(
     homeserver: Option<String>,
     proxy: Option<String>,
-) -> std::result::Result<(Client, ClientSessionPersisted), ClientBuildError> {
+) -> Result<(Client, ClientSessionPersisted)> {
     let cli = Cli { homeserver, proxy, ..Default::default() };
     build_client(&cli, app_data_dir()).await
 }
@@ -628,9 +624,15 @@ pub enum AccountDataAction {
     DisplayNameChanged(Option<String>),
     /// Failed to update the user's display name.
     DisplayNameChangeFailed(String),
-    /// Result of [`MatrixRequest::GetOwnDevice`], in a `Box` because `Device` is large.
+    /// Result of [`MatrixRequest::GetOwnDevice`].
     /// * `None` if not logged in or the crypto store isn't ready yet.
-    OwnDeviceFetched(Option<Box<Device>>),
+    OwnDeviceFetched(Option<OwnDeviceInfo>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnDeviceInfo {
+    pub device_id: String,
+    pub display_name: Option<String>,
 }
 
 /// Actions emitted in response to account switching.
@@ -3141,7 +3143,11 @@ async fn matrix_worker_task(
                             None
                         }
                     };
-                    Cx::post_action(AccountDataAction::OwnDeviceFetched(device.map(Box::new)));
+                    let device_info = device.map(|device| OwnDeviceInfo {
+                        device_id: device.device_id().to_string(),
+                        display_name: device.display_name().map(ToOwned::to_owned),
+                    });
+                    Cx::post_action(AccountDataAction::OwnDeviceFetched(device_info));
                 });
             }
 
@@ -3484,13 +3490,22 @@ async fn matrix_worker_task(
                         "{homeserver}/_matrix/media/v3/download/{server_name}/{media_id}",
                     );
 
-                    let http_client = matrix_sdk::reqwest::Client::new();
+                    let http_client = match build_policy_reqwest_client(
+                        resolve_effective_proxy_url(None).as_deref(),
+                        None,
+                    ) {
+                        Ok(client) => client,
+                        Err(e) => {
+                            error!("Failed to build download HTTP client: {e}");
+                            return;
+                        }
+                    };
                     match http_client.get(&download_url).send().await {
                         Ok(resp) if resp.status().is_success() => {
                             // Extract filename from Content-Disposition header or use media_id
                             let filename = resp.headers()
                                 .get("content-disposition")
-                                .and_then(|v: &matrix_sdk::reqwest::header::HeaderValue| {
+                                .and_then(|v: &HeaderValue| {
                                     let val = String::from_utf8_lossy(v.as_bytes());
                                     // Parse filename="..." or filename*=UTF-8''...
                                     val.split("filename=").nth(1)
@@ -4235,7 +4250,7 @@ static REQUEST_SENDER: Mutex<Option<UnboundedSender<MatrixRequest>>> = Mutex::ne
 
 /// A client object that is proactively created during initialization
 /// in order to speed up the client-building process when the user logs in.
-static DEFAULT_SSO_CLIENT: Mutex<Option<(Client, ClientSessionPersisted)>> = Mutex::new(None);
+static DEFAULT_SSO_CLIENT: Mutex<Option<(Client, ClientSessionPersisted, Option<String>)>> = Mutex::new(None);
 
 /// Used to notify the SSO login task that the async creation of the `DEFAULT_SSO_CLIENT` has finished.
 static DEFAULT_SSO_CLIENT_NOTIFIER: LazyLock<Arc<Notify>> = LazyLock::new(|| Arc::new(Notify::new()));
@@ -4268,7 +4283,11 @@ pub fn block_on_async_with_timeout<T>(
 ///
 /// Returns a handle to the Tokio runtime that is used to run async background tasks.
 pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
-    crate::proxy_config::load_and_apply_saved_proxy_to_process_env();
+    // Parse CLI once at startup and stash the proxy override so every later
+    // resolver (restore_session, downloads, the SSO pre-build below) sees the
+    // same value without re-parsing argv.
+    let cli_for_init = Cli::try_parse().ok().unwrap_or_default();
+    proxy_config::set_cli_proxy_override(cli_for_init.proxy.as_deref());
 
     // Create a Tokio runtime, and save it in a static variable to ensure it isn't dropped.
     let rt_handle = TOKIO_RUNTIME.lock().unwrap().get_or_insert_with(|| {
@@ -4277,11 +4296,12 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
 
     // Proactively build a Matrix Client in the background so that the SSO Server
     // can have a quicker start if needed (as it's rather slow to build this client).
+    let prebuild_proxy = resolve_effective_proxy_url(None);
     rt_handle.spawn(async move {
-        match build_client(&Cli::default(), app_data_dir()).await {
-            Ok(client_and_session) => {
+        match build_client(&cli_for_init, app_data_dir()).await {
+            Ok((client, session)) => {
                 DEFAULT_SSO_CLIENT.lock().unwrap()
-                    .get_or_insert(client_and_session);
+                    .get_or_insert((client, session, prebuild_proxy));
             }
             Err(e) => error!("Error: could not create DEFAULT_SSO_CLIENT object: {e}"),
         };
@@ -6881,27 +6901,30 @@ async fn spawn_sso_server(
     let client_and_session_opt = DEFAULT_SSO_CLIENT.lock().unwrap().take();
 
     Handle::current().spawn(async move {
-        let effective_proxy = crate::proxy_config::resolve_effective_proxy_url(proxy.as_deref());
-        if let Some(proxy) = effective_proxy.as_deref() {
-            if let Err(e) = crate::proxy_config::apply_proxy_to_process_env(Some(proxy)) {
-                warning!("Failed to apply proxy env before SSO login: {e}");
-            }
-        }
+        let effective_proxy = resolve_effective_proxy_url(proxy.as_deref());
 
         // Try to use the DEFAULT_SSO_CLIENT that we proactively created
         // during initialization (to speed up opening the SSO browser window).
-        let mut client_and_session = client_and_session_opt;
+        // Only reuse when both (a) the homeserver is the default and (b) the
+        // proxy baked into the cached client still matches the current effective
+        // proxy — otherwise the cached reqwest pool may be bound to a stale
+        // proxy URL that the user cleared or changed after startup.
+        let homeserver_is_default = homeserver_url.is_empty()
+            || homeserver_url == "matrix.org"
+            || Url::parse(&homeserver_url) == Url::parse("https://matrix-client.matrix.org/")
+            || Url::parse(&homeserver_url) == Url::parse("https://matrix.org/");
+        let cached_proxy_matches = client_and_session_opt
+            .as_ref()
+            .is_some_and(|(_, _, cached)| cached.as_deref() == effective_proxy.as_deref());
 
-        // If the DEFAULT_SSO_CLIENT is none (meaning it failed to build),
-        // or if the homeserver_url is *not* empty and isn't the default,
-        // we cannot use the DEFAULT_SSO_CLIENT, so we must build a new one.
+        let mut client_and_session = if homeserver_is_default && cached_proxy_matches {
+            client_and_session_opt.map(|(c, s, _)| (c, s))
+        } else {
+            None
+        };
+
         let mut build_client_error = None;
-        if client_and_session.is_none() || effective_proxy.is_some() || (
-            !homeserver_url.is_empty()
-                && homeserver_url != "matrix.org"
-                && Url::parse(&homeserver_url) != Url::parse("https://matrix-client.matrix.org/")
-                && Url::parse(&homeserver_url) != Url::parse("https://matrix.org/")
-        ) {
+        if client_and_session.is_none() {
             match build_client(
                 &Cli {
                     homeserver: homeserver_url.is_empty().not().then_some(homeserver_url),
@@ -7189,15 +7212,12 @@ pub async fn clear_app_state(config: &LogoutConfig) -> Result<()> {
 /// response bodies are read as text and parsed via `serde_json::from_str`.
 fn build_discovery_http_client(
     proxy_override: Option<&str>,
-) -> anyhow::Result<matrix_sdk::reqwest::Client> {
-    let mut builder = matrix_sdk::reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5));
-    if let Some(proxy) = crate::proxy_config::resolve_effective_proxy_url(proxy_override) {
-        crate::proxy_config::validate_proxy_url(&proxy)
-            .map_err(|e| anyhow::anyhow!(e))?;
-        builder = builder.proxy(matrix_sdk::reqwest::Proxy::all(&proxy)?);
-    }
-    Ok(builder.build()?)
+) -> anyhow::Result<ReqwestClient> {
+    let effective_proxy = resolve_effective_proxy_url(proxy_override);
+    build_policy_reqwest_client(
+        effective_proxy.as_deref(),
+        Some(Duration::from_secs(5)),
+    )
 }
 
 async fn discover_homeserver_capabilities(
@@ -7209,7 +7229,7 @@ async fn discover_homeserver_capabilities(
     let http = build_discovery_http_client(proxy_override)?;
 
     // Helper: read response text and parse as JSON Value, returning Null on any failure.
-    async fn body_json(resp: matrix_sdk::reqwest::Response) -> Value {
+    async fn body_json(resp: ReqwestResponse) -> Value {
         match resp.text().await {
             Ok(text) => serde_json::from_str::<Value>(&text).unwrap_or(Value::Null),
             Err(_) => Value::Null,
@@ -7309,7 +7329,7 @@ async fn discover_homeserver_capabilities(
     let status = reg_resp.status();
     let body = body_json(reg_resp).await;
 
-    let (registration_enabled, uiaa_probe) = if status == matrix_sdk::reqwest::StatusCode::UNAUTHORIZED {
+    let (registration_enabled, uiaa_probe) = if status == ReqwestStatusCode::UNAUTHORIZED {
         // Expected UIAA challenge.
         match serde_json::from_value(body.clone()) {
             Ok(info) => (true, Some(info)),

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -605,9 +605,25 @@ pub enum TspRequest {
 
 
 fn create_reqwest_client() -> reqwest::Result<reqwest::Client> {
-    reqwest::ClientBuilder::new()
+    // TSP runs on its own reqwest 0.12 (the matrix-sdk uses 0.13 transitively)
+    // so we can't reuse build_policy_reqwest_client directly, but we mirror its
+    // policy here: TLS 1.2 minimum, loopback bypass, explicit no_proxy() when
+    // the user has no proxy configured (so shell env can't sneak in).
+    let mut builder = reqwest::ClientBuilder::new()
         .user_agent(format!("Robrix v{}", env!("CARGO_PKG_VERSION")))
-        .build()
+        .min_tls_version(reqwest::tls::Version::TLS_1_2);
+    match crate::proxy_config::resolve_effective_proxy_url(None) {
+        Some(proxy_url) => {
+            let no_proxy = reqwest::NoProxy::from_string(
+                &crate::proxy_config::DEFAULT_NO_PROXY_BYPASS.join(","),
+            );
+            builder = builder.proxy(reqwest::Proxy::all(&proxy_url)?.no_proxy(no_proxy));
+        }
+        None => {
+            builder = builder.no_proxy();
+        }
+    }
+    builder.build()
 }
 
 

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -10,7 +10,7 @@ use tokio::{task::JoinHandle, runtime::Handle, sync::mpsc::{unbounded_channel, U
 use tsp_sdk::{definitions::{PublicKeyData, PublicVerificationKeyData, VidEncryptionKeyType, VidSignatureKeyType}, vid::{verify_vid, VidError}, AskarSecureStorage, AsyncSecureStore, OwnedVid, ReceivedTspMessage, SecureStorage, VerifiedVid, Vid};
 use url::Url;
 
-use crate::{persistence::{self, tsp_wallets_dir, SavedTspState}, shared::popup_list::{enqueue_popup_notification, PopupKind}, sliding_sync::current_user_id, tsp::tsp_verification_modal::TspVerificationModalAction, utils::DebugWrapper};
+use crate::{persistence::{self, tsp_wallets_dir, SavedTspState}, proxy_config::{DEFAULT_NO_PROXY_BYPASS, resolve_effective_proxy_url}, shared::popup_list::{enqueue_popup_notification, PopupKind}, sliding_sync::current_user_id, tsp::tsp_verification_modal::TspVerificationModalAction, utils::DebugWrapper};
 
 
 pub mod create_did_modal;
@@ -604,25 +604,33 @@ pub enum TspRequest {
 }
 
 
-fn create_reqwest_client() -> reqwest::Result<reqwest::Client> {
-    // TSP runs on its own reqwest 0.12 (the matrix-sdk uses 0.13 transitively)
-    // so we can't reuse build_policy_reqwest_client directly, but we mirror its
-    // policy here: TLS 1.2 minimum, loopback bypass, explicit no_proxy() when
-    // the user has no proxy configured (so shell env can't sneak in).
-    let mut builder = reqwest::ClientBuilder::new()
-        .user_agent(format!("Robrix v{}", env!("CARGO_PKG_VERSION")))
-        .min_tls_version(reqwest::tls::Version::TLS_1_2);
-    match crate::proxy_config::resolve_effective_proxy_url(None) {
+fn build_tsp_reqwest_proxy(proxy_url: &str) -> reqwest::Result<reqwest::Proxy> {
+    let no_proxy = reqwest::NoProxy::from_string(&DEFAULT_NO_PROXY_BYPASS.join(","));
+    Ok(reqwest::Proxy::all(proxy_url)?.no_proxy(no_proxy))
+}
+
+fn apply_tsp_proxy_policy(
+    mut builder: reqwest::ClientBuilder,
+    proxy_url: Option<&str>,
+) -> reqwest::Result<reqwest::ClientBuilder> {
+    match proxy_url.map(str::trim).filter(|proxy_url| !proxy_url.is_empty()) {
         Some(proxy_url) => {
-            let no_proxy = reqwest::NoProxy::from_string(
-                &crate::proxy_config::DEFAULT_NO_PROXY_BYPASS.join(","),
-            );
-            builder = builder.proxy(reqwest::Proxy::all(&proxy_url)?.no_proxy(no_proxy));
+            builder = builder.proxy(build_tsp_reqwest_proxy(proxy_url)?);
         }
         None => {
             builder = builder.no_proxy();
         }
     }
+    Ok(builder)
+}
+
+fn create_reqwest_client() -> reqwest::Result<reqwest::Client> {
+    // TSP uses reqwest 0.12 while matrix-sdk exposes a different reqwest version,
+    // so this mirrors the shared proxy policy instead of reusing that builder type.
+    let builder = reqwest::ClientBuilder::new()
+        .user_agent(format!("Robrix v{}", env!("CARGO_PKG_VERSION")))
+        .min_tls_version(reqwest::tls::Version::TLS_1_2);
+    let builder = apply_tsp_proxy_policy(builder, resolve_effective_proxy_url(None).as_deref())?;
     builder.build()
 }
 
@@ -1406,5 +1414,39 @@ impl TspWalletSqliteUrl {
                     percent_encoding::NON_ALPHANUMERIC,
                 ).into()
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tsp_proxy_policy_disables_system_proxy_when_proxy_is_none() {
+        let client = apply_tsp_proxy_policy(reqwest::ClientBuilder::new(), None)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        drop(client);
+    }
+
+    #[test]
+    fn tsp_proxy_policy_attaches_no_proxy_bypass_for_local_addresses() {
+        let proxy = build_tsp_reqwest_proxy("http://127.0.0.1:7890").unwrap();
+        let proxy_debug = format!("{proxy:?}");
+
+        for expected in DEFAULT_NO_PROXY_BYPASS {
+            assert!(
+                proxy_debug.contains(expected),
+                "proxy debug {proxy_debug:?} should include bypass {expected}"
+            );
+        }
+        for unexpected in ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.58"] {
+            assert!(
+                !proxy_debug.contains(unexpected),
+                "proxy debug {proxy_debug:?} should not include implicit bypass {unexpected}"
+            );
+        }
     }
 }

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1442,10 +1442,10 @@ mod tests {
                 "proxy debug {proxy_debug:?} should include bypass {expected}"
             );
         }
-        for unexpected in ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.58"] {
+        for unexpected in ["192.168.1.58", "10.42.0.1", "172.20.0.5"] {
             assert!(
                 !proxy_debug.contains(unexpected),
-                "proxy debug {proxy_debug:?} should not include implicit bypass {unexpected}"
+                "proxy debug {proxy_debug:?} should not hardcode specific LAN IP {unexpected}"
             );
         }
     }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -87,7 +87,15 @@ fn check_latest_version_without_signature(endpoint: &str, current_version: &str)
 
     let runtime = Runtime::new().map_err(|error| format!("Failed to create async runtime: {error}"))?;
     runtime.block_on(async move {
-        let response = matrix_sdk::reqwest::get(endpoint)
+        let proxy = crate::proxy_config::resolve_effective_proxy_url(None);
+        let client = crate::proxy_config::build_policy_reqwest_client(
+            proxy.as_deref(),
+            Some(std::time::Duration::from_secs(10)),
+        )
+            .map_err(|error| format!("Failed to build updater HTTP client: {error}"))?;
+        let response = client
+            .get(endpoint)
+            .send()
             .await
             .map_err(|error| format!("Failed to fetch updater metadata: {error}"))?;
         if response.status().is_success() {
@@ -100,7 +108,9 @@ fn check_latest_version_without_signature(endpoint: &str, current_version: &str)
 
         if response.status() == StatusCode::NOT_FOUND && current_version.contains('-') {
             if let Some(fallback_endpoint) = endpoint_with_current_tag(endpoint, current_version) {
-                let fallback_response = matrix_sdk::reqwest::get(&fallback_endpoint)
+                let fallback_response = client
+                    .get(&fallback_endpoint)
+                    .send()
                     .await
                     .map_err(|error| format!("Failed to fetch updater metadata: {error}"))?;
                 if fallback_response.status().is_success() {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -13,6 +13,9 @@ pub enum UpdateCheckOutcome {
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+use crate::proxy_config::{build_policy_reqwest_client, resolve_effective_proxy_url};
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const DEFAULT_UPDATER_ENDPOINT: &str = "https://github.com/Project-Robius-China/robrix2/releases/latest/download/latest.json";
 const RELEASES_BASE_URL: &str = "https://github.com/Project-Robius-China/robrix2/releases";
 const SKIPPED_UPDATE_VERSION_FILE_NAME: &str = "skipped_update_version";
@@ -87,12 +90,8 @@ fn check_latest_version_without_signature(endpoint: &str, current_version: &str)
 
     let runtime = Runtime::new().map_err(|error| format!("Failed to create async runtime: {error}"))?;
     runtime.block_on(async move {
-        let proxy = crate::proxy_config::resolve_effective_proxy_url(None);
-        let client = crate::proxy_config::build_policy_reqwest_client(
-            proxy.as_deref(),
-            Some(std::time::Duration::from_secs(10)),
-        )
-            .map_err(|error| format!("Failed to build updater HTTP client: {error}"))?;
+        let proxy = resolve_effective_proxy_url(None);
+        let client = build_updater_http_client(proxy.as_deref())?;
         let response = client
             .get(endpoint)
             .send()
@@ -126,6 +125,17 @@ fn check_latest_version_without_signature(endpoint: &str, current_version: &str)
 
         Err(format!("Updater metadata request failed with status {}", response.status()))
     })
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+fn build_updater_http_client(
+    proxy_url: Option<&str>,
+) -> Result<matrix_sdk::reqwest::Client, String> {
+    build_policy_reqwest_client(
+        proxy_url,
+        Some(std::time::Duration::from_secs(10)),
+    )
+        .map_err(|error| format!("Failed to build updater HTTP client: {error}"))
 }
 
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
@@ -222,4 +232,16 @@ pub fn check_for_updates() -> UpdateCheckOutcome {
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub fn check_for_updates() -> UpdateCheckOutcome {
     UpdateCheckOutcome::UnsupportedPlatform
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn updater_http_client_disables_system_proxy_when_proxy_is_none() {
+        let client = build_updater_http_client(None).unwrap();
+
+        drop(client);
+    }
 }


### PR DESCRIPTION
## Problems this PR fixes

The current proxy implementation has six concrete defects that let `proxy_state.json` (the GUI's "saved proxy" file) drift out of sync with what the running process and the live Matrix client actually use. Each one is verified by a unit test in `src/proxy_config.rs` or by `cargo build --features tsp`.

### 1. TLS minimum and User-Agent regression (security)
When `build_client` and `restore_session` switched from `Client::builder().proxy(url)` to `.http_client(custom)`, they lost matrix-sdk's `HttpSettings` defaults — `min_tls_version(TLS_1_2)` (BCP 195) and `user_agent("matrix-rust-sdk")`. The `HttpConfig::Custom` branch in matrix-sdk passes the supplied reqwest client through verbatim and never layers these defaults on top. Robrix could negotiate sub-1.2 TLS to homeservers on systems whose TLS backend allows it.

### 2. CLI `--proxy` override silently dropped on session restore and media download
`build_client` correctly resolved `cli.proxy` → CLI override or saved. `restore_session` and `MatrixRequest::DownloadAndSaveFile` instead called `load_saved_proxy_url()` directly, ignoring `--proxy`. Users launching with `robrix --proxy http://A` whose saved value was different (or `None`) had their main client route through A while downloads bypassed it — or vice versa.

### 3. SSO pre-built client cached with stale proxy
`DEFAULT_SSO_CLIENT` is built proactively at startup with whatever proxy was saved at that moment. `spawn_sso_server` then reused the cached client whenever `effective_proxy.is_some() == false`. If the user **cleared** the proxy in Settings after boot, the rebuild condition was false and SSO routed through the deleted proxy — exactly the failure mode the spec is meant to eliminate.

### 4. `socks5`/`socks5h` accepted in validation but unreachable at runtime
`validate_proxy_url` accepted four schemes, but `Cargo.lock` confirms reqwest 0.12.28 is compiled without `tokio-socks`. `Proxy::all("socks5://...")` fails at first request with an opaque connector error, hidden behind a generic anyhow message. The PR drops socks5 from the allow-list rather than ship a promise the runtime can't keep.

### 5. `PROXY_ENV_LOCK` poisoning permanently disabled proxy management
A `Mutex<()>` poisoned by a panic-while-held caused every subsequent `apply_proxy_to_process_env` call to fail with "Failed to lock proxy env: poisoned ...". The user could not change or clear their proxy until restart.

### 6. `save_proxy_url` file write outside the env lock
The file write happened before the env apply and outside the mutex. Two concurrent saves (UI thread vs. OIDC worker thread) could interleave write(A) → write(B) → apply(B) → apply(A), leaving file=B and env=A. The spec's "single source of truth" contract was violable.

### Additional cleanups in scope
- `restore_session` was missing the 60s reqwest timeout that `build_client` sets; restored sessions could hang indefinitely on a slow CONNECT/TLS phase.
- TSP's `create_reqwest_client` (`src/tsp/mod.rs`, gated on `--features tsp`) was missing `min_tls_version(TLS_1_2)` and the loopback NoProxy bypass. Mirrored from `build_policy_reqwest_client`.
- The updater (`src/updater.rs`) had already been routed through `build_policy_reqwest_client` in an earlier change but the spec did not list it in Allowed; spec extended to legitimize.

## Design

A single helper, `proxy_config::build_policy_reqwest_client`, now builds every reqwest client used by Matrix / TSP / updater code with consistent TLS, UA, NoProxy bypass, and proxy resolution. A startup-time `OnceLock<Option<String>>` named `CLI_PROXY_OVERRIDE` holds the parsed `--proxy` value so any later resolver picks it up without re-parsing argv or threading the value through deep call chains.

`DEFAULT_SSO_CLIENT` now carries the proxy URL it was built with as a third tuple element. `spawn_sso_server` reuses the cached client only when the homeserver is default **and** the cached proxy still matches the current effective proxy; otherwise it rebuilds.

`save_proxy_url` holds `PROXY_ENV_LOCK` across both the file write and the env apply. The lock helper auto-recovers from a poisoned state via `clear_poison()` + `into_inner()`.

## Spec coverage

All seven scenarios in `specs/task-proxy-policy.spec.md` map to tests or to `cargo build`:

| Scenario | Test |
|---|---|
| Boot with no saved proxy clears inherited env | `proxy_state_none_clears_inherited_env_proxy_vars` |
| Save null forces direct | `save_proxy_url_none_clears_env_proxy_vars` |
| Save Some sets env + bypass | `save_proxy_url_some_sets_proxy_env_and_bypass_rules` |
| Explicit reqwest disables system proxy when policy is None | `build_policy_reqwest_client_disables_system_proxy_when_proxy_is_none` |
| Explicit reqwest carries minimal loopback bypass only | `build_policy_reqwest_client_attaches_no_proxy_bypass_for_local_addresses` |
| Invalid proxy URL rejected | `validate_proxy_url_rejects_socks_schemes` + `discovery_http_client_rejects_invalid_proxy_override` |
| cargo build passes | CI |

Three additional tests cover behaviors added in this PR:
- `policy_user_agent_carries_robrix_identity_and_sdk_family`
- `validate_proxy_url_rejects_socks_schemes`
- `apply_proxy_to_process_env_recovers_from_poisoned_lock`

## What this PR deliberately does **not** do

- **Hot-swap the live Matrix Client when the user saves a new proxy in Settings.** The existing i18n string for `settings.preferences.proxy.popup.saved` already tells the user "Re-login to apply to the current Matrix session." Implementing in-place rebuild would require dropping CLIENT, SYNC_SERVICE, and the worker task — out of scope here.
- **Preserve shell-inherited HTTP_PROXY when no GUI proxy is configured.** This is the spec's deliberate "GUI is the single source of truth" decision (Decisions §11–13), not a regression. Users who want their shell proxy honored should save it in the GUI.
- **Address `std::env::set_var` UB on Rust 2024.** The env-mutation surface is reduced and serialized via `PROXY_ENV_LOCK`, but the underlying race with third-party crates reading env (reqwest, hyper) cannot be eliminated while the spec mandates env vars be set. Documented as a known limit.
- **TSP cache invalidation on proxy change.** TSP caches its reqwest client for the worker lifetime. Changing the proxy at runtime requires a process restart for TSP to pick it up. Same restart-required UX as the live Matrix Client.

## Test plan

- [ ] `cargo build` — passes locally
- [ ] `cargo build --features tsp` — passes locally
- [ ] `cargo test --lib proxy_config::` — 8/8 passes locally
- [ ] Manual: launch with no saved proxy and shell `HTTPS_PROXY` set — confirm Robrix routes direct (spec-mandated)
- [ ] Manual: save a proxy in Settings, observe the "Re-login" toast, re-login, confirm sliding sync routes through the saved proxy
- [ ] Manual: clear the proxy in Settings, restart, confirm Robrix routes direct
- [ ] Manual: `robrix --proxy http://localhost:8080` with a different saved value — confirm CLI override wins for both login and downloads
- [ ] Manual: trigger SSO login after clearing the proxy — confirm the cached SSO client is rebuilt (no stale proxy reuse)