### PR TITLE
Fix SSO pre-build noise via persistent skip-flag file

### DIFF
--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4988,10 +4988,6 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             if let Ok(mut client_opt) = DEFAULT_SSO_CLIENT.lock() {
                 let _ = client_opt.take();
             }
-            // Clear the SSO pre-build skip flag: a successful login proves the
-            // network can reach a homeserver, so future startups should retry
-            // the pre-build optimization instead of permanently skipping it.
-            clear_sso_prebuild_failure_flag();
 
             let logged_in_user_id: OwnedUserId = client.user_id()
                 .expect("BUG: Client::user_id() returned None after successful login!")
@@ -5014,6 +5010,14 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             if let Some(_existing) = CLIENT.lock().unwrap().replace(client.clone()) {
                 error!("BUG: unexpectedly replaced an existing client when initializing the matrix client.");
             }
+
+            // Clear the SSO pre-build skip flag now that CLIENT is set, so any
+            // in-flight pre-build that fails after this point will observe
+            // `get_client().is_some()` and skip writing a stale flag. A
+            // successful login proves the network reaches a homeserver, so
+            // future startups should retry the pre-build optimization
+            // instead of permanently skipping it.
+            clear_sso_prebuild_failure_flag();
 
             // Listen for changes to our verification status and incoming verification requests.
             add_verification_event_handlers_and_sync_client(client.clone());

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4416,14 +4416,22 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
                 let _ = std::fs::remove_file(&prebuild_flag_path);
             }
             Err(e) => {
-                // Persist the failure so future startups skip this noisy pre-build path.
-                // Ensure the parent dir exists on fresh installs where no DB has been created yet.
-                let _ = std::fs::create_dir_all(app_data_dir());
-                let _ = std::fs::write(&prebuild_flag_path, b"");
-                warning!(
-                    "DEFAULT_SSO_CLIENT pre-build failed; SSO login will build a fresh client on click. \
-                     Cause: {e}"
-                );
+                // If the user has already logged in (e.g. password or custom-homeserver SSO)
+                // while the pre-build was still racing the network, do NOT record a failure:
+                // we'd be writing the flag right after the post-login cleanup just cleared it,
+                // which would permanently disable the optimization for the wrong reason.
+                if get_client().is_some() {
+                    log!("DEFAULT_SSO_CLIENT pre-build failed after user already logged in; not recording skip flag. Cause: {e}");
+                } else {
+                    // Persist the failure so future startups skip this noisy pre-build path.
+                    // Ensure the parent dir exists on fresh installs where no DB has been created yet.
+                    let _ = std::fs::create_dir_all(app_data_dir());
+                    let _ = std::fs::write(&prebuild_flag_path, b"");
+                    warning!(
+                        "DEFAULT_SSO_CLIENT pre-build failed; SSO login will build a fresh client on click. \
+                         Cause: {e}"
+                    );
+                }
             }
         };
         DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
@@ -5092,6 +5100,14 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                                 log!("matrix worker task ended with error due to account switch: {e:?}");
                             } else {
                                 error!("Error: matrix worker task ended:\n\t{e:?}");
+                                rooms_list::enqueue_rooms_list_update(RoomsListUpdate::Status {
+                                    status: e.to_string(),
+                                });
+                                enqueue_popup_notification(
+                                    format!("Matrix worker error: {e}"),
+                                    PopupKind::Error,
+                                    None,
+                                );
                             }
                         },
                         Err(e) => {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4395,12 +4395,32 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
             return;
         }
 
+        // If this device previously failed to reach the default homeserver during pre-build,
+        // skip the attempt entirely to avoid spamming ERRORs from matrix-sdk internals.
+        // The SSO login path always falls back to building a fresh client on click.
+        let prebuild_flag_path = app_data_dir().join(".sso_prebuild_failed");
+        if prebuild_flag_path.exists() {
+            log!("Skipping DEFAULT_SSO_CLIENT pre-build (previously failed on this device; SSO login will build a fresh client on click).");
+            DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
+            Cx::post_action(LoginAction::SsoPending(false));
+            return;
+        }
+
         match build_client(&Cli::default(), app_data_dir()).await {
             Ok(client_and_session) => {
                 DEFAULT_SSO_CLIENT.lock().unwrap()
                     .get_or_insert(client_and_session);
+                // Clear any stale failure flag (e.g., after the user configures a proxy).
+                let _ = std::fs::remove_file(&prebuild_flag_path);
             }
-            Err(e) => error!("Error: could not create DEFAULT_SSO_CLIENT object: {e}"),
+            Err(e) => {
+                // Persist the failure so future startups skip this noisy pre-build path.
+                let _ = std::fs::write(&prebuild_flag_path, b"");
+                warning!(
+                    "DEFAULT_SSO_CLIENT pre-build failed; SSO login will build a fresh client on click. \
+                     Cause: {e}"
+                );
+            }
         };
         DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
         Cx::post_action(LoginAction::SsoPending(false));

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4396,8 +4396,10 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
         }
 
         // If this device previously failed to reach the default homeserver during pre-build,
-        // skip the attempt entirely to avoid spamming ERRORs from matrix-sdk internals.
+        // skip the attempt entirely to avoid spamming error logs from matrix-sdk internals.
         // The SSO login path always falls back to building a fresh client on click.
+        // The flag is cleared after any successful login, so a working network
+        // restores the optimization automatically without manual intervention.
         let prebuild_flag_path = app_data_dir().join(".sso_prebuild_failed");
         if prebuild_flag_path.exists() {
             log!("Skipping DEFAULT_SSO_CLIENT pre-build (previously failed on this device; SSO login will build a fresh client on click).");
@@ -4415,6 +4417,8 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
             }
             Err(e) => {
                 // Persist the failure so future startups skip this noisy pre-build path.
+                // Ensure the parent dir exists on fresh installs where no DB has been created yet.
+                let _ = std::fs::create_dir_all(app_data_dir());
                 let _ = std::fs::write(&prebuild_flag_path, b"");
                 warning!(
                     "DEFAULT_SSO_CLIENT pre-build failed; SSO login will build a fresh client on click. \
@@ -4956,6 +4960,10 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             if let Ok(mut client_opt) = DEFAULT_SSO_CLIENT.lock() {
                 let _ = client_opt.take();
             }
+            // Clear the SSO pre-build skip flag: a successful login proves the
+            // network can reach a homeserver, so future startups should retry
+            // the pre-build optimization instead of permanently skipping it.
+            let _ = std::fs::remove_file(app_data_dir().join(".sso_prebuild_failed"));
 
             let logged_in_user_id: OwnedUserId = client.user_id()
                 .expect("BUG: Client::user_id() returned None after successful login!")

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4296,6 +4296,30 @@ fn should_prebuild_default_sso_client(
     most_recent_user_id.is_none() && !cli_has_valid_username_password
 }
 
+/// Path to the marker file that records a previous [`DEFAULT_SSO_CLIENT`] pre-build
+/// failure on this device, so subsequent startups can skip the noisy attempt.
+fn sso_prebuild_failure_flag_path() -> PathBuf {
+    app_data_dir().join(".sso_prebuild_failed")
+}
+
+/// Records that the [`DEFAULT_SSO_CLIENT`] pre-build failed on this device,
+/// so future startups skip the attempt instead of re-spamming matrix-sdk error logs.
+///
+/// Safe to call from a fresh install: the parent directory is created on demand.
+/// Errors are swallowed: at worst the flag isn't persisted and the noise repeats once more.
+fn record_sso_prebuild_failure_flag() {
+    let _ = std::fs::create_dir_all(app_data_dir());
+    let _ = std::fs::write(sso_prebuild_failure_flag_path(), b"");
+}
+
+/// Clears the [`DEFAULT_SSO_CLIENT`] pre-build skip flag, if present.
+///
+/// Called after any successful pre-build or login, so a working network restores
+/// the optimization automatically without manual filesystem intervention.
+fn clear_sso_prebuild_failure_flag() {
+    let _ = std::fs::remove_file(sso_prebuild_failure_flag_path());
+}
+
 async fn attach_room_to_space(client: &Client, child_room: &Room, space_id: &OwnedRoomId) -> Result<()> {
     let user_id = client.user_id().ok_or_else(|| anyhow!("Current user ID not found"))?;
     let space_room = client.get_room(space_id)
@@ -4400,8 +4424,7 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
         // The SSO login path always falls back to building a fresh client on click.
         // The flag is cleared after any successful login, so a working network
         // restores the optimization automatically without manual intervention.
-        let prebuild_flag_path = app_data_dir().join(".sso_prebuild_failed");
-        if prebuild_flag_path.exists() {
+        if sso_prebuild_failure_flag_path().exists() {
             log!("Skipping DEFAULT_SSO_CLIENT pre-build (previously failed on this device; SSO login will build a fresh client on click).");
             DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
             Cx::post_action(LoginAction::SsoPending(false));
@@ -4413,7 +4436,7 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
                 DEFAULT_SSO_CLIENT.lock().unwrap()
                     .get_or_insert(client_and_session);
                 // Clear any stale failure flag (e.g., after the user configures a proxy).
-                let _ = std::fs::remove_file(&prebuild_flag_path);
+                clear_sso_prebuild_failure_flag();
             }
             Err(e) => {
                 // If the user has already logged in (e.g. password or custom-homeserver SSO)
@@ -4423,10 +4446,7 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
                 if get_client().is_some() {
                     log!("DEFAULT_SSO_CLIENT pre-build failed after user already logged in; not recording skip flag. Cause: {e}");
                 } else {
-                    // Persist the failure so future startups skip this noisy pre-build path.
-                    // Ensure the parent dir exists on fresh installs where no DB has been created yet.
-                    let _ = std::fs::create_dir_all(app_data_dir());
-                    let _ = std::fs::write(&prebuild_flag_path, b"");
+                    record_sso_prebuild_failure_flag();
                     warning!(
                         "DEFAULT_SSO_CLIENT pre-build failed; SSO login will build a fresh client on click. \
                          Cause: {e}"
@@ -4971,7 +4991,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             // Clear the SSO pre-build skip flag: a successful login proves the
             // network can reach a homeserver, so future startups should retry
             // the pre-build optimization instead of permanently skipping it.
-            let _ = std::fs::remove_file(app_data_dir().join(".sso_prebuild_failed"));
+            clear_sso_prebuild_failure_flag();
 
             let logged_in_user_id: OwnedUserId = client.user_id()
                 .expect("BUG: Client::user_id() returned None after successful login!")


### PR DESCRIPTION
## Problem

When the default homeserver (`matrix-client.matrix.org`) is unreachable on
startup — e.g. a restricted network without a proxy, or the user is logging
into a local Matrix server like Palpo — the speculative SSO pre-build inside
`start_matrix_tokio` emits a cascade of `ERROR matrix_sdk::http_client` lines
that lasts until matrix-sdk's internal 60s request timeout fires. The pre-build
is purely a UX optimization (it speeds up clicking the SSO login button) so the
failure is non-fatal, but the log noise is severe enough to drown out legitimate
debugging output, and it repeats on every startup until a session is saved.

## Approach

A persistent **skip flag** file at `app_data_dir()/.sso_prebuild_failed`:

| Event | Action |
|-------|--------|
| Pre-build attempted and **succeeded** | Remove flag (so future starts retry) |
| Pre-build attempted and **failed** AND user not logged in | Write flag |
| Pre-build attempted and failed BUT user already logged in | Do nothing (race-safe) |
| Flag detected on startup | Skip pre-build silently |
| Any successful login | Remove flag (so future starts retry) |

The optimization self-heals: a transient first-launch failure (offline, captive
portal, DNS hiccup) gets recorded once, then subsequent starts are silent. Once
the network is healthy and the user logs in, the flag is cleared, and the next
cold start will attempt the pre-build again. No manual filesystem intervention
required, no timeout values added or modified.

## Changes

All in `src/sliding_sync.rs`:

- **`start_matrix_tokio` (pre-build task)** — Check the skip flag before
  attempting `build_client`. On success, clear the flag. On failure, write
  the flag (unless a login already happened during the build, to avoid a
  race that would re-stick a flag the post-login cleanup just cleared).
  Downgrade the previous `error!` to `warning!`.
- **`start_matrix_client_login_and_sync` (post-login cleanup)** — Clear the
  flag whenever any login succeeds, so a working network restores the
  optimization automatically.
- **`start_matrix_client_login_and_sync` (worker-crash branch)** — Restore
  the `RoomsListUpdate::Status` + `enqueue_popup_notification` calls when
  `matrix_worker_task` ends with an unexpected error. These had inadvertently
  diverged from the sibling `room_list_service_task` and `space_service_task`
  arms, leaving the user with no visible signal when the background worker
  died.
- **Helpers** — `sso_prebuild_failure_flag_path`, `record_sso_prebuild_failure_flag`,
  `clear_sso_prebuild_failure_flag` centralize the file name and the
  `create_dir_all` + `write` + `remove_file` boilerplate.

## What this PR does **not** change

- **No timeout values added or modified.** The fix is purely file-based.
- **`validate_session=false` and the `RestoreSessionError → Preserve` policy
  are left untouched.** Those are design decisions from #140 and orthogonal
  to SSO pre-build noise; any concerns about them belong in a separate PR.

## Test plan

- [x] On a network where `matrix-client.matrix.org` is unreachable: first launch
      emits one `warning!`, subsequent launches are silent.
- [x] On a normal network: pre-build succeeds, no flag file is created.
- [x] After a transient first-launch failure, log in via password to a local
      homeserver (Palpo): on the next launch with restored network, pre-build
      runs again and succeeds.
- [x] `cargo build` clean.
- [x] `cargo clippy --all-targets` no warnings.
- [x] `typos` passes.
- [x] All 12 CI jobs green on the previous push (typos, clippy, check patches,
      build Ubuntu/Windows/macOS arm64/macOS x86_64/iOS/Android-Linux/Android-Windows/Android-macOS).