### PR TITLE
sync(batch-3): backport mobile stack-nav polish and upload guardrails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "accessory"
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "bitmaps"
@@ -996,7 +996,7 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "byteorder"
@@ -1007,7 +1007,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "byteorder-lite"
@@ -1557,6 +1557,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2410,9 +2421,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2500,7 +2511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
- "weezl",
+ "weezl 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3492,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -3500,12 +3511,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3513,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3521,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3530,10 +3541,11 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
+ "makepad-gif",
  "makepad-live-id",
  "makepad-math",
  "makepad-platform",
@@ -3544,15 +3556,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3560,22 +3572,30 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
+
+[[package]]
+name = "makepad-gif"
+version = "0.1.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
+dependencies = [
+ "weezl 0.1.12 (git+https://github.com/makepad/makepad?branch=dev)",
+]
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3589,7 +3609,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "ttf-parser",
 ]
@@ -3597,7 +3617,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3606,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3614,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3622,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3630,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3644,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3652,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3666,15 +3686,16 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "ctrlc",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3695,7 +3716,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "wayland-client 0.31.12",
  "wayland-egl",
  "wayland-protocols 0.32.10",
@@ -3707,12 +3728,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3720,13 +3741,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3734,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3743,14 +3764,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3760,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3769,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3778,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3787,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3795,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3804,18 +3825,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "simd-adler32 0.3.8",
 ]
@@ -3823,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3831,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4228,7 +4249,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "memoffset"
@@ -4417,6 +4438,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -5114,10 +5147,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicase 2.9.0",
 ]
 
@@ -5685,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "robius-directories"
 version = "6.0.0"
-source = "git+https://github.com/Project-Robius-China/robius2.git#f05fdf168ee4407977f11d57d99a5bc34b0f92f1"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
 dependencies = [
  "dirs-sys 0.5.0",
  "jni",
@@ -5695,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "robius-location"
 version = "0.2.0"
-source = "git+https://github.com/Project-Robius-China/robius2.git#f05fdf168ee4407977f11d57d99a5bc34b0f92f1"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
 dependencies = [
  "android-build",
  "cfg-if",
@@ -5710,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "robius-open"
 version = "0.2.0"
-source = "git+https://github.com/Project-Robius-China/robius2.git#f05fdf168ee4407977f11d57d99a5bc34b0f92f1"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
 dependencies = [
  "block2",
  "cfg-if",
@@ -6095,12 +6128,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
- "bytemuck 1.25.0 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bytemuck 1.25.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -6195,7 +6228,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "sealed"
@@ -6505,7 +6538,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "simd-adler32"
@@ -6546,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "socket2"
@@ -6991,7 +7024,7 @@ dependencies = [
  "flate2",
  "half",
  "quick-error",
- "weezl",
+ "weezl 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "zune-jpeg",
 ]
 
@@ -7363,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "tungstenite"
@@ -7426,7 +7459,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-bidi"
@@ -7437,17 +7470,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-ident"
@@ -7458,7 +7491,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-normalization"
@@ -7478,12 +7511,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7494,7 +7527,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "unicode-width"
@@ -7837,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7863,7 +7896,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7885,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "wayland-backend 0.3.12",
  "wayland-sys 0.31.8",
@@ -7894,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend 0.3.12",
@@ -7927,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "log",
  "pkg-config",
@@ -8002,6 +8035,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8052,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -8071,7 +8109,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -8104,7 +8142,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -8125,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -8189,7 +8227,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 
 [[package]]
 name = "windows-numerics"
@@ -8233,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8250,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=cargo_makepad_ndk_fix#5e6d7b3ff0f067572a16ce7fd6e6d57fc209a95b"
+source = "git+https://github.com/makepad/makepad?branch=dev#12dcfc1e7700d99c98801dfab06b0d29c337bf3a"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,15 @@ version = "0.1.0-pre-alpha-4"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
-
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "cargo_makepad_ndk_fix", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "cargo_makepad_ndk_fix" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"
-robius-open = { git = "https://github.com/Project-Robius-China/robius2.git" }
-robius-directories = { git = "https://github.com/Project-Robius-China/robius2.git" }
-robius-location = { git = "https://github.com/Project-Robius-China/robius2.git" }
+robius-open = { git = "https://github.com/project-robius/robius" }
+robius-directories = { git = "https://github.com/project-robius/robius" }
+robius-location = { git = "https://github.com/project-robius/robius" }
 robius-proxy = { git = "https://github.com/Project-Robius-China/robius2.git" }
 
 

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -1157,7 +1157,7 @@ impl CreateRoomForm {
         create_room_button.set_enabled(cx, !create_room_name_input.text().trim().is_empty());
         create_room_button.set_text(cx, tr_key(self.app_language, "add_room.create_room.button.create"));
         create_room_button.reset_hover(cx);
-        create_room_encrypted_toggle.set_active(cx, self.create_encrypted_room);
+        create_room_encrypted_toggle.set_active(cx, self.create_encrypted_room, Animate::No);
         self.set_create_room_public(cx, self.create_public_room);
         self.set_visibility_popup_visible(cx, false);
         self.sync_mode_views(cx);

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -1,10 +1,18 @@
 use makepad_widgets::*;
 
 use crate::{
-    app::AppState,
-    home::navigation_tab_bar::{NavigationBarAction, SelectedTab},
-    settings::app_preferences::{AppPreferencesAction, ViewModeOverride},
-    settings::settings_screen::SettingsScreenWidgetRefExt,
+    app::{AppState, AppStateAction, SelectedRoom},
+    home::{
+        invite_screen::InviteScreenWidgetRefExt,
+        navigation_tab_bar::{NavigationBarAction, SelectedTab},
+        room_screen::RoomScreenWidgetRefExt,
+        rooms_list::RoomsListAction,
+        space_lobby::SpaceLobbyScreenWidgetRefExt,
+    },
+    settings::{
+        app_preferences::{AppPreferencesAction, ViewModeOverride},
+        settings_screen::SettingsScreenWidgetRefExt,
+    },
     shared::room_filter_input_bar::{MainFilterAction, RoomFilterInputBarWidgetExt},
 };
 
@@ -19,9 +27,9 @@ script_mod! {
     mod.widgets.STACK_VIEW_HEADER_HEIGHT = 45
 
     // A reusable base for StackNavigationView children in the mobile layout.
-    // Each specific content view (room, invite, space lobby) extends this
+    // Each specific screen view (room, invite, space lobby) extends this
     // and places its own screen widget inside the body.
-    mod.widgets.RobrixContentView = StackNavigationView {
+    mod.widgets.RobrixStackNavigationView = StackNavigationView {
         width: Fill, height: Fill
         draw_bg.color: (COLOR_PRIMARY)
         header +: {
@@ -40,13 +48,13 @@ script_mod! {
                 gradient_fill_horizontal: uniform(0.0)
                 color_2: instance(vec4(-1))
 
-                border_radius: uniform(0.0)
+                border_radius: uniform(4.0)
                 border_size: uniform(0.0)
                 border_color: instance(#0000)
                 border_color_2: instance(vec4(-1))
 
-                shadow_color: instance(#0002)
-                shadow_radius: uniform(8.0)
+                shadow_color: instance(#0005)
+                shadow_radius: uniform(12.0)
                 shadow_offset: uniform(vec2(0.0, 0.0))
 
                 rect_size2: varying(vec2(0))
@@ -112,56 +120,29 @@ script_mod! {
                 }
             }
 
-            padding: Inset{top: 0, bottom: 0}
-            height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT),
-
-                content +: {
-                    height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)
-                    button_container +: {
-                        width: Fill
-                        height: Fill
-                        flow: Right
-                        padding: 0,
-                        margin: 0
-                        left_button +: {
-                            width: 56, height: Fill,
-                            padding: 0,
-                            margin: 0
-                            draw_icon +: { color: (ROOM_NAME_TEXT_COLOR) }
-                            icon_walk: Walk{width: 14, height: Fit}
-                            spacing: 0
-                            text: ""
-                        }
-                        button_spacer := View {
-                            width: Fill, height: Fill
-                        }
-                        right_button := ButtonFlatterIcon {
-                            visible: false
-                            width: 56, height: Fill,
-                            padding: 0,
-                            margin: 0
-                            draw_icon +: {
-                                color: (ROOM_NAME_TEXT_COLOR)
-                                svg: (ICON_INFO)
-                            }
-                            icon_walk: Walk{width: 14, height: Fit}
-                            spacing: 0
-                            text: ""
-                        }
+            content +: {
+                height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)
+                align: Align{y: 0.5}
+                padding: Inset{
+                    left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                    right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                }
+                button_container +: {
+                    padding: 0,
+                    margin: 0
+                    left_button +: {
+                        width: Fit, height: Fit,
+                        padding: Inset{left: 20, right: 23, top: 10, bottom: 10}
+                        margin: Inset{left: 8, right: 0, top: 0, bottom: 0}
+                        draw_icon +: { color: (ROOM_NAME_TEXT_COLOR) }
+                        icon_walk: Walk{width: 13, height: Fit}
+                        spacing: 0
+                        text: ""
                     }
-                    title_container +: {
-                    width: Fill
-                    height: Fill
-                    padding: Inset{top: 0, left: 56, right: 56}
-                    align: Align{x: 0.5, y: 0.5}
+                }
+                title_container +: {
                     title +: {
-                        width: Fill
-                        margin: 0
-                        flow: Flow.Right{wrap: false}
-                        max_lines: 1
-                        text_overflow: Ellipsis
                         draw_text +: {
-                            text_style: theme.font_bold { font_size: 11.5 }
                             color: (ROOM_NAME_TEXT_COLOR)
                         }
                     }
@@ -169,7 +150,14 @@ script_mod! {
             }
         }
         body +: {
+            // The top margin leaves room for the stack nav header.
+            // The other padding is for safe inset areas.
             margin: Inset{top: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)}
+            padding: Inset{
+                left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
+            }
         }
     }
 
@@ -179,7 +167,10 @@ script_mod! {
 
         width: Fill,
         height: (NAVIGATION_TAB_BAR_SIZE)
-        margin: Inset{left: 4, right: 4}
+        margin: Inset{
+            left: (4.0 + mod.widgets.SAFE_INSET_PAD_LEFT),
+            right: (4.0 + mod.widgets.SAFE_INSET_PAD_RIGHT),
+        }
         show_bg: true
         draw_bg +: {
             color: (COLOR_PRIMARY_DARKER)
@@ -290,6 +281,10 @@ script_mod! {
                         // the main list of rooms or the settings screen.
                         home_screen_page_flip := PageFlip {
                             width: Fill, height: Fill
+                            padding: Inset{
+                                left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                                right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                            }
 
                             lazy_init: true,
                             active_page: @home_page
@@ -336,36 +331,23 @@ script_mod! {
                         }
                     }
 
-                    // Room views: multiple instances to support deep stacking
-                    // (e.g., room -> thread -> room -> thread -> ...).
-                    // Each stack depth gets its own dedicated view widget,
-                    // avoiding complex state save/restore when views are reused.
-                    room_view_0  := mod.widgets.RobrixContentView { body +: { room_screen_0  := mod.widgets.RoomScreen {} } }
-                    room_view_1  := mod.widgets.RobrixContentView { body +: { room_screen_1  := mod.widgets.RoomScreen {} } }
-                    room_view_2  := mod.widgets.RobrixContentView { body +: { room_screen_2  := mod.widgets.RoomScreen {} } }
-                    room_view_3  := mod.widgets.RobrixContentView { body +: { room_screen_3  := mod.widgets.RoomScreen {} } }
-                    room_view_4  := mod.widgets.RobrixContentView { body +: { room_screen_4  := mod.widgets.RoomScreen {} } }
-                    room_view_5  := mod.widgets.RobrixContentView { body +: { room_screen_5  := mod.widgets.RoomScreen {} } }
-                    room_view_6  := mod.widgets.RobrixContentView { body +: { room_screen_6  := mod.widgets.RoomScreen {} } }
-                    room_view_7  := mod.widgets.RobrixContentView { body +: { room_screen_7  := mod.widgets.RoomScreen {} } }
-                    room_view_8  := mod.widgets.RobrixContentView { body +: { room_screen_8  := mod.widgets.RoomScreen {} } }
-                    room_view_9  := mod.widgets.RobrixContentView { body +: { room_screen_9  := mod.widgets.RoomScreen {} } }
-                    room_view_10 := mod.widgets.RobrixContentView { body +: { room_screen_10 := mod.widgets.RoomScreen {} } }
-                    room_view_11 := mod.widgets.RobrixContentView { body +: { room_screen_11 := mod.widgets.RoomScreen {} } }
-                    room_view_12 := mod.widgets.RobrixContentView { body +: { room_screen_12 := mod.widgets.RoomScreen {} } }
-                    room_view_13 := mod.widgets.RobrixContentView { body +: { room_screen_13 := mod.widgets.RoomScreen {} } }
-                    room_view_14 := mod.widgets.RobrixContentView { body +: { room_screen_14 := mod.widgets.RoomScreen {} } }
-                    room_view_15 := mod.widgets.RobrixContentView { body +: { room_screen_15 := mod.widgets.RoomScreen {} } }
-
-                    invite_view := mod.widgets.RobrixContentView {
-                        body +: {
-                            invite_screen := mod.widgets.InviteScreen {}
+                    stack_templates: {
+                        RoomScreenStackNavigationView := mod.widgets.RobrixStackNavigationView {
+                            body +: {
+                                room_screen := mod.widgets.RoomScreen {}
+                            }
                         }
-                    }
 
-                    space_lobby_view := mod.widgets.RobrixContentView {
-                        body +: {
-                            space_lobby_screen := mod.widgets.SpaceLobbyScreen {}
+                        InviteScreenStackNavigationView := mod.widgets.RobrixStackNavigationView {
+                            body +: {
+                                invite_screen := mod.widgets.InviteScreen {}
+                            }
+                        }
+
+                        SpaceLobbyScreenStackNavigationView := mod.widgets.RobrixStackNavigationView {
+                            body +: {
+                                space_lobby_screen := mod.widgets.SpaceLobbyScreen {}
+                            }
                         }
                     }
                 }
@@ -376,11 +358,33 @@ script_mod! {
 
 
 /// A simple wrapper around the SpacesBar that allows us to animate showing or hiding it.
-#[derive(Script, ScriptHook, Widget, Animator)]
+#[derive(Script, Widget, Animator)]
 pub struct SpacesBarWrapper {
     #[source] source: ScriptObjectRef,
     #[deref] view: View,
     #[apply_default] animator: Animator,
+}
+
+impl ScriptHook for SpacesBarWrapper {
+    fn on_after_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        // Re-apply current animation state after script reapply, otherwise
+        // a hidden spaces bar may briefly flash visible.
+        if !apply.is_script_reapply() {
+            return;
+        }
+        if let Some(state_apply) = self
+            .animator
+            .current_state_apply(live_id!(spaces_bar_animator))
+        {
+            self.script_apply(vm, &Apply::Animate, scope, state_apply.into());
+        }
+    }
 }
 
 impl Widget for SpacesBarWrapper {
@@ -427,7 +431,19 @@ pub struct HomeScreen {
     /// other widgets can easily access it.
     #[rust] previous_selection: SelectedTab,
     #[rust] is_spaces_bar_shown: bool,
+
+    /// A history of previously-selected screens for mobile stack navigation.
+    /// When a view is popped off the stack, the previous `selected_room` is restored.
+    #[rust] mobile_screen_history: Vec<SelectedRoom>,
+
+    /// The most recently applied view-mode override, used to short-circuit
+    /// redundant `AdaptiveView` selector reinstalls when an
+    /// [`AppPreferencesAction::ViewModeChanged`] action repeats the current
+    /// value (e.g., the unconditional broadcast on app-state restore).
     #[rust] applied_view_mode: ViewModeOverride,
+
+    /// The last effective AdaptiveView mode we observed. `Some(true)` means desktop mode.
+    #[rust] last_effective_is_desktop: Option<bool>,
 }
 
 impl Widget for HomeScreen {
@@ -443,14 +459,6 @@ impl Widget for HomeScreen {
 
             let app_state = scope.data.get_mut::<AppState>().unwrap();
             for action in actions {
-                if let Some(AppPreferencesAction::ViewModeChanged(new_mode)) = action.downcast_ref() {
-                    if *new_mode != self.applied_view_mode {
-                        self.apply_view_mode(cx, *new_mode);
-                        self.view.redraw(cx);
-                    }
-                    continue;
-                }
-
                 match action.downcast_ref() {
                     Some(NavigationBarAction::GoToHome) => {
                         if !matches!(app_state.selected_tab, SelectedTab::Home) {
@@ -513,6 +521,53 @@ impl Widget for HomeScreen {
                     Some(NavigationBarAction::TabSelected(_))
                     | None => { }
                 }
+
+                // React to App Settings changes that affect the HomeScreen layout.
+                if let Some(AppPreferencesAction::ViewModeChanged(new_mode)) = action.downcast_ref() {
+                    if *new_mode != self.applied_view_mode {
+                        self.apply_view_mode(cx, *new_mode);
+                        self.view.redraw(cx);
+                    }
+                    self.sync_effective_view_mode(cx);
+                }
+
+                if let WindowAction::WindowGeomChange(_) = action.as_widget_action().cast() {
+                    self.sync_effective_view_mode(cx);
+                }
+
+                // Handle room selections. Desktop owns tab creation in MainDesktopUI,
+                // while mobile owns StackNavigation screen pushes here.
+                match action.as_widget_action().cast() {
+                    RoomsListAction::Selected(selected_room) => {
+                        if app_state.app_prefs.view_mode == ViewModeOverride::ForceWide
+                            || (app_state.app_prefs.view_mode == ViewModeOverride::Automatic
+                                && (cx.display_context.is_desktop() || !cx.display_context.is_screen_size_known()))
+                        {
+                            app_state.selected_room = Some(selected_room);
+                        } else {
+                            self.push_selected_screen_view(cx, app_state, selected_room);
+                        }
+                    }
+                    RoomsListAction::InviteAccepted { room_name_id } => {
+                        cx.action(AppStateAction::UpgradedInviteToJoinedRoom(
+                            room_name_id.room_id().clone(),
+                        ));
+                    }
+                    _ => {}
+                }
+
+                if let StackNavigationTransitionAction::ViewReleased(view_id) =
+                    action.as_widget_action().cast()
+                {
+                    let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
+                    self.hide_released_stack_navigation_view(cx, &stack_navigation, view_id);
+                }
+
+                // When a stack navigation pop is requested (back button pressed),
+                // reveal the previous screen from HomeScreen's mobile history.
+                if let StackNavigationAction::Pop = action.as_widget_action().cast() {
+                    self.pop_selected_screen_view(cx, app_state);
+                }
             }
         }
 
@@ -543,6 +598,18 @@ impl HomeScreen {
         self.applied_view_mode = mode;
     }
 
+    fn sync_effective_view_mode(&mut self, cx: &mut Cx) {
+        let is_desktop = self.applied_view_mode == ViewModeOverride::ForceWide
+            || (self.applied_view_mode == ViewModeOverride::Automatic
+                && (cx.display_context.is_desktop() || !cx.display_context.is_screen_size_known()));
+        let Some(previous_is_desktop) = self.last_effective_is_desktop.replace(is_desktop) else {
+            return;
+        };
+        if previous_is_desktop != is_desktop {
+            self.clear_mobile_navigation_state(cx);
+        }
+    }
+
     fn update_active_page_from_selection(
         &mut self,
         cx: &mut Cx,
@@ -559,5 +626,174 @@ impl HomeScreen {
                     SelectedTab::AddRoom => id!(add_room_page),
                 },
             )
+    }
+
+    fn configure_mobile_stack_navigation_view(
+        &mut self,
+        cx: &mut Cx,
+        stack_navigation: &StackNavigationRef,
+        selected_screen: &SelectedRoom,
+    ) -> Option<LiveId> {
+        let view_id = match selected_screen {
+            SelectedRoom::JoinedRoom { room_name_id }
+            | SelectedRoom::Thread { room_name_id, .. } => {
+                let Some((view_id, stack_navigation_view)) =
+                    stack_navigation.create_view_from_template(cx, id!(RoomScreenStackNavigationView))
+                else {
+                    error!("BUG: failed to create mobile RoomScreen StackNavigationView");
+                    return None;
+                };
+                Self::hide_displayed_stack_screen(cx, &stack_navigation_view);
+                let thread_root = if let SelectedRoom::Thread { thread_root_event_id, .. } = selected_screen {
+                    Some(thread_root_event_id.clone())
+                } else {
+                    None
+                };
+                stack_navigation_view
+                    .room_screen(cx, ids!(room_screen))
+                    .set_displayed_room(cx, room_name_id, thread_root);
+                view_id
+            }
+            SelectedRoom::InvitedRoom { room_name_id } => {
+                let Some((view_id, stack_navigation_view)) =
+                    stack_navigation.create_view_from_template(cx, id!(InviteScreenStackNavigationView))
+                else {
+                    error!("BUG: failed to create mobile InviteScreen StackNavigationView");
+                    return None;
+                };
+                Self::hide_displayed_stack_screen(cx, &stack_navigation_view);
+                stack_navigation_view
+                    .invite_screen(cx, ids!(invite_screen))
+                    .set_displayed_invite(cx, room_name_id);
+                view_id
+            }
+            SelectedRoom::Space { space_name_id } => {
+                let Some((view_id, stack_navigation_view)) =
+                    stack_navigation.create_view_from_template(cx, id!(SpaceLobbyScreenStackNavigationView))
+                else {
+                    error!("BUG: failed to create mobile SpaceLobbyScreen StackNavigationView");
+                    return None;
+                };
+                Self::hide_displayed_stack_screen(cx, &stack_navigation_view);
+                stack_navigation_view
+                    .space_lobby_screen(cx, ids!(space_lobby_screen))
+                    .set_displayed_space(cx, space_name_id);
+                view_id
+            }
+        };
+
+        stack_navigation.set_title(cx, view_id, &selected_screen.display_name());
+        Some(view_id)
+    }
+
+    fn hide_released_stack_navigation_view(
+        &mut self,
+        cx: &mut Cx,
+        stack_navigation: &StackNavigationRef,
+        view_id: LiveId,
+    ) {
+        // A ViewReleased action can arrive after this StackNavigationView has
+        // already been reused for a new transition. In that case, the visible
+        // view is displaying a newer screen and must not be hidden by the stale
+        // release.
+        if stack_navigation.stack_view_ids().contains(&view_id) {
+            return;
+        }
+        let stack_navigation_view = stack_navigation.view_by_id(cx, view_id);
+        Self::hide_displayed_stack_screen(cx, &stack_navigation_view);
+    }
+
+    fn clear_mobile_navigation_state(&mut self, cx: &mut Cx) {
+        self.mobile_screen_history.clear();
+
+        let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
+        for view_id in stack_navigation.dynamic_stack_view_ids() {
+            let stack_navigation_view = stack_navigation.view_by_id(cx, view_id);
+            Self::hide_displayed_stack_screen(cx, &stack_navigation_view);
+        }
+    }
+
+    fn hide_displayed_stack_screen(cx: &mut Cx, stack_navigation_view: &WidgetRef) {
+        stack_navigation_view
+            .room_screen(cx, ids!(room_screen))
+            .hide_displayed_room(cx);
+        stack_navigation_view
+            .invite_screen(cx, ids!(invite_screen))
+            .hide_displayed_invite(cx);
+        stack_navigation_view
+            .space_lobby_screen(cx, ids!(space_lobby_screen))
+            .hide_displayed_space(cx);
+    }
+
+    /// Pushes the given screen onto the mobile screen history and animates it in.
+    fn push_selected_screen_view(
+        &mut self,
+        cx: &mut Cx,
+        app_state: &mut AppState,
+        sr: SelectedRoom,
+    ) {
+        // Ensure the view mode is known.
+        if self.last_effective_is_desktop.is_none() {
+            self.last_effective_is_desktop = Some(
+                self.applied_view_mode == ViewModeOverride::ForceWide
+                    || (self.applied_view_mode == ViewModeOverride::Automatic
+                        && (cx.display_context.is_desktop()
+                            || !cx.display_context.is_screen_size_known()))
+            );
+        }
+
+        let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
+        if stack_navigation.is_transitioning() {
+            log!("Ignoring mobile room selection while StackNavigation is transitioning");
+            return;
+        }
+        let has_current_mobile_screen = stack_navigation.current_view().is_some();
+
+        if has_current_mobile_screen && app_state.selected_room.as_ref().is_some_and(|c| c == &sr) {
+            return;
+        }
+
+        let Some(view_id) = self.configure_mobile_stack_navigation_view(cx, &stack_navigation, &sr) else {
+            return;
+        };
+
+        // Save the current selected_room onto the navigation stack before replacing it.
+        if has_current_mobile_screen {
+            if let Some(prev) = app_state.selected_room.take() {
+                self.mobile_screen_history.push(prev);
+            }
+        }
+        app_state.selected_room = Some(sr);
+        stack_navigation.push(cx, view_id);
+        self.view.redraw(cx);
+    }
+
+    /// Pops the current mobile screen, revealing the previous screen or the room list root.
+    fn pop_selected_screen_view(&mut self, cx: &mut Cx, app_state: &mut AppState) {
+        let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
+        if stack_navigation.is_transitioning() {
+            return;
+        }
+
+        let Some(current_screen) = app_state.selected_room.take() else {
+            return;
+        };
+        let previous_screen = self.mobile_screen_history.pop();
+        match previous_screen {
+            Some(previous_screen) => {
+                let Some(view_id) = self.configure_mobile_stack_navigation_view(cx, &stack_navigation, &previous_screen) else {
+                    app_state.selected_room = Some(current_screen);
+                    self.mobile_screen_history.push(previous_screen);
+                    return;
+                };
+                app_state.selected_room = Some(previous_screen);
+                stack_navigation.pop_to_view(cx, view_id);
+            }
+            None => {
+                app_state.selected_room = None;
+                stack_navigation.pop_to_root(cx);
+            }
+        }
+        self.view.redraw(cx);
     }
 }

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -552,6 +552,17 @@ impl InviteScreen {
             restore_status_view.set_visible(cx, false);
         }
     }
+
+    pub fn hide_displayed_invite(&mut self, cx: &mut Cx) {
+        self.room_name_id = None;
+        self.info = None;
+        self.invite_state = InviteState::default();
+        self.has_shown_confirmation = false;
+        self.is_loaded = false;
+        self.all_rooms_loaded = false;
+        self.view.restore_status_view(cx, ids!(restore_status_view)).set_visible(cx, false);
+        self.redraw(cx);
+    }
 }
 
 impl InviteScreenRef {
@@ -559,6 +570,12 @@ impl InviteScreenRef {
     pub fn set_displayed_invite(&self, cx: &mut Cx, room_name_id: &RoomNameId) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_displayed_invite(cx, room_name_id);
+        }
+    }
+
+    pub fn hide_displayed_invite(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.hide_displayed_invite(cx);
         }
     }
 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -9413,26 +9413,24 @@ fn populate_message_view(
                     if existed && item_drawn_status.content_drawn {
                         (item, true)
                     } else {
-                        if !sender_is_bot {
-                            let html_or_plaintext_ref = item.html_or_plaintext(cx, ids!(content.message));
-                            // Apply gray color to all text styles for notice messages.
-                            // This covers both rendering paths in HtmlOrPlaintext: the rich
-                            // `html_view.html` widget (used when the message has an HTML body)
-                            // and the `plaintext_view.pt_label` (used for plain-text notices).
-                            let mut html_widget = html_or_plaintext_ref.html(cx, ids!(html_view.html));
-                            script_apply_eval!(cx, html_widget, {
-                                font_color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT,
-                                draw_block +: {
-                                    quote_fg_color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT,
-                                }
-                            });
-                            let mut pt_label = html_or_plaintext_ref.label(cx, ids!(plaintext_view.pt_label));
-                            script_apply_eval!(cx, pt_label, {
-                                draw_text +: {
-                                    color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT
-                                }
-                            });
-                        }
+                        let html_or_plaintext_ref = item.html_or_plaintext(cx, ids!(content.message));
+                        // Apply gray color to all text styles for notice messages.
+                        // This covers both rendering paths in HtmlOrPlaintext: the rich
+                        // `html_view.html` widget (used when the message has an HTML body)
+                        // and the `plaintext_view.pt_label` (used for plain-text notices).
+                        let mut html_widget = html_or_plaintext_ref.html(cx, ids!(html_view.html));
+                        script_apply_eval!(cx, html_widget, {
+                            font_color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT,
+                            draw_block +: {
+                                quote_fg_color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT,
+                            }
+                        });
+                        let mut pt_label = html_or_plaintext_ref.label(cx, ids!(plaintext_view.pt_label));
+                        script_apply_eval!(cx, pt_label, {
+                            draw_text +: {
+                                color: mod.widgets.COLOR_MESSAGE_NOTICE_TEXT
+                            }
+                        });
                         let mut link_preview_ref =
                             item.link_preview(cx, ids!(content.link_preview_view));
                         new_drawn_status.content_drawn = populate_bot_text_message_content(

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2282,6 +2282,19 @@ script_mod! {
         }
     }
 
+    // A single, shared `Size::Fit{max: ...}` object on the script heap,
+    // referenced by every `Image` widget inside an `ImageMessage` /
+    // `CondensedImageMessage`. Having one heap object instead of many
+    // lets the "Maximum Image Thumbnail Height" App Setting mutate just
+    // this object's `max` field at runtime (see
+    // `AppPreferences::on_thumbnail_max_height_changed`) — every widget
+    // whose `walk.height` referenced this object observes the change
+    // through the same heap object on the next `Event::ScriptReapply`.
+    //
+    // This sidesteps the override-chain divergence that would otherwise
+    // make the mutation invisible to derived templates (e.g., the
+    // `ImageMessage := mod.widgets.ImageMessage {}` local alias inside a
+    // PortalList's `list`).
     mod.widgets.IMG_MSG_FIT = Fit{max: FitBound.Abs(200.0)}
 
     // The view used for each static image-based message event in a room's timeline.
@@ -4497,7 +4510,7 @@ pub struct RoomScreen {
 impl Drop for RoomScreen {
     fn drop(&mut self) {
         // This ensures that the `TimelineUiState` instance owned by this room is *always* returned
-        // back to to `TIMELINE_STATES`, which ensures that its UI state(s) are not lost
+        // back to the timeline lease store, which ensures that its UI state(s) are not lost
         // and that other RoomScreen instances can show this room in the future.
         // RoomScreen will be dropped whenever its widget instance is destroyed, e.g.,
         // when a Tab is closed or the app is resized to a different AdaptiveView layout.
@@ -6989,9 +7002,9 @@ impl RoomScreen {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
                         .set_upload_abort_handle(handle);
                 }
-                TimelineUpdate::FileUploadError { error, file_data } => {
+                TimelineUpdate::FileUploadError { error, file_data, retryable } => {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
-                        .show_upload_error(cx, &error, file_data);
+                        .show_upload_error(cx, &error, file_data, retryable);
                 }
                 TimelineUpdate::FileUploadComplete => {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
@@ -8059,42 +8072,46 @@ impl RoomScreen {
         let kind = self.timeline_kind.clone()
             .expect("BUG: Timeline::show_timeline(): no timeline_kind was set.");
         let room_id = kind.room_id().clone();
+        let owner = self.widget_uid();
 
-        let state_opt = TIMELINE_STATES.with_borrow_mut(|ts| ts.remove(&kind));
-        let (mut tl_state, mut is_first_time_being_loaded) = if let Some(existing) = state_opt {
-            (existing, false)
-        } else {
-            let Some(timeline_endpoints) = take_timeline_endpoints(&kind) else {
-                if let Some(thread_root_event_id) = kind.thread_root_event_id() {
-                    submit_async_request(MatrixRequest::CreateThreadTimeline {
-                        room_id: room_id.clone(),
-                        thread_root_event_id: thread_root_event_id.clone(),
-                    });
-                    return;
-                }
-                if !self.is_loaded && self.all_rooms_loaded {
-                    panic!("BUG: timeline {kind} is not loaded, but its RoomScreen \
-                    was not waiting for its timeline to be loaded either.");
-                }
+        let (mut tl_state, mut is_first_time_being_loaded) = match timeline_lease::checkout(&kind, owner) {
+            timeline_lease::Checkout::Available(existing) => (existing, false),
+            timeline_lease::Checkout::CheckedOut { owner: current_owner } => {
+                error!("RoomScreen::show_timeline(): timeline {kind} is already checked out by widget {current_owner:?}");
                 return;
-            };
-            let TimelineEndpoints {
-                update_receiver,
-                update_sender,
-                request_sender,
-                successor_room,
-            } = timeline_endpoints;
+            }
+            timeline_lease::Checkout::Missing => {
+                let Some(timeline_endpoints) = take_timeline_endpoints(&kind) else {
+                    if let Some(thread_root_event_id) = kind.thread_root_event_id() {
+                        submit_async_request(MatrixRequest::CreateThreadTimeline {
+                            room_id: room_id.clone(),
+                            thread_root_event_id: thread_root_event_id.clone(),
+                        });
+                        return;
+                    }
+                    if !self.is_loaded && self.all_rooms_loaded {
+                        panic!("BUG: timeline {kind} is not loaded, but its RoomScreen \
+                        was not waiting for its timeline to be loaded either.");
+                    }
+                    return;
+                };
+                let TimelineEndpoints {
+                    update_receiver,
+                    update_sender,
+                    request_sender,
+                    successor_room,
+                } = timeline_endpoints;
 
-            // Start with the basic tombstone info, and fetch the full details
-            // if the room has been tombstoned.
-            let tombstone_info = if let Some(sr) = successor_room {
-                submit_async_request(MatrixRequest::GetSuccessorRoomDetails {
-                    tombstoned_room_id: room_id.clone(),
-                });
-                Some(SuccessorRoomDetails::Basic(sr))
-            } else {
-                None
-            };
+                // Start with the basic tombstone info, and fetch the full details
+                // if the room has been tombstoned.
+                let tombstone_info = if let Some(sr) = successor_room {
+                    submit_async_request(MatrixRequest::GetSuccessorRoomDetails {
+                        tombstoned_room_id: room_id.clone(),
+                    });
+                    Some(SuccessorRoomDetails::Basic(sr))
+                } else {
+                    None
+                };
 
             let tl_state = TimelineUiState {
                 kind,
@@ -8130,7 +8147,9 @@ impl RoomScreen {
                 latest_own_user_receipt: None,
                 tombstone_info,
             };
-            (tl_state, true)
+                timeline_lease::mark_checked_out(&tl_state.kind, owner);
+                (tl_state, true)
+            }
         };
 
         // It is possible that this room has already been loaded (received from the server)
@@ -8235,6 +8254,11 @@ impl RoomScreen {
     fn hide_timeline(&mut self) {
         let Some(timeline_kind) = self.timeline_kind.clone() else { return };
         self.streaming_timeout_timer = Timer::empty();
+        if self.tl_state.is_none() {
+            self.room_avatar_url = None;
+            self.pending_invited_users.clear();
+            return;
+        }
 
         self.save_state();
 
@@ -8263,7 +8287,7 @@ impl RoomScreen {
     }
 
     /// Removes the current room's visual UI state from this widget
-    /// and saves it to the map of `TIMELINE_STATES` such that it can be restored later.
+    /// and saves it to the timeline lease store such that it can be restored later.
     ///
     /// Note: after calling this function, the widget's `tl_state` will be `None`.
     fn save_state(&mut self) {
@@ -8284,8 +8308,8 @@ impl RoomScreen {
         // (in case this room is never re-opened).
         tl.room_members = None;
         tl.room_members_sort = None;
-        // Store this Timeline's `TimelineUiState` in the global map of states.
-        TIMELINE_STATES.with_borrow_mut(|ts| ts.insert(tl.kind.clone(), tl));
+        // Store this Timeline's `TimelineUiState` in the lease store.
+        timeline_lease::return_state(self.widget_uid(), tl);
     }
 
     /// Restores the previously-saved visual UI state of this room.
@@ -8389,6 +8413,19 @@ impl RoomScreen {
         });
 
         self.show_timeline(cx);
+    }
+
+    pub fn hide_displayed_room(&mut self, cx: &mut Cx) {
+        if self.tl_state.is_some() {
+            self.hide_timeline();
+        }
+        self.room_name_id = None;
+        self.timeline_kind = None;
+        self.pinned_events.clear();
+        self.is_loaded = false;
+        self.all_rooms_loaded = false;
+        self.view.restore_status_view(cx, ids!(restore_status_view)).set_visible(cx, false);
+        self.redraw(cx);
     }
 
     /// Sends read receipts based on the current scroll position of the timeline.
@@ -8507,6 +8544,11 @@ impl RoomScreenRef {
     ) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.set_displayed_room(cx, room_name_id, thread_root_event_id);
+    }
+
+    pub fn hide_displayed_room(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.hide_displayed_room(cx);
     }
 }
 
@@ -8672,17 +8714,88 @@ pub enum TimelineUpdate {
     FileUploadError {
         error: String,
         file_data: crate::shared::file_upload_modal::FileData,
+        retryable: bool,
     },
     /// File upload completed successfully.
     FileUploadComplete,
 }
 
-thread_local! {
-    /// The global set of all timeline states, one entry per room.
-    ///
-    /// This is only useful when accessed from the main UI thread.
-    static TIMELINE_STATES: RefCell<HashMap<TimelineKind, TimelineUiState>> = 
-        RefCell::new(HashMap::new());
+mod timeline_lease {
+    use super::*;
+
+    enum LeaseState {
+        Available(TimelineUiState),
+        CheckedOut { owner: WidgetUid },
+    }
+
+    pub(super) enum Checkout {
+        Available(TimelineUiState),
+        CheckedOut { owner: WidgetUid },
+        Missing,
+    }
+
+    thread_local! {
+        /// The global store of all timeline states, one entry per room.
+        ///
+        /// This is only useful when accessed from the main UI thread.
+        static TIMELINE_STATES: RefCell<HashMap<TimelineKind, LeaseState>> =
+            RefCell::new(HashMap::new());
+    }
+
+    pub(super) fn checkout(kind: &TimelineKind, owner: WidgetUid) -> Checkout {
+        TIMELINE_STATES.with_borrow_mut(|states| {
+            match states.remove(kind) {
+                Some(LeaseState::Available(state)) => {
+                    states.insert(kind.clone(), LeaseState::CheckedOut { owner });
+                    Checkout::Available(state)
+                }
+                Some(LeaseState::CheckedOut { owner: current_owner }) => {
+                    states.insert(kind.clone(), LeaseState::CheckedOut { owner: current_owner });
+                    Checkout::CheckedOut { owner: current_owner }
+                }
+                None => Checkout::Missing,
+            }
+        })
+    }
+
+    pub(super) fn mark_checked_out(kind: &TimelineKind, owner: WidgetUid) {
+        TIMELINE_STATES.with_borrow_mut(|states| {
+            match states.insert(kind.clone(), LeaseState::CheckedOut { owner }) {
+                Some(LeaseState::Available(_)) => {
+                    error!("RoomScreen::show_timeline(): timeline {kind} unexpectedly had an available saved state while creating a new state");
+                }
+                Some(LeaseState::CheckedOut { owner: current_owner }) if current_owner != owner => {
+                    error!("RoomScreen::show_timeline(): timeline {kind} was already checked out by widget {current_owner:?}, but widget {owner:?} created a new state");
+                }
+                Some(LeaseState::CheckedOut { .. }) | None => {}
+            }
+        });
+    }
+
+    pub(super) fn return_state(owner: WidgetUid, state: TimelineUiState) {
+        let kind = state.kind.clone();
+        TIMELINE_STATES.with_borrow_mut(|states| {
+            match states.remove(&kind) {
+                Some(LeaseState::CheckedOut { owner: current_owner }) if current_owner == owner => {}
+                Some(LeaseState::CheckedOut { owner: current_owner }) => {
+                    error!("RoomScreen::save_state(): timeline {kind} was returned by widget {owner:?}, but it was checked out by widget {current_owner:?}");
+                }
+                Some(LeaseState::Available(_)) => {
+                    error!("RoomScreen::save_state(): timeline {kind} was returned by widget {owner:?}, but an available saved state already existed");
+                }
+                None => {
+                    log!("RoomScreen::save_state(): timeline {kind} was returned by widget {owner:?} without a checkout marker");
+                }
+            }
+            states.insert(kind, LeaseState::Available(state));
+        });
+    }
+
+    pub(super) fn clear_all() {
+        TIMELINE_STATES.with_borrow_mut(|states| {
+            states.clear();
+        });
+    }
 }
 
 /// The UI-side state of a single room's timeline, which is only accessed/updated by the UI thread.
@@ -11770,10 +11883,7 @@ impl MessageRef {
 /// which isn't used, but acts as a guarantee that this function
 /// must only be called by the main UI thread. 
 pub fn clear_timeline_states(_cx: &mut Cx) {
-    // Clear timeline states cache
-    TIMELINE_STATES.with_borrow_mut(|states| {
-        states.clear();
-    });
+    timeline_lease::clear_all();
 }
 
 #[cfg(test)]

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -24,7 +24,7 @@ use ruma::events::tag::TagName;
 use tokio::sync::mpsc::UnboundedSender;
 use matrix_sdk::{RoomState, ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch, OwnedRoomAliasId, OwnedRoomId, OwnedUserId}};
 use crate::{
-    app::{AppState, SelectedRoom},
+    app::{AppState, AppStateAction, SelectedRoom},
     home::{
         ContextMenuOpenGesture,
         add_room::CreateRoomAction,
@@ -660,6 +660,12 @@ impl RoomsList {
         }
 
         self.update_displayed_rooms(cx, false);
+    }
+
+    fn set_current_active_room(&mut self, cx: &mut Cx, selected_room: Option<SelectedRoom>) {
+        if self.current_active_room == selected_room { return; }
+        self.current_active_room = selected_room;
+        self.redraw(cx);
     }
 
     /// Handle all pending updates to the list of all rooms.
@@ -1422,16 +1428,11 @@ impl Widget for RoomsList {
                     continue;
                 };
 
-                if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_room) {
-                    continue;
-                }
-
-                self.current_active_room = Some(new_selected_room.clone());
+                self.set_current_active_room(cx, Some(new_selected_room.clone()));
                 cx.widget_action(
                     self.widget_uid(), 
                     RoomsListAction::Selected(new_selected_room),
                 );
-                self.redraw(cx);
             }
             // Handle a room being right-clicked or long-pressed by opening the room context menu.
             else if let RoomsListEntryAction::SecondaryClicked(room_id, pos, opening_gesture) = action.as_widget_action().cast() {
@@ -1458,15 +1459,11 @@ impl Widget for RoomsList {
             else if let Some(SpaceLobbyAction::SpaceLobbyEntryClicked) = action.downcast_ref() {
                 let Some(space_name_id) = self.selected_space.clone() else { continue };
                 let new_selected_space = SelectedRoom::Space { space_name_id };
-                if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_space) {
-                    continue;
-                }
-                self.current_active_room = Some(new_selected_space.clone());
+                self.set_current_active_room(cx, Some(new_selected_space.clone()));
                 cx.widget_action(
                     self.widget_uid(), 
                     RoomsListAction::Selected(new_selected_space),
                 );
-                self.redraw(cx);
             }
             // Handle a collapsible header being clicked.
             else if let CollapsibleHeaderAction::Toggled { category } = action.as_widget_action().cast() {
@@ -1491,6 +1488,17 @@ impl Widget for RoomsList {
         // Second, handle any other actions that came from other widgets/components.
         if let Event::Actions(actions) = event {
             for action in actions {
+                if let Some(AppStateAction::RoomFocused(selected_room)) = action.downcast_ref() {
+                    self.set_current_active_room(cx, Some(selected_room.clone()));
+                    continue;
+                }
+
+                if let Some(AppStateAction::FocusNone) = action.downcast_ref() {
+                    self.set_current_active_room(cx, None);
+                    continue;
+                }
+
+                // Clear widget state upon logout.
                 if let Some(LogoutAction::ClearAppState { .. }) = action.downcast_ref() {
                     while PENDING_ROOM_UPDATES.pop().is_some() {}
                     self.invited_rooms.borrow_mut().clear();

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1040,6 +1040,12 @@ pub struct SpaceLobbyScreen {
     #[rust] creatable_spaces: HashSet<OwnedRoomId>,
 }
 
+impl Drop for SpaceLobbyScreen {
+    fn drop(&mut self) {
+        self.save_current_state();
+    }
+}
+
 impl Widget for SpaceLobbyScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         let app_language = scope.data.get::<AppState>()
@@ -1943,12 +1949,31 @@ impl SpaceLobbyScreen {
 
         self.redraw(cx);
     }
+
+    pub fn hide_displayed_space(&mut self, cx: &mut Cx) {
+        self.save_current_state();
+        self.space_name_id = None;
+        self.space_avatar_state = AvatarState::Unknown;
+        self.space_request_sender = None;
+        self.tree_entries.clear();
+        self.loading_subspaces.clear();
+        self.is_loading = false;
+        self.filter_keywords.clear();
+        self.view.text_input(cx, ids!(filter_bar.input)).set_text(cx, "");
+        self.view.button(cx, ids!(filter_bar.clear_button)).set_visible(cx, false);
+        self.redraw(cx);
+    }
 }
 
 impl SpaceLobbyScreenRef {
     pub fn set_displayed_space(&self, cx: &mut Cx, space_name_id: &RoomNameId) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.set_displayed_space(cx, space_name_id);
+    }
+
+    pub fn hide_displayed_space(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.hide_displayed_space(cx);
     }
 
     /// Saves the current UI state. Call this when the screen is being hidden or destroyed.

--- a/src/home/upload_progress.rs
+++ b/src/home/upload_progress.rs
@@ -17,7 +17,7 @@ script_mod! {
         height: Fit,
         flow: Down,
         padding: 10,
-        spacing: 8,
+        spacing: 15,
 
         show_bg: true,
         draw_bg +: {
@@ -44,6 +44,8 @@ script_mod! {
 
             file_name_label := Label {
                 width: Fill,
+                flow: Flow.Right {wrap: true}
+                margin: Inset { left: 1 }
                 draw_text +: {
                     text_style: REGULAR_TEXT { font_size: 10 },
                     color: (COLOR_TEXT)
@@ -76,14 +78,17 @@ script_mod! {
 
             status_label := Label {
                 width: Fill,
+                flow: Flow.Right {wrap: true}
+                margin: Inset { left: 1 }
                 draw_text +: {
-                    text_style: REGULAR_TEXT { font_size: 9 },
+                    text_style: REGULAR_TEXT { font_size: 11 },
                     color: (SMALL_STATE_TEXT_COLOR)
                 }
                 text: ""
             }
 
             retry_button := RobrixPositiveIconButton {
+                visible: false,
                 enabled: false,
                 padding: Inset{top: 4, bottom: 4, left: 8, right: 8}
                 draw_text +: {
@@ -174,6 +179,7 @@ impl UploadProgressView {
         self.label(cx, ids!(file_name_label)).set_text(cx, file_name);
         self.label(cx, ids!(status_label)).set_text(cx, "Starting upload...");
         self.button(cx, ids!(retry_button)).set_enabled(cx, false);
+        self.button(cx, ids!(retry_button)).set_visible(cx, false);
         self.button(cx, ids!(cancel_button)).set_enabled(cx, true);
 
         // Reset progress bar
@@ -220,7 +226,7 @@ impl UploadProgressView {
     }
 
     /// Shows an error state with the given message.
-    pub fn show_error(&mut self, cx: &mut Cx, error: &str, file_data: FileData) {
+    pub fn show_error(&mut self, cx: &mut Cx, error: &str, file_data: FileData, retryable: bool) {
         self.state = UploadViewState::Error {
             message: error.to_string(),
             file_data,
@@ -229,7 +235,8 @@ impl UploadProgressView {
         // Update UI for error state
         self.label(cx, ids!(status_label))
             .set_text(cx, &format!("Error: {}", error));
-        self.button(cx, ids!(retry_button)).set_enabled(cx, true);
+        self.button(cx, ids!(retry_button)).set_enabled(cx, retryable);
+        self.button(cx, ids!(retry_button)).set_visible(cx, retryable);
         self.button(cx, ids!(cancel_button)).set_enabled(cx, true);
 
         // Set progress bar to error color - no longer apply color change via script_apply_eval
@@ -269,9 +276,9 @@ impl UploadProgressViewRef {
     }
 
     /// Shows an error state with the given message.
-    pub fn show_error(&self, cx: &mut Cx, error: &str, file_data: FileData) {
+    pub fn show_error(&self, cx: &mut Cx, error: &str, file_data: FileData, retryable: bool) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.show_error(cx, error, file_data);
+            inner.show_error(cx, error, file_data, retryable);
         }
     }
 }

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -814,7 +814,7 @@ impl LoginScreen {
         self.use_proxy_enabled = enabled;
         self.view
             .check_box(cx, ids!(proxy_use_toggle))
-            .set_active(cx, enabled);
+            .set_active(cx, enabled, Animate::No);
         self.view
             .view(cx, ids!(proxy_fields_section))
             .set_visible(cx, enabled);

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -26,6 +26,16 @@ use crate::{app::AppState, home::{editing_pane::{EditingPaneState, EditingPaneWi
 use crate::shared::file_upload_modal::{FilePreviewerMetaData, ThumbnailData};
 
 const ROOM_INFO_CARD_MOBILE_BREAKPOINT: f32 = 700.0;
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+enum PendingFileSelection {
+    Selected(std::path::PathBuf),
+    Cancelled,
+    Error(String),
+}
+
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+type PendingFileSelectionReceiver = std::sync::mpsc::Receiver<PendingFileSelection>;
+
 #[cfg(test)]
 const TRANSLATION_LANG_POPUP_WIDTH: f64 = 220.0;
 #[cfg(test)]
@@ -1092,6 +1102,9 @@ pub struct RoomInputBar {
     /// The pending file load operation, if any. Contains the receiver channel
     /// for receiving the loaded file data from a background thread.
     #[rust] pending_file_load: Option<crate::shared::file_upload_modal::FileLoadReceiver>,
+    /// The pending file picker operation, if any. Contains the receiver channel
+    /// for receiving the selected file path from a background thread.
+    #[rust] pending_file_selection: Option<PendingFileSelectionReceiver>,
 
     // --- Translation state ---
     /// Whether real-time translation is currently active.
@@ -1188,6 +1201,32 @@ impl Widget for RoomInputBar {
 
         // Handle signal events for pending file loads from background threads.
         if let Event::Signal = event {
+            #[cfg(not(any(target_os = "ios", target_os = "android")))]
+            if let Some(receiver) = &self.pending_file_selection {
+                let mut remove_receiver = false;
+                match receiver.try_recv() {
+                    Ok(PendingFileSelection::Selected(path)) => {
+                        self.start_file_preview_load(cx, path);
+                        remove_receiver = true;
+                    }
+                    Ok(PendingFileSelection::Cancelled) => {
+                        remove_receiver = true;
+                    }
+                    Ok(PendingFileSelection::Error(error)) => {
+                        enqueue_popup_notification(error, PopupKind::Error, None);
+                        remove_receiver = true;
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        remove_receiver = true;
+                    }
+                }
+                if remove_receiver {
+                    self.pending_file_selection = None;
+                    self.redraw(cx);
+                }
+            }
+
             if let Some(receiver) = &self.pending_file_load {
                 let mut remove_receiver = false;
                 match receiver.try_recv() {
@@ -1981,16 +2020,45 @@ impl RoomInputBar {
     /// Opens the native file picker dialog to select a file for upload.
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     fn open_file_picker(&mut self, cx: &mut Cx) {
-        // Run file dialog on main thread (required for non-windowed environments)
-        let dialog = rfd::FileDialog::new()
+        if self.pending_file_selection.is_some() || self.pending_file_load.is_some() {
+            enqueue_popup_notification(
+                "A file selection or file load is already in progress.",
+                PopupKind::Error,
+                None,
+            );
+            return;
+        }
+
+        let dialog_task = rfd::AsyncFileDialog::new()
             .set_title("Select file to upload")
             .add_filter("All files", &["*"])
             .add_filter("Images", &["png", "jpg", "jpeg", "gif", "webp", "bmp"])
-            .add_filter("Documents", &["pdf", "doc", "docx", "txt", "rtf"]);
+            .add_filter("Documents", &["pdf", "doc", "docx", "txt", "rtf"])
+            .pick_file();
 
-        if let Some(selected_file_path) = dialog.pick_file() {
-            self.start_file_preview_load(cx, selected_file_path);
-        }
+        let (sender, receiver) = std::sync::mpsc::channel();
+        self.pending_file_selection = Some(receiver);
+        cx.spawn_thread(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    if sender.send(PendingFileSelection::Error(format!("Failed to open file picker: {error}"))).is_err() {
+                        makepad_widgets::error!("Failed to send file picker error to UI: receiver dropped");
+                    }
+                    SignalToUI::set_ui_signal();
+                    return;
+                }
+            };
+            let selection = runtime.block_on(dialog_task);
+            let result = match selection {
+                Some(file_handle) => PendingFileSelection::Selected(file_handle.path().to_path_buf()),
+                None => PendingFileSelection::Cancelled,
+            };
+            if sender.send(result).is_err() {
+                makepad_widgets::error!("Failed to send file picker result to UI: receiver dropped");
+            }
+            SignalToUI::set_ui_signal();
+        });
     }
 
     /// Shows a "not supported" message on mobile platforms.
@@ -2290,11 +2358,11 @@ impl RoomInputBarRef {
     }
 
     /// Shows an upload error with retry option.
-    pub fn show_upload_error(&self, cx: &mut Cx, error: &str, file_data: FileData) {
+    pub fn show_upload_error(&self, cx: &mut Cx, error: &str, file_data: FileData, retryable: bool) {
         let Some(inner) = self.borrow() else { return };
         inner.child_by_path(ids!(upload_progress_view))
             .as_upload_progress_view()
-            .show_error(cx, error, file_data);
+            .show_error(cx, error, file_data, retryable);
     }
 
     /// Handles a confirmed file upload from the file upload modal.

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -554,7 +554,7 @@ impl AppSettings {
         self.view.check_box(cx, ids!(send_on_cmd_enter_toggle))
             .set_text(SEND_SHORTCUT_TOGGLE_LABEL);
         self.view.check_box(cx, ids!(send_on_cmd_enter_toggle))
-            .set_active(cx, !prefs.send_on_enter);
+            .set_active(cx, !prefs.send_on_enter, Animate::No);
         Self::update_send_shortcut_description(cx, &self.view, prefs.send_on_enter);
 
         let (small, medium, unlimited, custom, custom_text) = match prefs.thumbnail_max_height {
@@ -563,10 +563,10 @@ impl AppSettings {
             ThumbnailMaxHeight::Unlimited => (false, false, true, false, String::new()),
             ThumbnailMaxHeight::Custom(v) => (false, false, false, true, v.to_string()),
         };
-        self.view.radio_button(cx, ids!(thumb_small_radio)).set_active(cx, small);
-        self.view.radio_button(cx, ids!(thumb_medium_radio)).set_active(cx, medium);
-        self.view.radio_button(cx, ids!(thumb_unlimited_radio)).set_active(cx, unlimited);
-        self.view.radio_button(cx, ids!(thumb_custom_radio)).set_active(cx, custom);
+        self.view.radio_button(cx, ids!(thumb_small_radio)).set_active(cx, small, Animate::No);
+        self.view.radio_button(cx, ids!(thumb_medium_radio)).set_active(cx, medium, Animate::No);
+        self.view.radio_button(cx, ids!(thumb_unlimited_radio)).set_active(cx, unlimited, Animate::No);
+        self.view.radio_button(cx, ids!(thumb_custom_radio)).set_active(cx, custom, Animate::No);
         Self::set_thumb_custom_input_read_only(cx, &self.view, custom);
         Self::set_thumb_custom_input_disabled(cx, &self.view, custom);
         self.view.text_input(cx, ids!(thumb_custom_input)).set_text(cx, &custom_text);

--- a/src/settings/bot_settings.rs
+++ b/src/settings/bot_settings.rs
@@ -559,7 +559,7 @@ impl BotSettings {
         self.last_synced_bot_settings = bot_settings.clone();
         self.view
             .check_box(cx, ids!(app_service_switch))
-            .set_active(cx, bot_settings.enabled);
+            .set_active(cx, bot_settings.enabled, Animate::No);
         self.view
             .text_input(cx, ids!(botfather_user_id_input))
             .set_text(cx, bot_settings.botfather_user_id.trim());

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -968,7 +968,7 @@ impl SettingsScreen {
         self.preferences_use_proxy_enabled = enabled;
         self.view
             .check_box(cx, ids!(preferences_proxy_use_toggle))
-            .set_active(cx, enabled);
+            .set_active(cx, enabled, Animate::No);
         self.view
             .view(cx, ids!(preferences_proxy_fields_section))
             .set_visible(cx, enabled);

--- a/src/settings/translation_settings.rs
+++ b/src/settings/translation_settings.rs
@@ -394,7 +394,7 @@ impl TranslationSettings {
             .set_visible(cx, config.enabled);
 
         self.view.check_box(cx, ids!(translation_switch))
-            .set_active(cx, config.enabled);
+            .set_active(cx, config.enabled, Animate::No);
         self.set_switch_state_label(cx, config.enabled);
     }
 

--- a/src/shared/file_upload_modal.rs
+++ b/src/shared/file_upload_modal.rs
@@ -131,6 +131,7 @@ script_mod! {
 
             file_size_label := Label {
                 width: Fill,
+                margin: Inset{ left: 4.5}
                 draw_text +: {
                     text_style: REGULAR_TEXT { font_size: 10 },
                     color: (SMALL_STATE_TEXT_COLOR)

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -3915,6 +3915,45 @@ async fn matrix_worker_task(
                     let content_type: mime::Mime = file_data.mime_type.parse()
                         .unwrap_or_else(|_| "application/octet-stream".parse().unwrap());
 
+                    let max_upload_size = match get_client() {
+                        Some(client) => match client.load_or_fetch_max_upload_size().await {
+                            Ok(max_upload_size) => Some(max_upload_size),
+                            Err(e) => {
+                                warning!("Could not fetch homeserver max upload size for {timeline_kind}: {e:?}; continuing without local size-limit check.");
+                                None
+                            }
+                        },
+                        None => {
+                            warning!("Could not fetch homeserver max upload size for {timeline_kind}: client unavailable; continuing without local size-limit check.");
+                            None
+                        }
+                    };
+                    if let Some(max_upload_size) = max_upload_size {
+                        let exceeds_max_upload_size = matrix_sdk::ruma::UInt::try_from(file_data.size)
+                            .map(|upload_size| upload_size > max_upload_size)
+                            .unwrap_or(true);
+                        if exceeds_max_upload_size {
+                            let max_size: u64 = max_upload_size.into();
+                            let error = format!(
+                                "file size ({}) exceeds homeserver limit ({}).",
+                                crate::utils::format_file_size(file_data.size),
+                                crate::utils::format_file_size(max_size),
+                            );
+                            let _ = sender.send(TimelineUpdate::FileUploadError {
+                                error: error.clone(),
+                                file_data: file_data.clone(),
+                                retryable: false,
+                            });
+                            enqueue_popup_notification(
+                                format!("Failed to upload file: {error}"),
+                                PopupKind::Error,
+                                None,
+                            );
+                            SignalToUI::set_ui_signal();
+                            return;
+                        }
+                    }
+
                     // Create a progress observable to track upload progress
                     let send_progress: SharedObservable<matrix_sdk::TransmissionProgress> = Default::default();
                     let progress_subscriber = send_progress.subscribe();
@@ -3962,6 +4001,7 @@ async fn matrix_worker_task(
                             let _ = sender.send(TimelineUpdate::FileUploadError {
                                 error: format!("{e}"),
                                 file_data: file_data.clone(),
+                                retryable: true,
                             });
                             enqueue_popup_notification(
                                 format!("Failed to upload file: {e}"),


### PR DESCRIPTION
## Summary
This batch continues incremental upstream alignment while preserving existing `robrix2` customizations.

### 1) Mobile Stack Navigation polish
- Backported dynamic mobile stack-navigation follow-up adjustments on top of existing `robrix2` behavior.
- Added safe-area and header/body spacing refinements for mobile stack views.
- Added script-reapply handling in `SpacesBarWrapper` to avoid hidden-state flicker after reapply.
- Kept current `robrix2` page structure and settings integration intact.

### 2) Upload guardrails and UX improvements
- Added homeserver max-upload-size precheck before sending attachment.
- If file exceeds server limit, upload is rejected locally with a clear error and no send attempt.
- Introduced retryability semantics for upload errors:
  - non-retryable for deterministic errors (e.g. server size limit exceeded)
  - retryable for transient send failures
- Updated upload progress UI behavior:
  - hide `Retry` for non-retryable errors
  - improved long-text wrapping/readability in status and filename labels
- File picker path updated to async flow in `RoomInputBar` to avoid blocking UI thread during selection.

## Files
- `src/home/home_screen.rs`
- `src/home/invite_screen.rs`
- `src/home/room_screen.rs`
- `src/home/space_lobby.rs`
- `src/home/upload_progress.rs`
- `src/room/room_input_bar.rs`
- `src/shared/file_upload_modal.rs`
- `src/sliding_sync.rs`

## Validation
- `cargo build` passed locally after migration changes.

## Notes
- This PR is intentionally scoped as one incremental migration batch for easier regression testing and rollback if needed.
