### PR TITLE
fix(settings): send lightweight own device info

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2881,8 +2881,10 @@ mod tests {
 
     #[test]
     fn test_app_state_roundtrip_preserves_selected_room_with_empty_dock() {
-        let mut state = AppState::default();
-        state.selected_room = Some(joined_room("!room:example.org", "octosbot"));
+        let state = AppState {
+            selected_room: Some(joined_room("!room:example.org", "octosbot")),
+            ..Default::default()
+        };
         assert!(
             state.saved_dock_state_home.open_rooms.is_empty(),
             "precondition: this test simulates the mobile case where selected_room persists without desktop dock tabs",

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -4,9 +4,9 @@ use std::cell::RefCell;
 use makepad_widgets::{text::selection::Cursor, *};
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use rfd::FileDialog;
-use matrix_sdk::{encryption::{identities::Device, VerificationState}, ruma::OwnedUserId};
+use matrix_sdk::{encryption::VerificationState, ruma::OwnedUserId};
 
-use crate::{account_manager, app::AppState, avatar_cache::{self}, home::navigation_tab_bar::get_own_profile, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::{user_profile::UserProfile, user_profile_cache}, shared::{avatar::{AvatarState, AvatarWidgetExt}, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{get_client, AccessTokenCopyAction, AccessTokenCopyError, AccountDataAction, AccountSwitchAction, MatrixRequest, submit_async_request}, utils, verification::VerificationStateAction};
+use crate::{account_manager, app::AppState, avatar_cache::{self}, home::navigation_tab_bar::get_own_profile, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::{user_profile::UserProfile, user_profile_cache}, shared::{avatar::{AvatarState, AvatarWidgetExt}, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{get_client, AccessTokenCopyAction, AccessTokenCopyError, AccountDataAction, AccountSwitchAction, MatrixRequest, OwnDeviceInfo, submit_async_request}, utils, verification::VerificationStateAction};
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use crate::{app::ConfirmDeleteAction, shared::confirmation_modal::ConfirmationModalContent};
 
@@ -491,7 +491,7 @@ pub struct AccountSettings {
 
     #[rust] own_profile: Option<UserProfile>,
     #[rust(VerificationState::Unknown)] verification_state: VerificationState,
-    #[rust] own_device: Option<Device>,
+    #[rust] own_device: Option<OwnDeviceInfo>,
     #[rust] app_language: AppLanguage,
     /// List of other account user IDs (not the currently active one)
     #[rust] other_accounts: Vec<OwnedUserId>,
@@ -711,7 +711,7 @@ impl MatchEvent for AccountSettings {
                     continue;
                 }
                 Some(AccountDataAction::OwnDeviceFetched(device)) => {
-                    self.own_device = device.as_deref().cloned();
+                    self.own_device = device.clone();
                     self.update_verification_banner(cx);
                     continue;
                 }
@@ -1022,9 +1022,9 @@ impl AccountSettings {
         self.view.view(cx, ids!(verification_banner_unverified)).set_visible(cx, unverified);
 
         let info_text = match self.own_device.as_ref() {
-            Some(device) => match device.display_name() {
-                Some(name) => format!("Session: \"{name}\",  Device ID: {}", device.device_id()),
-                None => format!("Device ID: {}", device.device_id()),
+            Some(device) => match device.display_name.as_ref() {
+                Some(name) => format!("Session: \"{name}\",  Device ID: {}", device.device_id),
+                None => format!("Device ID: {}", device.device_id),
             },
             None => String::new(),
         };

--- a/src/shared/mentionable_text_input.rs
+++ b/src/shared/mentionable_text_input.rs
@@ -1113,13 +1113,7 @@ impl Widget for MentionableTextInput {
                 .unwrap_or(true);
             let should_submit = modifiers.logo
                 || modifiers.control
-                || (
-                    send_on_enter
-                    && !modifiers.shift
-                    && !modifiers.alt
-                    && !modifiers.logo
-                    && !modifiers.control
-                );
+                || send_on_enter && !modifiers.shift && !modifiers.alt;
             if should_submit {
                 let text_input = self.cmd_text_input.text_input(cx, ids!(text_input));
                 let uid = text_input.widget_uid();

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -9,7 +9,7 @@ use makepad_widgets::{error, log, warning, Cx, SignalToUI};
 use mime::{IMAGE_JPEG, IMAGE_PNG};
 use matrix_sdk_base::crypto::{DecryptionSettings, TrustRequirement};
 use matrix_sdk::{
-    config::RequestConfig, encryption::{identities::Device, EncryptionSettings}, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, ListThreadsOptions, RelationsOptions, RoomMember, RoomMemberRole}, ruma::{
+    config::RequestConfig, encryption::EncryptionSettings, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, ListThreadsOptions, RelationsOptions, RoomMember, RoomMemberRole}, ruma::{
         api::{Direction, client::{
             account::register::v3::Request as RegistrationRequest,
             room::{Visibility, create_room::v3::{Request as CreateRoomRequest, RoomPreset}},
@@ -713,9 +713,15 @@ pub enum AccountDataAction {
     DisplayNameChanged(Option<String>),
     /// Failed to update the user's display name.
     DisplayNameChangeFailed(String),
-    /// Result of [`MatrixRequest::GetOwnDevice`], in a `Box` because `Device` is large.
+    /// Result of [`MatrixRequest::GetOwnDevice`].
     /// * `None` if not logged in or the crypto store isn't ready yet.
-    OwnDeviceFetched(Option<Box<Device>>),
+    OwnDeviceFetched(Option<OwnDeviceInfo>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnDeviceInfo {
+    pub device_id: String,
+    pub display_name: Option<String>,
 }
 
 /// Actions emitted in response to account switching.
@@ -1713,13 +1719,15 @@ mod matrix_request_tests {
 
     #[test]
     fn test_should_restore_loaded_app_state_with_selected_room_and_empty_dock() {
-        let mut app_state = crate::app::AppState::default();
-        app_state.selected_room = Some(crate::app::SelectedRoom::JoinedRoom {
-            room_name_id: crate::utils::RoomNameId::new(
-                matrix_sdk::RoomDisplayName::Named("octosbot".into()),
-                "!room:example.org".parse().unwrap(),
-            ),
-        });
+        let app_state = crate::app::AppState {
+            selected_room: Some(crate::app::SelectedRoom::JoinedRoom {
+                room_name_id: crate::utils::RoomNameId::new(
+                    matrix_sdk::RoomDisplayName::Named("octosbot".into()),
+                    "!room:example.org".parse().unwrap(),
+                ),
+            }),
+            ..Default::default()
+        };
 
         assert!(
             should_restore_loaded_app_state(&app_state),
@@ -3226,7 +3234,11 @@ async fn matrix_worker_task(
                             None
                         }
                     };
-                    Cx::post_action(AccountDataAction::OwnDeviceFetched(device.map(Box::new)));
+                    let device_info = device.map(|device| OwnDeviceInfo {
+                        device_id: device.device_id().to_string(),
+                        display_name: device.display_name().map(ToOwned::to_owned),
+                    });
+                    Cx::post_action(AccountDataAction::OwnDeviceFetched(device_info));
                 });
             }
 


### PR DESCRIPTION
## Summary
- Replace `AccountDataAction::OwnDeviceFetched`'s SDK `Device` payload with lightweight `OwnDeviceInfo` containing only `device_id` and `display_name`.
- Update account settings verification banner rendering to use the lightweight device info.
- Clear current clippy warnings by simplifying one boolean expression and using struct update syntax in affected tests.

## Test Plan
- [x] Manual test: account settings page opens normally and session/device info renders correctly.
- [x] `cargo clippy --workspace --all-features`
- [x] `cargo build`
- [x] `git diff --check`
- [x] `cargo test test_app_state_roundtrip_preserves_selected_room_with_empty_dock`
- [x] `cargo test test_should_restore_loaded_app_state_with_selected_room_and_empty_dock`
- [x] `cargo test` currently has 4 failures that reproduce on clean baseline `HEAD c2be7e95` and are not introduced by this branch:
  - `home::room_screen::tests::test_parse_bot_timeline_layers_invalid_metadata_does_not_panic`
  - `room::room_input_bar::tests::test_classified_management_command_prefers_bound_bot_when_parent_config_mismatches`
  - `room::room_input_bar::tests::test_message_bot_mention_suppresses_explicit_bot_target`
  - `room::room_input_bar::tests::test_room_bot_mention_overrides_selected_explicit_bot`
