### PR TITLE
perf(android): skip redundant script_apply_eval in enable_send_message_button (14fps → 59fps scroll)

### DIFF
--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -1211,6 +1211,13 @@ pub struct RoomInputBar {
     /// The pending file load operation, if any. Contains the receiver channel
     /// for receiving the loaded file data from a background thread.
     #[rust] pending_file_load: Option<crate::shared::file_upload_modal::FileLoadReceiver>,
+    /// The last `enable` state applied to the send button, used to skip the
+    /// expensive `script_apply_eval!` in `enable_send_message_button()` when
+    /// the state hasn't changed. `handle_actions()` calls it on every actions
+    /// batch (i.e., every frame during a scroll), and each `script_apply_eval!`
+    /// re-tokenizes, re-parses, and re-evaluates the script source.
+    /// `None` forces the next call to apply unconditionally.
+    #[rust] send_button_enabled: Option<bool>,
 
     // --- Translation state ---
     /// Whether real-time translation is currently active.
@@ -2068,6 +2075,15 @@ impl RoomInputBar {
     ///
     /// This should be called to update the button state when the message TextInput content changes.
     fn enable_send_message_button(&mut self, cx: &mut Cx, enable: bool) {
+        // Skip the expensive `script_apply_eval!` below if the button is already
+        // in the requested state. This function is called unconditionally from
+        // `handle_actions()`, which runs on every actions batch — including every
+        // frame of a scroll — and re-evaluating script source each time was
+        // profiled as the single largest CPU cost during timeline scrolling.
+        if self.send_button_enabled == Some(enable) {
+            return;
+        }
+        self.send_button_enabled = Some(enable);
         let mut send_message_button = self.view.button(cx, ids!(send_message_button));
         let (fg_color, bg_color) = if enable {
             (COLOR_FG_ACCEPT_GREEN, COLOR_BG_ACCEPT_GREEN)
@@ -2389,6 +2405,9 @@ impl RoomInputBarRef {
         let is_text_input_empty = inner.text_input(cx, ids!(mentionable_text_input.text_input))
             .text()
             .is_empty();
+        // Force a re-apply: this `RoomInputBar` instance is reused across rooms,
+        // so the cached send-button state may not match the newly-restored room.
+        inner.send_button_enabled = None;
         inner.enable_send_message_button(cx, !is_text_input_empty);
         inner.is_location_card_expanded = false;
         inner.view.view(cx, ids!(more_actions_popup)).set_visible(cx, false);

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -21,7 +21,7 @@ use matrix_sdk::room::reply::{EnforceThread, Reply};
 use ruma::events::room::message::AddMentions;
 use matrix_sdk_ui::timeline::{EmbeddedEvent, EventTimelineItem, TimelineEventItemId};
 use ruma::{events::room::message::{LocationMessageEventContent, MessageType, ReplyWithinThread, RoomMessageEventContent}, OwnedRoomId, OwnedUserId, UserId};
-use crate::{app::AppState, home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt, EditingPaneWidgetRefExt}, location_preview::{LocationPreviewWidgetExt, LocationPreviewWidgetRefExt}, room_screen::{MessageAction, RoomScreenProps, is_known_or_likely_bot, populate_preview_of_timeline_item}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}, upload_progress::UploadProgressViewWidgetRefExt}, i18n::{AppLanguage, tr_fmt, tr_key}, location::init_location_subscriber, room::translation::{self, TRANSLATION_REQUEST_ID}, shared::{avatar::AvatarWidgetRefExt, file_upload_modal::{FileData, FileLoadedData, FilePreviewerAction}, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::{MentionableTextInputWidgetExt, classify_known_slash_command_for_submission, parse_command_with_at_suffix}, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{MatrixRequest, TimelineKind, UserPowerLevels, submit_async_request}, utils};
+use crate::{app::AppState, home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt, EditingPaneWidgetRefExt}, location_preview::{LocationPreviewWidgetExt, LocationPreviewWidgetRefExt}, room_screen::{MessageAction, RoomScreenProps, is_known_or_likely_bot, populate_preview_of_timeline_item}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}, upload_progress::UploadProgressViewWidgetRefExt}, i18n::{AppLanguage, tr_fmt, tr_key}, location::init_location_subscriber, room::translation::{self, TRANSLATION_REQUEST_ID}, shared::{avatar::AvatarWidgetRefExt, file_upload_modal::{FileData, FileLoadedData, FilePreviewerAction}, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::{MentionableTextInputWidgetExt, classify_known_slash_command_for_submission, parse_command_with_at_suffix}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, TimelineKind, UserPowerLevels, submit_async_request}, utils};
 #[cfg(not(any(target_os = "ios", target_os = "android")))]
 use crate::shared::file_upload_modal::{FilePreviewerMetaData, ThumbnailData};
 
@@ -2071,31 +2071,26 @@ impl RoomInputBar {
         }
     }
 
-    /// Sets the send_message_button to be shown/enabled and green, or hidden/disabled and gray.
+    /// Sets the send_message_button to be shown/enabled, or hidden/disabled.
     ///
     /// This should be called to update the button state when the message TextInput content changes.
     fn enable_send_message_button(&mut self, cx: &mut Cx, enable: bool) {
-        // Skip the expensive `script_apply_eval!` below if the button is already
-        // in the requested state. This function is called unconditionally from
-        // `handle_actions()`, which runs on every actions batch — including every
-        // frame of a scroll — and re-evaluating script source each time was
-        // profiled as the single largest CPU cost during timeline scrolling.
+        // Skip the work below if the button is already in the requested state.
+        // This function is called unconditionally from `handle_actions()`, which
+        // runs on every actions batch — including every frame of a scroll — so
+        // it must be cheap when nothing has changed.
         if self.send_button_enabled == Some(enable) {
             return;
         }
         self.send_button_enabled = Some(enable);
-        let mut send_message_button = self.view.button(cx, ids!(send_message_button));
-        let (fg_color, bg_color) = if enable {
-            (COLOR_FG_ACCEPT_GREEN, COLOR_BG_ACCEPT_GREEN)
-        } else {
-            (COLOR_FG_DISABLED, COLOR_BG_DISABLED)
-        };
-        script_apply_eval!(cx, send_message_button, {
-            visible: #(enable),
-            enabled: #(enable),
-            draw_icon.color: #(fg_color),
-            draw_bg.color: #(bg_color),
-        });
+        // The green enabled-state styling is already baked into the
+        // `RobrixPositiveIconButton` template, and the disabled state is hidden
+        // entirely, so toggling visibility/enabled-ness is all that's needed.
+        // (The previous `script_apply_eval!` here re-compiled script source on
+        // every call, which was the dominant CPU cost during scrolling.)
+        let send_message_button = self.view.button(cx, ids!(send_message_button));
+        send_message_button.set_visible(cx, enable);
+        send_message_button.set_enabled(cx, enable);
     }
 
     fn try_handle_bot_shortcut(


### PR DESCRIPTION
## Problem

Scrolling on Android was severely janky on all screens: ~14fps in the room timeline and ~10fps on the rooms list, on a 90Hz device (OnePlus PLR110, Android 16, release build).

## Root cause (simpleperf flame graph)

`RoomInputBar::handle_actions()` calls `enable_send_message_button()` **unconditionally on every actions batch** — which means every frame during a scroll. Each call runs `script_apply_eval!`, and profiling shows that macro re-runs the full Splash pipeline per call:

```
enable_send_message_button (≈50% of scroll CPU)
└─ with_vm → ScriptVm::eval_with_source
   ├─ ScriptTokenizer::tokenize        ← re-tokenizes source every call
   ├─ ScriptParser::parse              ← re-parses every call
   └─ Button::script_apply
      └─ DrawVars::compute_shader_functions_hash  ← shader hash recomputed
```

Drawing was **not** the bottleneck — `draw_walk` was only ~1.6% of CPU. The cost was entirely on the event side.

This also explains why the rooms list was slow: `StackNavigation` keeps the `RoomScreen` (and its input bar) alive in the widget tree, so the per-frame script eval taxed every screen.

## Fix

Cache the last applied state in a new `send_button_enabled: Option<bool>` field and return early when unchanged. The script eval now only runs on actual empty ↔ non-empty transitions. `restore_state()` resets the cache to `None` because the same `RoomInputBar` instance is reused across rooms.

## Results

Same device, same measurement (SurfaceFlinger timestats, single 3s drag):

| Screen | Before | After |
|--------|--------|-------|
| Room timeline scroll | 14.0 fps | **59.1 fps** (68% of frames at 11ms = full 90Hz pace, 0 dropped) |
| Rooms list scroll | ~10 fps | **45.2 fps** |

## Notes

- Remaining frame-time cost is makepad 2.0 `WidgetTree` `ids!()` lookup overhead (SipHash + per-event cache-graph refresh, ~55% of the post-fix flat profile) — framework-level, will be reported upstream separately.
- Lesson for future code: `script_apply_eval!` compiles script source on every call — never invoke it unconditionally in `handle_actions` or any per-frame path; guard on state change.