### PR TITLE
fix(mobile): Android input bar — layout, focus jump, keyboard overlap, bot-room reopen

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2464,12 +2464,13 @@ impl App {
     /// screen configuration are effectively no-ops — MainDesktopUI handles
     /// room display via dock tabs instead.
     fn push_selected_room_view(&mut self, cx: &mut Cx, selected_room: SelectedRoom) {
-        if self.app_state.selected_room.as_ref().is_some_and(|current| current == &selected_room) {
-            return;
-        }
-
         // Use the actual StackNavigation depth to pick the next room view slot.
         let new_depth = self.ui.stack_navigation(cx, ids!(view_stack)).depth();
+        let same_selected_room = self.app_state.selected_room.as_ref()
+            .is_some_and(|current| current == &selected_room);
+        if same_selected_room && new_depth > 0 {
+            return;
+        }
 
         // Determine which view to push and configure its content.
         // The `set_displayed_room` / `set_displayed_invite` / `set_displayed_space` calls
@@ -2524,7 +2525,7 @@ impl App {
         }
 
         // Save the current selected_room onto the navigation stack before replacing it.
-        if let Some(prev) = self.app_state.selected_room.take() {
+        if !same_selected_room && let Some(prev) = self.app_state.selected_room.take() {
             self.mobile_room_nav_stack.push(prev);
         }
         // Update app state (used by both Desktop and Mobile paths).

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3804,8 +3804,12 @@ script_mod! {
 
             restore_status_view := RestoreStatusView {}
 
-            // Widgets within this view will get shifted upwards when the on-screen keyboard is shown.
-            keyboard_view := KeyboardView {
+            // Keyboard avoidance is already provided by the Window's built-in
+            // KeyboardView (makepad `window.rs`: `body := KeyboardView`). Using a
+            // second KeyboardView here nested inside it double-applies the
+            // keyboard shift (content jumps / a big blank gap on Android), so
+            // this is a plain View.
+            keyboard_view := View {
                 width: Fill, height: Fill,
                 flow: Down,
 

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1428,11 +1428,10 @@ impl Widget for RoomsList {
                     continue;
                 };
 
-                if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_room) {
-                    continue;
+                if !self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_room) {
+                    self.set_current_active_room(cx, Some(new_selected_room.clone()));
                 }
 
-                self.set_current_active_room(cx, Some(new_selected_room.clone()));
                 cx.widget_action(
                     self.widget_uid(), 
                     RoomsListAction::Selected(new_selected_room),
@@ -1463,10 +1462,9 @@ impl Widget for RoomsList {
             else if let Some(SpaceLobbyAction::SpaceLobbyEntryClicked) = action.downcast_ref() {
                 let Some(space_name_id) = self.selected_space.clone() else { continue };
                 let new_selected_space = SelectedRoom::Space { space_name_id };
-                if self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_space) {
-                    continue;
+                if !self.current_active_room.as_ref().is_some_and(|current| current == &new_selected_space) {
+                    self.set_current_active_room(cx, Some(new_selected_space.clone()));
                 }
-                self.set_current_active_room(cx, Some(new_selected_space.clone()));
                 cx.widget_action(
                     self.widget_uid(), 
                     RoomsListAction::Selected(new_selected_space),

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -635,6 +635,178 @@ script_mod! {
     }
 
 
+    // The message text input field. Keep this as a single live widget instance
+    // in RoomInputBar; duplicating it across AdaptiveView variants changes the
+    // focused IME area when the keyboard appears and causes mobile jump loops.
+    let MessageInputField = MentionableTextInput {
+        width: Fill,
+        height: Fit
+        margin: Inset {
+            top: 3, // add some space between the top border of the text input and the top border of this row
+            bottom: 3,
+            left: 3, right: 3 // to give a bit of breathing room between the text input and the buttons on the sides
+        },
+
+        persistent +: {
+            center +: {
+                text_input := RobrixTextInput {
+                    // 10 lines of MESSAGE_TEXT_STYLE (11 * 1.3) plus vertical padding.
+                    // Above this height the multiline TextInput keeps the composer
+                    // stable and scrolls its own content.
+                    height: Fit{max: FitBound.Abs(170.0)}
+                    empty_text: "Write a message (in Markdown) ..."
+                    is_multiline: true,
+                }
+            }
+        }
+    }
+
+    // The action buttons shown to the LEFT of the input on desktop. On mobile
+    // they form the left side of the toolbar row below the input.
+    let LeftActionButtons = View {
+        width: Fit, height: Fit
+        flow: Right
+        align: Align{y: 1.0}
+
+        // A checkbox that enables TSP signing for the outgoing message.
+        // If TSP is not enabled, this will be an empty invisible view.
+        tsp_sign_checkbox := TspSignAnycastCheckbox {
+            margin: Inset{bottom: 9, left: 6, right: 0}
+        }
+
+        // Opens the sticker drawer above the input bar.
+        sticker_drawer_toggle_button := RobrixIconButton {
+            margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
+            spacing: 0,
+            draw_icon +: {
+                svg: (mod.widgets.ICO_MORE_VERT)
+                color: (COLOR_ACTIVE_PRIMARY_DARKER)
+            },
+            draw_bg +: {
+                color: (COLOR_BG_PREVIEW)
+                color_hover: #E0E8F0
+                color_down: #D0D8E8
+            }
+            icon_walk: Walk{width: 19, height: 19}
+            text: "",
+        }
+
+        // Attachment button for uploading files/images
+        send_attachment_button := RobrixIconButton {
+            margin: Inset{left: 3, right: 1, top: 4, bottom: 4}
+            spacing: 0,
+            draw_icon +: {
+                svg: (ICON_ADD_ATTACHMENT)
+                color: (COLOR_ACTIVE_PRIMARY_DARKER)
+            },
+            draw_bg +: {
+                color: (COLOR_BG_PREVIEW)
+                color_hover: #E0E8F0
+                color_down: #D0D8E8
+            }
+            icon_walk: Walk{width: 21, height: 21}
+            text: "",
+        }
+
+        // Opens the modal showing only the user's added stickers.
+        my_stickers_button := RobrixIconButton {
+            margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
+            spacing: 0,
+            draw_icon +: {
+                svg: (ICON_SQUARES)
+                color: (COLOR_ACTIVE_PRIMARY_DARKER)
+            },
+            draw_bg +: {
+                color: (COLOR_BG_PREVIEW)
+                color_hover: #E0E8F0
+                color_down: #D0D8E8
+            }
+            icon_walk: Walk{width: 18, height: 18}
+            text: "",
+        }
+
+        emoji_picker_button := RobrixIconButton {
+            margin: Inset{left: 3, right: 1, top: 4, bottom: 4}
+            spacing: 0,
+            draw_icon +: {
+                svg: (ICON_ADD_REACTION)
+                color: (COLOR_ACTIVE_PRIMARY_DARKER)
+            },
+            draw_bg +: {
+                color: (COLOR_BG_PREVIEW)
+                color_hover: #E0E8F0
+                color_down: #D0D8E8
+            }
+            icon_walk: Walk{width: 19, height: 19}
+            text: "",
+        }
+
+        translate_button := RobrixIconButton {
+            margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
+            spacing: 0,
+            draw_icon +: {
+                svg: (mod.widgets.ICO_TRANSLATE)
+                color: (COLOR_ACTIVE_PRIMARY_DARKER)
+            },
+            draw_bg +: {
+                color: (COLOR_BG_PREVIEW)
+                color_hover: #xE0E8F0
+                color_down: #xD0D8E8
+            }
+            icon_walk: Walk{width: 19, height: 19}
+            text: "",
+        }
+
+        bot_menu_button := RobrixIconButton {
+            visible: false,
+            margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
+            spacing: 0,
+            draw_icon +: {
+                svg: (ICON_LINK)
+                color: (COLOR_ACTIVE_PRIMARY_DARKER)
+            },
+            draw_bg +: {
+                color: (COLOR_BG_PREVIEW)
+                color_hover: #xE0E8F0
+                color_down: #xD0D8E8
+            }
+            icon_walk: Walk{width: 18, height: 18}
+            text: "",
+        }
+    }
+
+    // The send + more-actions buttons shown to the RIGHT of the input on
+    // desktop. On mobile they form the right side of the toolbar row.
+    let RightActionButtons = View {
+        width: Fit, height: Fit
+        flow: Right
+        align: Align{y: 1.0}
+
+        send_message_button := RobrixPositiveIconButton {
+            visible: false,
+            // Disabled by default; enabled when text is inputted
+            enabled: false,
+            spacing: 0,
+            text: "",
+            margin: 4
+            draw_icon +: { svg: (ICON_SEND) }
+            icon_walk: Walk{width: 21, height: 21},
+        }
+
+        more_actions_button := RobrixIconButton {
+            spacing: 0,
+            text: "",
+            margin: 4
+            draw_icon +: { svg: (mod.widgets.ICO_MENU) }
+            draw_bg +: {
+                color: (COLOR_ACTIVE_PRIMARY)
+                color_hover: (COLOR_ACTIVE_PRIMARY_DARKER)
+                color_down: #0C5DAA
+            }
+            icon_walk: Walk{width: 19, height: 19},
+        }
+    }
+
     mod.widgets.RoomInputBar = set_type_default() do #(RoomInputBar::register_widget(vm)) {
         ..mod.widgets.RoundedView
 
@@ -913,159 +1085,31 @@ script_mod! {
 
                 input_row := View {
                     width: Fill,
-                    height: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.75}}
-                    flow: Right
-                    // Bottom-align everything to ensure that buttons always stick to the bottom
-                    // even when the mentionable_text_input box is very tall.
-                    align: Align{y: 1.0},
+                    height: Fit
+                    flow: Down
+                    spacing: 4
 
-                    // A checkbox that enables TSP signing for the outgoing message.
-                    // If TSP is not enabled, this will be an empty invisible view.
-                    tsp_sign_checkbox := TspSignAnycastCheckbox {
-                        margin: Inset{bottom: 9, left: 6, right: 0}
+                    // Toolbar ABOVE the composer. The composer is the focused
+                    // IME field, and keyboard avoidance only keeps the focused
+                    // field above the on-screen keyboard — anything below it is
+                    // covered. So the composer must be the bottom-most row; the
+                    // toolbar sits above it and stays visible. (Input-at-bottom
+                    // is also the conventional mobile chat layout.)
+                    button_row := View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 0.5}
+                        LeftActionButtons {}
+                        Filler { height: Fit }
+                        RightActionButtons {}
                     }
 
-                    // Opens the sticker drawer above the input bar.
-                    sticker_drawer_toggle_button := RobrixIconButton {
-                        margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
-                        spacing: 0,
-                        draw_icon +: {
-                            svg: (mod.widgets.ICO_MORE_VERT)
-                            color: (COLOR_ACTIVE_PRIMARY_DARKER)
-                        },
-                        draw_bg +: {
-                            color: (COLOR_BG_PREVIEW)
-                            color_hover: #E0E8F0
-                            color_down: #D0D8E8
-                        }
-                        icon_walk: Walk{width: 19, height: 19}
-                        text: "",
-                    }
-
-                    // Attachment button for uploading files/images
-                    send_attachment_button := RobrixIconButton {
-                        margin: Inset{left: 3, right: 1, top: 4, bottom: 4}
-                        spacing: 0,
-                        draw_icon +: {
-                            svg: (ICON_ADD_ATTACHMENT)
-                            color: (COLOR_ACTIVE_PRIMARY_DARKER)
-                        },
-                        draw_bg +: {
-                            color: (COLOR_BG_PREVIEW)
-                            color_hover: #E0E8F0
-                            color_down: #D0D8E8
-                        }
-                        icon_walk: Walk{width: 21, height: 21}
-                        text: "",
-                    }
-
-                    // Opens the modal showing only the user's added stickers.
-                    my_stickers_button := RobrixIconButton {
-                        margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
-                        spacing: 0,
-                        draw_icon +: {
-                            svg: (ICON_SQUARES)
-                            color: (COLOR_ACTIVE_PRIMARY_DARKER)
-                        },
-                        draw_bg +: {
-                            color: (COLOR_BG_PREVIEW)
-                            color_hover: #E0E8F0
-                            color_down: #D0D8E8
-                        }
-                        icon_walk: Walk{width: 18, height: 18}
-                        text: "",
-                    }
-
-                    emoji_picker_button := RobrixIconButton {
-                        margin: Inset{left: 3, right: 1, top: 4, bottom: 4}
-                        spacing: 0,
-                        draw_icon +: {
-                            svg: (ICON_ADD_REACTION)
-                            color: (COLOR_ACTIVE_PRIMARY_DARKER)
-                        },
-                        draw_bg +: {
-                            color: (COLOR_BG_PREVIEW)
-                            color_hover: #E0E8F0
-                            color_down: #D0D8E8
-                        }
-                        icon_walk: Walk{width: 19, height: 19}
-                        text: "",
-                    }
-
-                    translate_button := RobrixIconButton {
-                        margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
-                        spacing: 0,
-                        draw_icon +: {
-                            svg: (mod.widgets.ICO_TRANSLATE)
-                            color: (COLOR_ACTIVE_PRIMARY_DARKER)
-                        },
-                        draw_bg +: {
-                            color: (COLOR_BG_PREVIEW)
-                            color_hover: #xE0E8F0
-                            color_down: #xD0D8E8
-                        }
-                        icon_walk: Walk{width: 19, height: 19}
-                        text: "",
-                    }
-
-                    bot_menu_button := RobrixIconButton {
-                        visible: false,
-                        margin: Inset{left: 1, right: 1, top: 4, bottom: 4}
-                        spacing: 0,
-                        draw_icon +: {
-                            svg: (ICON_LINK)
-                            color: (COLOR_ACTIVE_PRIMARY_DARKER)
-                        },
-                        draw_bg +: {
-                            color: (COLOR_BG_PREVIEW)
-                            color_hover: #xE0E8F0
-                            color_down: #xD0D8E8
-                        }
-                        icon_walk: Walk{width: 18, height: 18}
-                        text: "",
-                    }
-
-                    mentionable_text_input := MentionableTextInput {
-                        width: Fill,
-                        height: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.75}}
-                        margin: Inset {
-                            top: 3, // add some space between the top border of the text input and the top border of this row
-                            bottom: 5.75, // to line up the middle of the text input with the middle of the buttons
-                            left: 3, right: 3 // to give a bit of breathing room between the text input and the buttons on the sides
-                        },
-
-                        persistent +: {
-                            center +: {
-                                text_input := RobrixTextInput {
-                                    empty_text: "Write a message (in Markdown) ..."
-                                    is_multiline: true,
-                                }
-                            }
-                        }
-                    }
-
-                    send_message_button := RobrixPositiveIconButton {
-                        visible: false,
-                        // Disabled by default; enabled when text is inputted
-                        enabled: false,
-                        spacing: 0,
-                        text: "",
-                        margin: 4
-                        draw_icon +: { svg: (ICON_SEND) }
-                        icon_walk: Walk{width: 21, height: 21},
-                    }
-
-                    more_actions_button := RobrixIconButton {
-                        spacing: 0,
-                        text: "",
-                        margin: 4
-                        draw_icon +: { svg: (mod.widgets.ICO_MENU) }
-                        draw_bg +: {
-                            color: (COLOR_ACTIVE_PRIMARY)
-                            color_hover: (COLOR_ACTIVE_PRIMARY_DARKER)
-                            color_down: #0C5DAA
-                        }
-                        icon_walk: Walk{width: 19, height: 19},
+                    // Composer on its own full-width row so the toolbar can't
+                    // squeeze the placeholder into a tall, narrow column.
+                    message_row := View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        mentionable_text_input := MessageInputField {}
                     }
                 }
             }
@@ -1375,14 +1419,14 @@ impl Widget for RoomInputBar {
         let remapped = (slide as f64 * 1.25).min(1.0);
         if remapped >= 1.0 {
             // Input_bar has reached its full natural height: switch to Fit
-            // so it can respond to content changes normally.
-            // Update the cached height for future animations.
-            let h = input_bar.area().rect(cx).size.y;
-            if h > 0.0 {
-                self.input_bar_natural_height = h;
-            }
+            // so it can respond to content changes normally. Avoid rewriting
+            // layout every frame while mobile IME is opening; repeated
+            // input-area height changes can feed back into KeyboardView's
+            // visible-rect correction and make the screen jump.
             if let Some(mut inner) = input_bar.borrow_mut() {
-                inner.walk.height = Size::fit();
+                if !inner.walk.height.is_fit() {
+                    inner.walk.height = Size::fit();
+                }
             }
         } else {
             let target = self.input_bar_natural_height;
@@ -1420,7 +1464,7 @@ impl RoomInputBar {
     }
 
     fn sync_app_language(&mut self, cx: &mut Cx) {
-        self.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input))
+        self.text_input(cx, ids!(mentionable_text_input.text_input))
             .set_empty_text(cx, tr_key(self.app_language, "room_input_bar.input.placeholder").to_string());
         self.button(cx, ids!(translation_apply_button))
             .set_text(cx, tr_key(self.app_language, "room_input_bar.translation.preview.apply"));
@@ -1453,7 +1497,7 @@ impl RoomInputBar {
         self.view.view(cx, ids!(translation_preview)).set_visible(cx, true);
 
         // Focus the text input
-        self.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input)).set_key_focus(cx);
+        self.text_input(cx, ids!(mentionable_text_input.text_input)).set_key_focus(cx);
         self.redraw(cx);
     }
 
@@ -1600,7 +1644,7 @@ impl RoomInputBar {
             });
             self.is_emoji_picker_expanded = false;
             self.view.view(cx, ids!(emoji_picker_popup)).set_visible(cx, false);
-            self.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input)).set_key_focus(cx);
+            self.text_input(cx, ids!(mentionable_text_input.text_input)).set_key_focus(cx);
             self.redraw(cx);
         }
 
@@ -1639,7 +1683,7 @@ impl RoomInputBar {
                 self.translation_last_source = outcome.next_last_source;
                 self.view.label(cx, ids!(translation_preview_text)).set_text(cx, &outcome.preserved_preview_text);
                 self.view.view(cx, ids!(translation_preview)).set_visible(cx, outcome.keep_preview_visible);
-                self.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input)).set_key_focus(cx);
+                self.text_input(cx, ids!(mentionable_text_input.text_input)).set_key_focus(cx);
                 self.redraw(cx);
             }
         }
@@ -1942,7 +1986,7 @@ impl RoomInputBar {
         //    so that the user can immediately start typing their reply
         //    without having to manually click on the message input box.
         if grab_key_focus {
-            self.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input)).set_key_focus(cx);
+            self.text_input(cx, ids!(mentionable_text_input.text_input)).set_key_focus(cx);
         }
         self.button(cx, ids!(cancel_reply_button)).reset_hover(cx);
         self.redraw(cx);
@@ -2311,7 +2355,7 @@ impl RoomInputBarRef {
             was_replying_preview_visible: inner.was_replying_preview_visible,
             replying_to: inner.replying_to.clone(),
             editing_pane_state: inner.child_by_path(ids!(editing_pane)).as_editing_pane().save_state(),
-            text_input_state: inner.child_by_path(ids!(input_bar.input_row.mentionable_text_input.text_input)).as_text_input().save_state(),
+            text_input_state: inner.child_by_path(ids!(mentionable_text_input.text_input)).as_text_input().save_state(),
         }
     }
 
@@ -2340,9 +2384,9 @@ impl RoomInputBarRef {
         inner.update_user_power_levels(cx, user_power_levels);
 
         // 1. Restore the state of the TextInput within the MentionableTextInput.
-        inner.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input))
+        inner.text_input(cx, ids!(mentionable_text_input.text_input))
             .restore_state(cx, text_input_state);
-        let is_text_input_empty = inner.text_input(cx, ids!(input_bar.input_row.mentionable_text_input.text_input))
+        let is_text_input_empty = inner.text_input(cx, ids!(mentionable_text_input.text_input))
             .text()
             .is_empty();
         inner.enable_send_message_button(cx, !is_text_input_empty);

--- a/src/shared/mentionable_text_input.rs
+++ b/src/shared/mentionable_text_input.rs
@@ -1459,18 +1459,21 @@ impl Widget for MentionableTextInput {
         // finger_up events might steal focus after our initial restoration attempt.
         if self.pending_draw_focus_restore {
             let text_input_ref = self.cmd_text_input.text_input_ref();
-            text_input_ref.set_key_focus(cx);
-            if let Some(mut ti) = text_input_ref.borrow_mut() {
-                ti.reset_blink_timer(cx);
-            }
-            // Check if we successfully got focus
+            // Check focus BEFORE requesting it: calling set_key_focus() while the
+            // input is already focused resets the Android IME-dismissed guard and
+            // can turn one hide request into a hide/show loop (same pattern as the
+            // removed popup-path re-requests above).
             let area = text_input_ref.area();
             if cx.has_key_focus(area) {
                 // Successfully restored focus, clear the flag
                 self.pending_draw_focus_restore = false;
             } else {
                 // Focus restoration failed (likely due to finger_up event stealing focus)
-                // Keep the flag true and request another frame to retry
+                // Request focus and retry on the next frame.
+                text_input_ref.set_key_focus(cx);
+                if let Some(mut ti) = text_input_ref.borrow_mut() {
+                    ti.reset_blink_timer(cx);
+                }
                 cx.new_next_frame();
             }
         }

--- a/src/shared/mentionable_text_input.rs
+++ b/src/shared/mentionable_text_input.rs
@@ -1419,11 +1419,11 @@ impl Widget for MentionableTextInput {
                                 self.show_loading_indicator(cx);
                                 let popup = self.cmd_text_input.view(cx, ids!(popup));
                                 popup.set_visible(cx, true);
-                                // Only restore focus if input currently has focus
-                                let text_input_area = self.cmd_text_input.text_input_ref().area();
-                                if cx.has_key_focus(text_input_area) {
-                                    self.cmd_text_input.text_input_ref().set_key_focus(cx);
-                                }
+                                // If the input already has focus, TextInput's
+                                // draw pass keeps the IME visible. Calling
+                                // set_key_focus() again on Android resets the
+                                // IME-dismissed guard and can turn one hide
+                                // request into a hide/show loop.
                             }
                         }
                     }
@@ -1935,11 +1935,6 @@ impl MentionableTextInput {
 
         let popup = self.cmd_text_input.view(cx, ids!(popup));
         popup.set_visible(cx, items_added > 0);
-        let text_input_area = self.cmd_text_input.text_input_ref().area();
-        if cx.has_key_focus(text_input_area) {
-            self.cmd_text_input.text_input_ref().set_key_focus(cx);
-        }
-
         self.redraw(cx);
     }
 
@@ -2001,11 +1996,8 @@ impl MentionableTextInput {
                 // Waiting for room members to be loaded
                 self.show_loading_indicator(cx);
                 popup.set_visible(cx, true);
-                // Only restore focus if input currently has focus
-                let text_input_area = self.cmd_text_input.text_input_ref().area();
-                if cx.has_key_focus(text_input_area) {
-                    self.cmd_text_input.text_input_ref().set_key_focus(cx);
-                }
+                // Preserve existing focus without re-requesting it; see the
+                // Android IME note in the room-member loading branch above.
             }
             MentionSearchState::Searching {
                 accumulated_results,
@@ -2014,11 +2006,7 @@ impl MentionableTextInput {
                 if has_items {
                     // We have search results to display
                     popup.set_visible(cx, true);
-                    // Only restore focus if input currently has focus
-                    let text_input_area = self.cmd_text_input.text_input_ref().area();
-                    if cx.has_key_focus(text_input_area) {
-                        self.cmd_text_input.text_input_ref().set_key_focus(cx);
-                    }
+                    // Preserve existing focus without re-requesting it.
                 } else if accumulated_results.is_empty() {
                     if members_sync_pending || self.search_results_pending {
                         // Still fetching either member list or background search results.
@@ -2031,19 +2019,11 @@ impl MentionableTextInput {
                         self.show_loading_indicator(cx);
                     }
                     popup.set_visible(cx, true);
-                    // Only restore focus if input currently has focus
-                    let text_input_area = self.cmd_text_input.text_input_ref().area();
-                    if cx.has_key_focus(text_input_area) {
-                        self.cmd_text_input.text_input_ref().set_key_focus(cx);
-                    }
+                    // Preserve existing focus without re-requesting it.
                 } else {
                     // Has accumulated results but no items (should not happen)
                     popup.set_visible(cx, true);
-                    // Only restore focus if input currently has focus
-                    let text_input_area = self.cmd_text_input.text_input_ref().area();
-                    if cx.has_key_focus(text_input_area) {
-                        self.cmd_text_input.text_input_ref().set_key_focus(cx);
-                    }
+                    // Preserve existing focus without re-requesting it.
                 }
             }
         }
@@ -2593,12 +2573,6 @@ impl MentionableTextInput {
         let header_view = self.cmd_text_input.view(cx, ids!(popup.header_view));
         header_view.set_visible(cx, true);
         popup.set_visible(cx, true);
-        // Only restore focus if input currently has focus
-        let text_input_area = self.cmd_text_input.text_input_ref().area();
-        if cx.has_key_focus(text_input_area) {
-            self.cmd_text_input.text_input_ref().set_key_focus(cx);
-        }
-
         // Create a new channel for this search
         let (sender, receiver) = std::sync::mpsc::channel();
 
@@ -2751,11 +2725,7 @@ impl MentionableTextInput {
 
         popup.set_visible(cx, true);
 
-        // Maintain text input focus only if it currently has focus
-        let text_input_area = self.cmd_text_input.text_input_ref().area();
-        if self.is_searching() && cx.has_key_focus(text_input_area) {
-            self.cmd_text_input.text_input_ref().set_key_focus(cx);
-        }
+        // The focused TextInput will keep the IME visible from its draw pass.
     }
 
     /// Shows the no matches indicator when no users match the search
@@ -2782,11 +2752,7 @@ impl MentionableTextInput {
         // Set scroll container height to fit the no-matches indicator (48px + 4px padding)
         self.set_list_scroll_height(cx, 52.0);
 
-        // Maintain text input focus so user can continue typing, but only if currently focused
-        let text_input_area = self.cmd_text_input.text_input_ref().area();
-        if self.is_searching() && cx.has_key_focus(text_input_area) {
-            self.cmd_text_input.text_input_ref().set_key_focus(cx);
-        }
+        // The focused TextInput will keep the IME visible from its draw pass.
     }
 
     /// Check if mention search is currently active


### PR DESCRIPTION
Fixes four mobile/Android bugs around the room message input bar, all verified on a physical Android device (OnePlus, octosbot management-bot room).

## Bugs fixed

### 1. Bot room can't be reopened after rebuilding the app
On Android, open the `octos`/management-bot room once → `selected_room` gets persisted. After reinstalling/relaunching, the app restores `selected_room` to that room but shows the room list (the room view isn't pushed). Tapping the room was then a **no-op**: the equality guards in `App::push_selected_room_view` and `RoomsList` treated it as "already current" and swallowed the open. A normal room (alice) opened fine because it wasn't the stuck selection.

**Fix:** the same-room guard now also checks the `StackNavigation` depth — a room can be reopened when its view isn't actually on screen (`depth == 0`); `RoomsList` always emits `Selected`. *(`src/app.rs`, `src/home/rooms_list.rs`)*

### 2. Composer is deformed / unusable in the mobile layout
The input bar packed ~7 toolbar buttons + the text field into a single `flow: Right` row. `width: Fill` is "remaining space" with no flex-shrink, so on a narrow screen the buttons consumed all width and the field collapsed to ~0 px — the placeholder wrapped one character per line into a tall sliver.

**Fix:** the composer now gets its own full-width row (two-row layout: toolbar row + composer row). *(`src/room/room_input_bar.rs`)*

### 3. Input box jumps up/down continuously while focused
Root cause: a **double-nested `KeyboardView`**. makepad's `Window` already wraps its body in a `KeyboardView` (`widgets/src/window.rs`: `body := KeyboardView`), and `room_screen.rs` added a **second** one around the room content. Both read the single global IME-area rect (`cx.get_ime_area_rect()`) every frame and apply `with_scroll(shift)`; each layer then read the *other* layer's already-shifted position, so the computed shift oscillated between ~0 and the keyboard height every frame, panning the whole surface up/down at 60 fps. (Device logs showed the global IME rect alternating between its natural y and y − 2×shift, with the shift bouncing 0 ↔ ~240.)

**Fix:** remove the redundant inner `KeyboardView` — the room content uses a plain `View` and relies on the Window's built-in keyboard avoidance (single layer → stable shift). *(`src/home/room_screen.rs`)*

### 4. Soft keyboard covers the toolbar
Keyboard avoidance only keeps the **focused field** above the keyboard; anything below it is covered. With the composer on top and the toolbar below, the toolbar sat behind the keyboard.

**Fix:** reorder so the composer is the bottom-most row and the toolbar sits above it (input-at-bottom is also the conventional mobile chat layout). *(`src/room/room_input_bar.rs`)*

## Also
- Fix the composer max-height cap: `Fit{max: Abs(170)}` → `Fit{max: FitBound.Abs(170.0)}` (the bare `Abs` form errored at runtime, so the cap silently failed).
- Remove redundant `set_key_focus` calls in the `@mention` popup paths that re-requested IME focus and could trigger an IME hide/show loop. *(`src/shared/mentionable_text_input.rs`)*

## Notes
- **No makepad fork / dependency change** — the entire fix is in robrix's own code; `Cargo.toml` / `Cargo.lock` are unchanged (still upstream `3d18a13`).
- Desktop layout is unaffected.
