### PR TITLE
Fix settings language selector initialization

### DIFF
--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -1165,6 +1165,8 @@ impl SettingsScreen {
             self.load_saved_proxy_to_preferences_form(cx);
         }
 
+        self.sync_app_language(cx);
+
         let mut category_account_button = self.view.button(cx, ids!(category_account_button));
         let mut category_preferences_button = self.view.button(cx, ids!(category_preferences_button));
         let mut category_devices_button = self.view.button(cx, ids!(category_devices_button));


### PR DESCRIPTION
## Summary

- fix the Settings language selector so it reflects the persisted app language after restart
- resync localized settings UI after the lazy-initialized Preferences page becomes live

## Root cause

The Preferences section is lazy-initialized and is not created when Settings first opens on the Account page. When the user later switches to Preferences, the language selector label could remain on its DSL default text (`English`) because the app language had not changed, so the normal sync path did not rerun for the newly-created widgets.

## Validation

- cargo build
