### PR TITLE
fix(dsl): resolve two script_mod runtime errors

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2018,7 +2018,7 @@ script_mod! {
                 }
 
                 message := HtmlOrPlaintext { }
-                splash_card := Splash { visible: false }
+                splash_card := Splash { }
                 action_buttons := View {
                     visible: false
                     width: Fill

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -269,6 +269,14 @@ script_mod! {
     mod.widgets.SETTINGS_CONTENT_PADDING = 16
     mod.widgets.SETTINGS_BUTTON_HEIGHT = 36
 
+    // The font size used for regular (non-title, non-subsection) text
+    // within any settings screen (e.g., dropdown labels, radio/toggle
+    // labels, inline helper text inside a control).
+    mod.widgets.SETTINGS_REGULAR_FONT_SIZE = 11
+    mod.widgets.SETTINGS_REGULAR_TEXT_STYLE = theme.font_regular {
+        font_size: (mod.widgets.SETTINGS_REGULAR_FONT_SIZE),
+    }
+
     // Text alignment compensation for non-Label widgets (LinkLabel, IconButton)
     // whose internal rendering origin differs from plain Label.
     mod.widgets.LINK_LABEL_LEFT_PAD = 6


### PR DESCRIPTION
Fixes two Makepad `script_mod!` runtime errors that spammed the log on every startup.

## Changes
- **`room_screen.rs`**: removed the invalid `visible: false` property on the `Splash` widget. `Splash` is a custom widget (not a `View`) and has no `visible` field, so the property was rejected at load. Its visibility is already driven by its `body` content (empty body renders nothing), so behavior is unchanged.
- **`styles.rs`**: added the missing `SETTINGS_REGULAR_TEXT_STYLE` token (and its `SETTINGS_REGULAR_FONT_SIZE`). It was referenced 4× in `app_settings.rs` (introduced by the upstream sync in #148) but its definition was never ported. Copied verbatim from upstream robrix.

## Verification
- `cargo build` passes.
- Confirmed at runtime: `room_screen.rs:2021` and `app_settings.rs:51/95/170/291` errors no longer appear.