### PR TITLE
sync: backport upstream room/media/upload stability fixes (batch 1-3)

### DIFF
--- a/src/home/room_image_viewer.rs
+++ b/src/home/room_image_viewer.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
     ruma::events::room::{message::MessageType, MediaSource},
 };
 
-use crate::{media_cache::{MediaCache, MediaCacheEntry}, shared::image_viewer::{ImageViewerAction, ImageViewerError, LoadState}};
+use crate::{media_cache::{MediaCache, MediaCacheEntry, media_source_mxc}, shared::image_viewer::{ImageViewerAction, ImageViewerError, LoadState}};
 
 /// Populates the image viewer modal with the given media content.
 ///
@@ -18,11 +18,8 @@ pub fn populate_matrix_image_modal(
     media_source: MediaSource,
     media_cache: &mut MediaCache,
 ) {
-    let MediaSource::Plain(mxc_uri) = media_source else {
-        return;
-    };
     // Try to get media from cache or trigger fetch
-    let media_entry = media_cache.try_get_media_or_fetch(&mxc_uri, MediaFormat::File);
+    let media_entry = media_cache.try_get_media_or_fetch(&media_source, MediaFormat::File);
 
     // Handle the different media states
     match media_entry {
@@ -39,7 +36,7 @@ pub fn populate_matrix_image_modal(
             };
             cx.action(ImageViewerAction::Show(LoadState::Error(error)));
             // Remove failed media entry from cache for MediaFormat::File so as to start all over again from loading Thumbnail.
-            media_cache.remove_cache_entry(&mxc_uri, Some(MediaFormat::File));
+            media_cache.remove_cache_entry(media_source_mxc(&media_source), Some(MediaFormat::File));
         }
         _ => {}
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -16,7 +16,7 @@ use matrix_sdk::{
                     AudioMessageEventContent, EmoteMessageEventContent, FileMessageEventContent, FormattedBody, ImageMessageEventContent, KeyVerificationRequestEventContent, LocationMessageEventContent, MessageFormat, MessageType, NoticeMessageEventContent, RoomMessageEventContent, TextMessageEventContent, VideoMessageEventContent
                 }
             },
-            sticker::{StickerEventContent, StickerMediaSource},
+            sticker::StickerEventContent,
         }, matrix_uri::MatrixId, uint
     }
 };
@@ -27,7 +27,7 @@ use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, e
 
 use matrix_sdk_ui::sync_service::State;
 use crate::{
-    app::{AppState, AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{bot_binding_modal::BotBindingModalAction, create_bot_modal::{CreateBotModalAction, CreateBotModalWidgetExt}, delete_bot_modal::{DeleteBotModalAction, DeleteBotModalWidgetExt}, edited_indicator::EditedIndicatorWidgetRefExt, encryption_notice::{EncryptionNoticeWidgetRefExt, first_other_member_display_name}, invite_modal::InviteModalAction, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{get_image_name_and_filesize, populate_matrix_image_modal}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, i18n::{AppLanguage, tr_fmt, tr_key}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    app::{AppState, AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{bot_binding_modal::BotBindingModalAction, create_bot_modal::{CreateBotModalAction, CreateBotModalWidgetExt}, delete_bot_modal::{DeleteBotModalAction, DeleteBotModalWidgetExt}, edited_indicator::EditedIndicatorWidgetRefExt, encryption_notice::{EncryptionNoticeWidgetRefExt, first_other_member_display_name}, invite_modal::InviteModalAction, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{get_image_name_and_filesize, populate_matrix_image_modal}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, i18n::{AppLanguage, tr_fmt, tr_key}, media_cache::{MediaCache, MediaCacheEntry, media_source_mxc}, profile::{
         user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
@@ -6989,9 +6989,9 @@ impl RoomScreen {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
                         .set_upload_abort_handle(handle);
                 }
-                TimelineUpdate::FileUploadError { error, file_data } => {
+                TimelineUpdate::FileUploadError { error, file_data, retryable } => {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
-                        .show_upload_error(cx, &error, file_data);
+                        .show_upload_error(cx, &error, file_data, retryable);
                 }
                 TimelineUpdate::FileUploadComplete => {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
@@ -8672,6 +8672,7 @@ pub enum TimelineUpdate {
     FileUploadError {
         error: String,
         file_data: crate::shared::file_upload_modal::FileData,
+        retryable: bool,
     },
     /// File upload completed successfully.
     FileUploadComplete,
@@ -9745,23 +9746,19 @@ fn populate_message_view(
             if existed && item_drawn_status.content_drawn {
                 (item, true)
             } else {
-                if let StickerMediaSource::Plain(owned_mxc_url) = source {
-                    let image_info = info;
-                    let text_or_image_ref = item.text_or_image(cx, ids!(content.message));
-                    let is_image_fully_drawn = populate_image_message_content(
-                        cx,
-                        &text_or_image_ref,
-                        app_language,
-                        Some(Box::new(image_info.clone())),
-                        MediaSource::Plain(owned_mxc_url.clone()),
-                        body,
-                        media_cache,
-                    );
-                    new_drawn_status.content_drawn = is_image_fully_drawn;
-                    (item, false)
-                } else {
-                    (item, true)
-                }
+                let image_info = info;
+                let text_or_image_ref = item.text_or_image(cx, ids!(content.message));
+                let is_image_fully_drawn = populate_image_message_content(
+                    cx,
+                    &text_or_image_ref,
+                    app_language,
+                    Some(Box::new(image_info.clone())),
+                    source.clone().into(),
+                    body,
+                    media_cache,
+                );
+                new_drawn_status.content_drawn = is_image_fully_drawn;
+                (item, false)
             }
         } 
         // Handle messages that have been redacted (deleted).
@@ -10329,12 +10326,10 @@ fn populate_image_message_content(
 
     let mut fully_drawn = false;
 
-    // A closure that fetches and shows the image from the given `mxc_uri`,
-    // marking it as fully drawn if the image was available.
-    let mut fetch_and_show_image_uri = |cx: &mut Cx, mxc_uri: OwnedMxcUri, image_info: Box<ImageInfo>| {
-        match media_cache.try_get_media_or_fetch(&mxc_uri, MEDIA_THUMBNAIL_FORMAT.into()) {
+    let mut fetch_and_show_media_source = |cx: &mut Cx, media_source: MediaSource, image_info: Box<ImageInfo>| {
+        match media_cache.try_get_media_or_fetch(&media_source, MEDIA_THUMBNAIL_FORMAT.into()) {
             (MediaCacheEntry::Loaded(data), _media_format) => {
-                let show_image_result = text_or_image_ref.show_image(cx, Some(MediaSource::Plain(mxc_uri)),|cx, img| {
+                let show_image_result = text_or_image_ref.show_image(cx, Some(media_source), |cx, img| {
                     utils::load_png_or_jpg(&img, cx, &data)
                         .map(|()| img.size_in_pixels(cx).unwrap_or_default())
                 });
@@ -10350,7 +10345,7 @@ fn populate_image_message_content(
             (MediaCacheEntry::Requested, _media_format) => {
                 // If the image is being fetched, we try to show its blurhash.
                 if let (Some(ref blurhash), Some(width), Some(height)) = (image_info.blurhash.clone(), image_info.width, image_info.height) {
-                    let show_image_result = text_or_image_ref.show_image(cx, Some(MediaSource::Plain(mxc_uri)), |cx, img| {
+                    let show_image_result = text_or_image_ref.show_image(cx, Some(media_source), |cx, img| {
                         let (Ok(width), Ok(height)) = (width.try_into(), height.try_into()) else {
                             return Err(image_cache::ImageError::EmptyData)
                         };
@@ -10383,7 +10378,7 @@ fn populate_image_message_content(
                             Err(e) => {
                                 error!("Failed to decode blurhash {e:?}");
                                 Err(image_cache::ImageError::EmptyData)
-                            }   
+                            }
                         }
                     });
                     if let Err(e) = show_image_result {
@@ -10400,25 +10395,10 @@ fn populate_image_message_content(
                     return;
                 }
                 text_or_image_ref
-                    .show_text(cx, tr_fmt(app_language, "room_screen.image.failed_to_fetch", &[("body", body), ("mxc_uri", &format!("{mxc_uri:?}"))]));
+                    .show_text(cx, tr_fmt(app_language, "room_screen.image.failed_to_fetch", &[("body", body), ("mxc_uri", &format!("{:?}", media_source_mxc(&media_source)))]));
                 // For now, we consider this as being "complete". In the future, we could support
                 // retrying to fetch thumbnail of the image on a user click/tap.
                 fully_drawn = true;
-            }
-        }
-    };
-
-    let mut fetch_and_show_media_source = |cx: &mut Cx, media_source: MediaSource, image_info: Box<ImageInfo>| {
-        match media_source {
-            MediaSource::Encrypted(encrypted) => {
-                // We consider this as "fully drawn" since we don't yet support encryption.
-                text_or_image_ref.show_text(
-                    cx,
-                    tr_fmt(app_language, "room_screen.image.encrypted_todo", &[("body", body), ("url", &format!("{:?}", encrypted.url))])
-                );
-            },
-            MediaSource::Plain(mxc_uri) => {
-                fetch_and_show_image_uri(cx, mxc_uri, image_info)
             }
         }
     };

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -24,7 +24,7 @@ use ruma::events::tag::TagName;
 use tokio::sync::mpsc::UnboundedSender;
 use matrix_sdk::{RoomState, ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch, OwnedRoomAliasId, OwnedRoomId, OwnedUserId}};
 use crate::{
-    app::{AppState, SelectedRoom},
+    app::{AppState, AppStateAction, SelectedRoom},
     home::{
         ContextMenuOpenGesture,
         add_room::CreateRoomAction,
@@ -660,6 +660,12 @@ impl RoomsList {
         }
 
         self.update_displayed_rooms(cx, false);
+    }
+
+    fn set_current_active_room(&mut self, cx: &mut Cx, selected_room: Option<SelectedRoom>) {
+        if self.current_active_room == selected_room { return; }
+        self.current_active_room = selected_room;
+        self.redraw(cx);
     }
 
     /// Handle all pending updates to the list of all rooms.
@@ -1426,12 +1432,11 @@ impl Widget for RoomsList {
                     continue;
                 }
 
-                self.current_active_room = Some(new_selected_room.clone());
+                self.set_current_active_room(cx, Some(new_selected_room.clone()));
                 cx.widget_action(
                     self.widget_uid(), 
                     RoomsListAction::Selected(new_selected_room),
                 );
-                self.redraw(cx);
             }
             // Handle a room being right-clicked or long-pressed by opening the room context menu.
             else if let RoomsListEntryAction::SecondaryClicked(room_id, pos, opening_gesture) = action.as_widget_action().cast() {
@@ -1461,12 +1466,11 @@ impl Widget for RoomsList {
                 if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_space) {
                     continue;
                 }
-                self.current_active_room = Some(new_selected_space.clone());
+                self.set_current_active_room(cx, Some(new_selected_space.clone()));
                 cx.widget_action(
                     self.widget_uid(), 
                     RoomsListAction::Selected(new_selected_space),
                 );
-                self.redraw(cx);
             }
             // Handle a collapsible header being clicked.
             else if let CollapsibleHeaderAction::Toggled { category } = action.as_widget_action().cast() {
@@ -1491,6 +1495,17 @@ impl Widget for RoomsList {
         // Second, handle any other actions that came from other widgets/components.
         if let Event::Actions(actions) = event {
             for action in actions {
+                if let Some(AppStateAction::RoomFocused(selected_room)) = action.downcast_ref() {
+                    self.set_current_active_room(cx, Some(selected_room.clone()));
+                    continue;
+                }
+
+                if let Some(AppStateAction::FocusNone) = action.downcast_ref() {
+                    self.set_current_active_room(cx, None);
+                    continue;
+                }
+
+                // Clear widget state upon logout.
                 if let Some(LogoutAction::ClearAppState { .. }) = action.downcast_ref() {
                     while PENDING_ROOM_UPDATES.pop().is_some() {}
                     self.invited_rooms.borrow_mut().clear();

--- a/src/home/upload_progress.rs
+++ b/src/home/upload_progress.rs
@@ -105,6 +105,7 @@ pub enum UploadViewState {
     Error {
         message: String,
         file_data: FileData,
+        retryable: bool,
     },
 }
 
@@ -148,7 +149,10 @@ impl Widget for UploadProgressView {
 
             // Handle retry button
             if self.button(cx, ids!(retry_button)).clicked(actions) {
-                if let UploadViewState::Error { file_data, .. } = &self.state {
+                if let UploadViewState::Error { file_data, retryable, .. } = &self.state {
+                    if !retryable {
+                        return;
+                    }
                     let file_data = file_data.clone();
                     cx.widget_action(self.widget_uid(), UploadProgressViewAction::Retry(file_data));
                     self.hide(cx);
@@ -220,16 +224,17 @@ impl UploadProgressView {
     }
 
     /// Shows an error state with the given message.
-    pub fn show_error(&mut self, cx: &mut Cx, error: &str, file_data: FileData) {
+    pub fn show_error(&mut self, cx: &mut Cx, error: &str, file_data: FileData, retryable: bool) {
         self.state = UploadViewState::Error {
             message: error.to_string(),
             file_data,
+            retryable,
         };
 
         // Update UI for error state
         self.label(cx, ids!(status_label))
             .set_text(cx, &format!("Error: {}", error));
-        self.button(cx, ids!(retry_button)).set_enabled(cx, true);
+        self.button(cx, ids!(retry_button)).set_enabled(cx, retryable);
         self.button(cx, ids!(cancel_button)).set_enabled(cx, true);
 
         // Set progress bar to error color - no longer apply color change via script_apply_eval
@@ -269,9 +274,9 @@ impl UploadProgressViewRef {
     }
 
     /// Shows an error state with the given message.
-    pub fn show_error(&self, cx: &mut Cx, error: &str, file_data: FileData) {
+    pub fn show_error(&self, cx: &mut Cx, error: &str, file_data: FileData, retryable: bool) {
         if let Some(mut inner) = self.borrow_mut() {
-            inner.show_error(cx, error, file_data);
+            inner.show_error(cx, error, file_data, retryable);
         }
     }
 }

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -1,8 +1,16 @@
-use std::{ops::{Deref, DerefMut}, sync::{Arc, Mutex}, time::SystemTime};
+use std::{ops::{Deref, DerefMut}, sync::{Arc, Mutex}};
 use hashbrown::{hash_map::RawEntryMut, HashMap};
-use makepad_widgets::{error, log, SignalToUI};
+use makepad_widgets::{error, SignalToUI};
 use matrix_sdk::{media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings}, reqwest::StatusCode, ruma::{events::room::MediaSource, OwnedMxcUri}, Error, HttpError};
 use crate::{home::room_screen::TimelineUpdate, sliding_sync::{self, MatrixRequest}};
+
+/// Returns the underlying `mxc://` URI for a Matrix media source.
+pub fn media_source_mxc(source: &MediaSource) -> &OwnedMxcUri {
+    match source {
+        MediaSource::Plain(mxc_uri) => mxc_uri,
+        MediaSource::Encrypted(file) => &file.url,
+    }
+}
 
 /// The value type in the media cache, one per Matrix URI.
 #[derive(Debug, Clone)]
@@ -79,9 +87,10 @@ impl MediaCache {
     /// Returns a tuple of the media cache entry and the media format of that cached entry.
     pub fn try_get_media_or_fetch(
         &mut self,
-        mxc_uri: &OwnedMxcUri,
+        source: &MediaSource,
         requested_format: MediaFormat,
     ) -> (MediaCacheEntry, MediaFormat) {
+        let mxc_uri = media_source_mxc(source);
         let mut post_request_retval = (MediaCacheEntry::Requested, requested_format.clone());
         let entry_ref_to_fetch: MediaCacheEntryRef;
 
@@ -156,7 +165,7 @@ impl MediaCache {
 
         sliding_sync::submit_async_request(MatrixRequest::FetchMedia {
             media_request: MediaRequestParameters {
-                source: MediaSource::Plain(mxc_uri.clone()),
+                source: source.clone(),
                 format: requested_format,
             },
             on_fetched: insert_into_cache,
@@ -273,23 +282,6 @@ fn insert_into_cache<D: Into<Arc<[u8]>>>(
     let new_value = match data {
         Ok(data) => {
             let data = data.into();
-
-            // debugging: dump out the media image to disk
-            if false {
-                if let MediaSource::Plain(mxc_uri) = &request.source {
-                    log!("Fetched media for {mxc_uri}");
-                    let mut path = crate::temp_storage::get_temp_dir_path().clone();
-                    let filename = format!("{}_{}_{}",
-                        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis(),
-                        mxc_uri.server_name().unwrap(), mxc_uri.media_id().unwrap(),
-                    );
-                    path.push(filename);
-                    path.set_extension("png");
-                    log!("Writing user media image to disk: {:?}", path);
-                    std::fs::write(path, &data)
-                        .expect("Failed to write user media image to disk");
-                }
-            }
             MediaCacheEntry::Loaded(data)
         }
         Err(e) => error_to_media_cache_entry(e, &request)

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -2290,11 +2290,11 @@ impl RoomInputBarRef {
     }
 
     /// Shows an upload error with retry option.
-    pub fn show_upload_error(&self, cx: &mut Cx, error: &str, file_data: FileData) {
+    pub fn show_upload_error(&self, cx: &mut Cx, error: &str, file_data: FileData, retryable: bool) {
         let Some(inner) = self.borrow() else { return };
         inner.child_by_path(ids!(upload_progress_view))
             .as_upload_progress_view()
-            .show_error(cx, error, file_data);
+            .show_error(cx, error, file_data, retryable);
     }
 
     /// Handles a confirmed file upload from the file upload modal.

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4001,6 +4001,39 @@ async fn matrix_worker_task(
                     continue;
                 };
 
+                let max_upload_size = match get_client() {
+                    Some(client) => match client.load_or_fetch_max_upload_size().await {
+                        Ok(max_upload_size) => Some(max_upload_size),
+                        Err(e) => {
+                            warning!("Could not fetch homeserver max upload size for {timeline_kind}: {e:?}; continuing without local size check.");
+                            None
+                        }
+                    },
+                    None => {
+                        warning!("Could not fetch homeserver max upload size for {timeline_kind}: client unavailable; continuing without local size check.");
+                        None
+                    }
+                };
+                if let Some(max_upload_size) = max_upload_size {
+                    let exceeds_max_upload_size = matrix_sdk::ruma::UInt::try_from(file_data.size)
+                        .map(|upload_size| upload_size > max_upload_size)
+                        .unwrap_or(true);
+                    if exceeds_max_upload_size {
+                        let max_size: u64 = max_upload_size.into();
+                        let _ = sender.send(TimelineUpdate::FileUploadError {
+                            error: format!(
+                                "File size ({}) exceeds homeserver upload limit ({}).",
+                                utils::format_file_size(file_data.size),
+                                utils::format_file_size(max_size),
+                            ),
+                            file_data,
+                            retryable: false,
+                        });
+                        SignalToUI::set_ui_signal();
+                        continue;
+                    }
+                }
+
                 // Spawn a new async task to send the attachment.
                 let _send_attachment_task = Handle::current().spawn(async move {
                     use matrix_sdk::attachment::AttachmentConfig;
@@ -4064,6 +4097,7 @@ async fn matrix_worker_task(
                             let _ = sender.send(TimelineUpdate::FileUploadError {
                                 error: format!("{e}"),
                                 file_data: file_data.clone(),
+                                retryable: true,
                             });
                             enqueue_popup_notification(
                                 format!("Failed to upload file: {e}"),
@@ -5134,14 +5168,6 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                                 log!("matrix worker task ended with error due to account switch: {e:?}");
                             } else {
                                 error!("Error: matrix worker task ended:\n\t{e:?}");
-                                rooms_list::enqueue_rooms_list_update(RoomsListUpdate::Status {
-                                    status: e.to_string(),
-                                });
-                                enqueue_popup_notification(
-                                    format!("Matrix worker error: {e}"),
-                                    PopupKind::Error,
-                                    None,
-                                );
                             }
                         },
                         Err(e) => {


### PR DESCRIPTION
## Summary
This PR backports a focused set of upstream fixes into `robrix2` while keeping `robrix2` as the primary codebase.

### 1) Rooms list selection sync and redraw robustness
- Backported the room selection synchronization flow so the rooms list active state is updated consistently from app focus actions.
- Consolidated active-room updates through a single helper to avoid stale UI state.

### 2) Reduce noisy user-facing upload/runtime errors
- Removed user-facing popup/status surfacing for internal matrix worker termination paths that are not actionable for end users.

### 3) Encrypted media handling support path
- Unified media cache key extraction from `MediaSource` (`Plain` and `Encrypted`) using a shared resolver helper.
- Updated image/modal and room image rendering path to fetch by `MediaSource`, enabling encrypted-media sources to follow the same loading pipeline.

### 4) Attachment upload safety: homeserver max-size precheck
- Added a pre-upload max file size check via `load_or_fetch_max_upload_size()`.
- If file exceeds homeserver limit, fail early without starting upload and return a clear size-limit error.

### 5) Upload error retryability semantics
- Added `retryable` to upload error propagation so non-retryable failures (e.g. size-limit) do not offer retry in UI.
- Threaded this flag through `TimelineUpdate -> RoomScreen -> RoomInputBar -> UploadProgressView`.

## Files changed
- `src/home/rooms_list.rs`
- `src/sliding_sync.rs`
- `src/media_cache.rs`
- `src/home/room_image_viewer.rs`
- `src/home/room_screen.rs`
- `src/room/room_input_bar.rs`
- `src/home/upload_progress.rs`

## Validation
- `cargo build` passed locally.

## Notes
- This PR intentionally avoids formatter-driven refactors and only migrates required logic paths.
- UI style/layout churn from upstream was intentionally excluded; only behavior-critical logic was backported.
