### PR TITLE
docs: require i18n review for new features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ This project does not use automatic Rust formatting. Do not run `cargo fmt`, `ru
 
 Present changes for testing first. Wait for user confirmation before committing or opening a PR.
 
+### Check i18n for new features
+
+When designing or implementing new features, always check whether i18n translation keys and UI text alignment need updates so translated content is not missing or visually inconsistent.
+
 ### Makepad 2.0 only
 
 - Use `script_mod!`, not `live_design!`


### PR DESCRIPTION
## What changed
- added a new AGENTS.md rule requiring i18n checks during new feature design and implementation
- explicitly calls out translation key coverage and UI text alignment review

## Why
New features can ship with missing translations or inconsistent layout across languages if i18n review is skipped. This documents the expectation earlier in the workflow so it is checked before code lands.

## Impact
- improves consistency for future feature work
- reduces the chance of untranslated or misaligned UI text reaching users

## Validation
- reviewed the AGENTS.md diff to confirm the PR only adds the new project rule