### PR TITLE
feat(settings): mobile-only Settings redesign — adaptive shell + consolidated Account

### DIFF
--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -20,9 +20,18 @@ script_mod! {
         width: Fill, height: Fit
         flow: Down
 
-        account_settings_title := TitleLabel {
-            text: "Account Settings"
-        }
+        // Desktop = original layout (verbatim); Mobile = minimal redesign.
+        // Both variants share the same child ids so the Rust logic is reused.
+        account_adaptive := AdaptiveView {
+            width: Fill, height: Fit
+
+            Desktop := View {
+            width: Fill, height: Fit
+            flow: Down
+
+            account_settings_title := TitleLabel {
+                text: "Account Settings"
+            }
 
         verification_banner_verified := RoundedView {
             visible: false
@@ -481,6 +490,369 @@ script_mod! {
                 }
             }
         }
+            } // end Desktop variant
+
+            // =================================================================
+            // MOBILE — minimal, consolidated account (agent-first: identity is
+            // secondary). Profile + name + user id + accounts live in ONE card;
+            // actions in a second card. Avatar upload/delete is desktop-only, so
+            // those buttons are kept (hidden) only to keep the Rust logic safe.
+            // =================================================================
+            Mobile := View {
+                width: Fill, height: Fit
+                flow: Down
+                spacing: (SPACE_MD)
+
+                // ---- verification banners (compact; same ids, RBX tokens) ----
+                verification_banner_verified := RoundedView {
+                    visible: false
+                    width: Fill, height: Fit
+                    flow: Right, align: Align{y: 0.5}
+                    padding: Inset{top: 9, bottom: 9, left: 12, right: 12}
+                    show_bg: true
+                    draw_bg +: {
+                        color: (RBX_SUCCESS_BG)
+                        border_color: (RBX_SUCCESS_FG)
+                        border_size: 1.0
+                        border_radius: (RBX_RADIUS_SM)
+                    }
+                    verification_verified_label := Label {
+                        width: Fill, height: Fit
+                        flow: Flow.Right{wrap: true}
+                        draw_text +: {
+                            color: (RBX_SUCCESS_FG),
+                            text_style: RBX_TEXT_BODY {},
+                        }
+                        text: "This device is verified and can access encrypted messages."
+                    }
+                }
+                verification_banner_unverified := RoundedView {
+                    visible: false
+                    width: Fill, height: Fit
+                    flow: Down, align: Align{y: 0.5}
+                    padding: Inset{top: 10, bottom: 12, left: 12, right: 12}
+                    show_bg: true
+                    draw_bg +: {
+                        color: (RBX_DANGER_BG)
+                        border_color: (RBX_DANGER_FG)
+                        border_size: 1.0
+                        border_radius: (RBX_RADIUS_SM)
+                    }
+                    verification_unverified_label := Label {
+                        width: Fill, height: Fit
+                        flow: Flow.Right{wrap: true}
+                        draw_text +: {
+                            color: (RBX_DANGER_FG),
+                            text_style: RBX_TEXT_BODY {},
+                        }
+                        text: "This device is not verified and can't view encrypted messages."
+                    }
+                    verification_unverified_hint_label := Label {
+                        width: Fill, height: Fit
+                        flow: Flow.Right{wrap: true}
+                        margin: Inset{top: 4, bottom: 1}
+                        draw_text +: {
+                            color: (RBX_FG_SECONDARY),
+                            text_style: RBX_TEXT_META {},
+                        }
+                        text: "Verify it from another client using this info:"
+                    }
+                    unverified_device_info_label := Label {
+                        width: Fill, height: Fit
+                        padding: Inset{left: 8}
+                        flow: Flow.Right{wrap: true}
+                        draw_text +: {
+                            color: (RBX_FG_SECONDARY),
+                            text_style: RBX_TEXT_META {},
+                        }
+                        text: ""
+                    }
+                }
+
+                // ---- Card 1: identity + accounts (consolidated) ----
+                RoundedView {
+                    width: Fill, height: Fit
+                    flow: Down
+                    spacing: (SPACE_SM)
+                    padding: (SPACE_LG)
+                    show_bg: true
+                    draw_bg +: {
+                        color: (RBX_BG_SURFACE)
+                        border_radius: (RBX_RADIUS_MD)
+                        border_size: 1.0
+                        border_color: (RBX_STROKE_SOFT)
+                    }
+
+                    // hero: avatar + name + user id
+                    View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_MD)
+
+                        our_own_avatar := Avatar {
+                            width: 56, height: 56
+                            text_view +: {
+                                text +: {
+                                    draw_text +: {
+                                        text_style: theme.font_regular { font_size: 22.0 }
+                                    }
+                                }
+                            }
+                        }
+
+                        View {
+                            width: Fill, height: Fit
+                            flow: Down
+                            spacing: (SPACE_XS)
+
+                            display_name_input := RobrixTextInput {
+                                width: Fill, height: Fit
+                                empty_text: "Add a display name..."
+                            }
+
+                            View {
+                                width: Fill, height: Fit
+                                flow: Right
+                                align: Align{y: 0.5}
+                                spacing: (SPACE_XS)
+
+                                user_id := Label {
+                                    width: Fill, height: Fit
+                                    flow: Flow.Right{wrap: true}
+                                    draw_text +: {
+                                        color: (RBX_FG_SECONDARY),
+                                        text_style: RBX_TEXT_META {},
+                                    }
+                                    text: "You are not logged in."
+                                }
+
+                                copy_user_id_button := RobrixNeutralIconButton {
+                                    enable_long_press: true,
+                                    width: Fit, height: Fit,
+                                    padding: (SPACE_XS),
+                                    spacing: 0,
+                                    draw_bg +: { border_radius: (RBX_RADIUS_SM) }
+                                    draw_icon.svg: (ICON_COPY)
+                                    icon_walk: Walk{width: 14, height: 14}
+                                }
+                            }
+                        }
+                    }
+
+                    // display-name edit actions (enabled by Rust when name changes)
+                    View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_SM)
+
+                        cancel_display_name_button := RobrixNeutralIconButton {
+                            enabled: false,
+                            width: Fit, height: Fit,
+                            padding: (SPACE_SM),
+                            draw_icon.svg: (ICON_FORBIDDEN)
+                            icon_walk: Walk{width: 14, height: 14, margin: 0}
+                            text: "Cancel"
+                        }
+                        accept_display_name_button := RobrixPositiveIconButton {
+                            enabled: false,
+                            width: Fit, height: Fit,
+                            padding: (SPACE_SM),
+                            draw_bg.border_radius: (RADIUS_MD)
+                            draw_icon.svg: (ICON_CHECKMARK)
+                            icon_walk: Walk{width: 14, height: 14, margin: 0}
+                            text: "Save Name"
+                        }
+                        save_name_spinner := LoadingSpinner {
+                            width: 16, height: 16
+                            margin: Inset{top: 11}
+                            visible: false
+                            draw_bg.color: (RBX_ACCENT)
+                        }
+                    }
+
+                    // avatar editing is desktop-only — kept hidden so the avatar
+                    // enable/spinner logic still has valid widget refs on mobile.
+                    upload_avatar_button := RobrixIconButton {
+                        visible: false
+                        draw_icon.svg: (ICON_UPLOAD)
+                        icon_walk: Walk{width: 0, height: 0}
+                        text: "Upload Avatar"
+                    }
+                    upload_avatar_spinner := LoadingSpinner {
+                        visible: false
+                        width: 16, height: 16
+                        draw_bg.color: (RBX_ACCENT)
+                    }
+                    delete_avatar_button := RobrixNegativeIconButton {
+                        visible: false
+                        draw_icon.svg: (ICON_TRASH)
+                        icon_walk: Walk{width: 0, height: 0}
+                        text: "Delete Avatar"
+                    }
+                    delete_avatar_spinner := LoadingSpinner {
+                        visible: false
+                        width: 16, height: 16
+                        draw_bg.color: (RBX_ACCENT)
+                    }
+
+                    // divider
+                    View {
+                        width: Fill, height: 1.0
+                        margin: Inset{top: (SPACE_XS), bottom: (SPACE_XS)}
+                        show_bg: true
+                        draw_bg +: { color: (RBX_DIVIDER) }
+                    }
+
+                    // accounts
+                    active_account_view := View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_SM)
+
+                        View {
+                            width: Fill, height: Fit
+                            flow: Down
+                            spacing: 2
+
+                            active_account_label := Label {
+                                width: Fill, height: Fit
+                                draw_text +: {
+                                    color: (RBX_FG_PRIMARY),
+                                    text_style: RBX_TEXT_BODY_STRONG {},
+                                }
+                                text: "@user:server"
+                            }
+                            active_account_status_label := Label {
+                                width: Fit, height: Fit
+                                draw_text +: {
+                                    color: (RBX_SUCCESS_FG),
+                                    text_style: RBX_TEXT_META {},
+                                }
+                                text: "Active"
+                            }
+                        }
+                    }
+
+                    other_accounts_label := Label {
+                        width: Fill, height: Fit
+                        visible: false
+                        margin: Inset{top: (SPACE_XS)}
+                        draw_text +: {
+                            color: (RBX_FG_SECONDARY),
+                            text_style: RBX_TEXT_META {},
+                        }
+                        text: "Other accounts:"
+                    }
+
+                    other_account_entry := View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_SM)
+                        visible: false
+
+                        other_account_label := Label {
+                            width: Fill, height: Fit
+                            draw_text +: {
+                                color: (RBX_FG_PRIMARY),
+                                text_style: RBX_TEXT_BODY {},
+                            }
+                            text: "@other:server"
+                        }
+                        switch_account_button := RobrixIconButton {
+                            width: Fit, height: Fit
+                            padding: Inset{top: (SPACE_XS), bottom: (SPACE_XS), left: (SPACE_SM), right: (SPACE_SM)}
+                            draw_bg +: {
+                                color: (RBX_ACCENT)
+                                color_hover: (RBX_ACCENT_HOVER)
+                                color_down: (RBX_ACCENT_PRESSED)
+                                border_radius: (RBX_RADIUS_SM)
+                            }
+                            draw_text +: {
+                                color: (RBX_FG_ON_ACCENT)
+                                color_hover: (RBX_FG_ON_ACCENT)
+                                color_down: (RBX_FG_ON_ACCENT)
+                            }
+                            draw_icon.svg: (ICON_JUMP)
+                            icon_walk: Walk{width: 14, height: 14}
+                            text: "Switch"
+                        }
+                    }
+
+                    View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 0.5}
+                        spacing: (SPACE_SM)
+                        margin: Inset{top: (SPACE_XS)}
+
+                        account_count_label := Label {
+                            width: Fill, height: Fit
+                            draw_text +: {
+                                color: (RBX_FG_TERTIARY),
+                                text_style: RBX_TEXT_META {},
+                            }
+                            text: "1 account logged in"
+                        }
+                        add_account_button := RobrixIconButton {
+                            width: Fit, height: Fit
+                            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                            draw_bg +: {
+                                color: (RBX_ACCENT)
+                                color_hover: (RBX_ACCENT_HOVER)
+                                color_down: (RBX_ACCENT_PRESSED)
+                                border_radius: (RBX_RADIUS_SM)
+                            }
+                            draw_text +: {
+                                color: (RBX_FG_ON_ACCENT)
+                                color_hover: (RBX_FG_ON_ACCENT)
+                                color_down: (RBX_FG_ON_ACCENT)
+                            }
+                            draw_icon.svg: (ICON_ADD)
+                            icon_walk: Walk{width: 14, height: 14}
+                            text: "Add Account"
+                        }
+                    }
+                }
+
+                // ---- Card 2: actions ----
+                RoundedView {
+                    width: Fill, height: Fit
+                    flow: Down
+                    spacing: (SPACE_SM)
+                    padding: (SPACE_LG)
+                    show_bg: true
+                    draw_bg +: {
+                        color: (RBX_BG_SURFACE)
+                        border_radius: (RBX_RADIUS_MD)
+                        border_size: 1.0
+                        border_color: (RBX_STROKE_SOFT)
+                    }
+
+                    copy_access_token_button := RobrixNeutralIconButton {
+                        width: Fill, height: Fit,
+                        align: Align{x: 0.0, y: 0.5}
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        draw_bg +: { border_radius: (RBX_RADIUS_SM) }
+                        draw_icon.svg: (ICON_COPY)
+                        icon_walk: Walk{width: 16, height: 16}
+                        text: "Copy Access Token"
+                    }
+                    logout_button := RobrixNegativeIconButton {
+                        width: Fill, height: Fit,
+                        align: Align{x: 0.0, y: 0.5}
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        draw_bg +: { border_radius: (RBX_RADIUS_SM) }
+                        draw_icon.svg: (ICON_LOGOUT)
+                        icon_walk: Walk{width: 16, height: 16, margin: Inset{right: -2}}
+                        text: "Log out"
+                    }
+                }
+            } // end Mobile variant
+        } // end account_adaptive AdaptiveView
     }
 }
 
@@ -495,6 +867,13 @@ pub struct AccountSettings {
     #[rust] app_language: AppLanguage,
     /// List of other account user IDs (not the currently active one)
     #[rust] other_accounts: Vec<OwnedUserId>,
+    /// Last view-mode applied to the internal Desktop/Mobile AdaptiveView, so we
+    /// only re-set the variant selector when the app's view mode actually changes.
+    #[rust] applied_view_mode: Option<crate::settings::app_preferences::ViewModeOverride>,
+    /// Fires the frame AFTER the internal AdaptiveView swaps in its variant, so we
+    /// can re-populate the freshly-instantiated widgets from our stored profile
+    /// (the swap only happens on the next draw — see AdaptiveView).
+    #[rust] resync_frame: NextFrame,
 }
 
 impl Widget for AccountSettings {
@@ -504,6 +883,10 @@ impl Widget for AccountSettings {
             .unwrap_or_default();
         if self.app_language != app_language {
             self.set_app_language(cx, app_language);
+        }
+        self.sync_view_mode(cx);
+        if self.resync_frame.is_event(event).is_some() {
+            self.refresh_ui_after_switch(cx);
         }
         self.match_event(cx, event);
 
@@ -933,6 +1316,55 @@ impl MatchEvent for AccountSettings {
 }
 
 impl AccountSettings {
+    /// Keep the internal Desktop/Mobile `AdaptiveView` in sync with the app's
+    /// view-mode override (so a forced narrow/wide layout flips this sub-widget
+    /// too, not just the parent SettingsScreen). Cheap: only acts on change.
+    fn sync_view_mode(&mut self, cx: &mut Cx) {
+        let view_mode = cx.global::<crate::settings::app_preferences::AppPreferencesGlobal>().0.view_mode;
+        if self.applied_view_mode == Some(view_mode) {
+            return;
+        }
+        self.applied_view_mode = Some(view_mode);
+        if let Some(mut adaptive) = self.view
+            .child_by_path(ids!(account_adaptive))
+            .borrow_mut::<AdaptiveView>()
+        {
+            adaptive.set_variant_selector(view_mode.variant_selector());
+        }
+        // The variant swaps in on the next draw; re-populate it the frame after.
+        self.resync_frame = cx.new_next_frame();
+        self.view.redraw(cx);
+    }
+
+    /// Re-populate the freshly-swapped-in AdaptiveView variant's widgets from our
+    /// stored profile (the variant is a brand-new widget instance, so any data set
+    /// before the swap was on the now-discarded variant).
+    fn refresh_ui_after_switch(&mut self, cx: &mut Cx) {
+        if self.own_profile.is_none() {
+            user_profile_cache::process_user_profile_updates(cx);
+            if let Some(new_profile) = get_own_profile(cx) {
+                self.own_profile = Some(new_profile);
+            }
+        }
+        if let Some(profile) = self.own_profile.clone() {
+            self.view.label(cx, ids!(user_id))
+                .set_text(cx, profile.user_id.as_str());
+            self.view.text_input(cx, ids!(display_name_input))
+                .set_text(cx, profile.username.as_deref().unwrap_or_default());
+            Self::enable_display_name_buttons(
+                cx,
+                false,
+                &self.view.button(cx, ids!(accept_display_name_button)),
+                &self.view.button(cx, ids!(cancel_display_name_button)),
+            );
+            self.populate_avatar_views(cx);
+        }
+        self.populate_account_list(cx);
+        self.refresh_verification_state(cx);
+        self.sync_app_language(cx);
+        self.view.redraw(cx);
+    }
+
     fn set_app_language(&mut self, cx: &mut Cx, app_language: AppLanguage) {
         self.app_language = app_language;
         self.sync_app_language(cx);
@@ -1090,6 +1522,7 @@ impl AccountSettings {
 
     /// Show and initializes the account settings within the SettingsScreen.
     pub fn populate(&mut self, cx: &mut Cx, own_profile: UserProfile) {
+        self.sync_view_mode(cx);
         self.view.label(cx, ids!(user_id))
             .set_text(cx, own_profile.user_id.as_str());
         self.view.text_input(cx, ids!(display_name_input))

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -2,7 +2,7 @@
 use makepad_widgets::*;
 use url::Url;
 
-use crate::{app::{AppState, AppUpdateAction, BotSettingsState}, home::navigation_tab_bar::{NavigationBarAction, get_own_profile}, i18n::{AppLanguage, I18nKey, language_dropdown_labels, tr, tr_fmt, tr_key}, persistence, proxy_config::{validate_proxy_url_for_user_input, ProxyInputError}, profile::user_profile::UserProfile, settings::{account_settings::AccountSettingsWidgetExt, app_preferences::AppPreferences, app_settings::AppSettingsWidgetExt, bot_settings::BotSettingsWidgetExt, translation_settings::TranslationSettingsWidgetExt}, shared::{expand_arrow::ExpandArrow, popup_list::{PopupKind, enqueue_popup_notification}, styles::{apply_neutral_button_style, apply_primary_button_style}}, sliding_sync::current_user_id, updater::{UpdateCheckOutcome, check_for_updates}};
+use crate::{app::{AppState, AppUpdateAction, BotSettingsState}, home::navigation_tab_bar::{NavigationBarAction, get_own_profile}, i18n::{AppLanguage, I18nKey, language_dropdown_labels, tr, tr_fmt, tr_key}, persistence, proxy_config::{validate_proxy_url_for_user_input, ProxyInputError}, profile::user_profile::UserProfile, settings::{account_settings::AccountSettingsWidgetExt, app_preferences::AppPreferences, app_settings::AppSettingsWidgetExt, bot_settings::BotSettingsWidgetExt, translation_settings::TranslationSettingsWidgetExt}, shared::{expand_arrow::ExpandArrow, popup_list::{PopupKind, enqueue_popup_notification}, styles::{apply_neutral_button_style, apply_primary_button_style, apply_segment_selected_style, apply_segment_idle_style}}, sliding_sync::current_user_id, updater::{UpdateCheckOutcome, check_for_updates}};
 
 const CONTRIBUTE_REPO_URL: &str = "https://github.com/Project-Robius-China/robrix2";
 
@@ -18,7 +18,16 @@ script_mod! {
         width: Fill, height: Fill,
         flow: Overlay
 
-        View {
+        // The settings screen is the SAME CachedWidget instance on desktop and
+        // mobile (see home_screen.rs). To redesign ONLY the mobile layout without
+        // touching desktop, the whole screen is wrapped in an AdaptiveView whose
+        // `Desktop` variant is the original layout verbatim and whose `Mobile`
+        // variant is the redesigned one. The variant is chosen by the same
+        // `ViewModeOverride::variant_selector()` the NavigationTabBar uses.
+        settings_adaptive := AdaptiveView {
+            width: Fill, height: Fill
+
+            Desktop := View {
             padding: Inset{top: (SPACE_SM), left: (SETTINGS_CONTENT_PADDING), right: (SETTINGS_CONTENT_PADDING), bottom: (SETTINGS_CONTENT_PADDING)},
             flow: Down
 
@@ -592,6 +601,264 @@ script_mod! {
             }
         }
 
+            // =================================================================
+            // MOBILE variant — the redesigned settings screen (spec §5.1).
+            // Page canvas + page title + segmented category tabs + a body
+            // PageFlip that reuses the SAME page / sub-widget / control ids as
+            // the Desktop variant, so all existing Rust logic drives it
+            // unchanged (only the active AdaptiveView variant is instantiated).
+            // =================================================================
+            Mobile := View {
+                width: Fill, height: Fill
+                flow: Down
+                show_bg: true
+                draw_bg +: { color: (RBX_BG_CANVAS) }
+
+                // ---- Header: page title + close button ----
+                View {
+                    width: Fill, height: Fit
+                    flow: Right
+                    align: Align{y: 0.5}
+                    padding: Inset{top: (SPACE_LG), left: (SPACE_LG), right: (SPACE_MD), bottom: (SPACE_SM)}
+                    spacing: (SPACE_SM)
+
+                    m_settings_title := Label {
+                        width: Fill, height: Fit
+                        draw_text +: {
+                            color: (RBX_FG_PRIMARY)
+                            text_style: RBX_TEXT_PAGE_TITLE {}
+                        }
+                        text: "Settings"
+                    }
+
+                    // Reuses the `close_button` id so the existing close handler
+                    // (click / back / Escape -> CloseSettings) works on mobile too.
+                    close_button := RobrixNeutralIconButton {
+                        width: Fit, height: Fit,
+                        spacing: 0, margin: 0,
+                        padding: (SPACE_SM),
+                        draw_bg +: { border_radius: (RBX_RADIUS_PILL) }
+                        draw_icon.svg: (ICON_CLOSE)
+                        icon_walk: Walk{width: 14, height: 14}
+                    }
+                }
+
+                // ---- Category tabs: text-only (transparent bg; selected = teal
+                //      text, idle = gray text; recolored at runtime after the
+                //      variant swap). Wraps on narrow widths. ----
+                m_tabs_row := View {
+                    width: Fill, height: Fit
+                    flow: Flow.Right{wrap: true}
+                    align: Align{y: 0.5}
+                    spacing: (SPACE_XS)
+                    padding: Inset{left: (SPACE_LG), right: (SPACE_LG), top: 0, bottom: (SPACE_SM)}
+
+                    m_tab_account := RobrixNeutralIconButton {
+                        width: Fit, height: Fit,
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        spacing: 0, margin: 0,
+                        icon_walk: Walk{width: 0, height: 0, margin: 0}
+                        draw_bg +: { color: #0000, color_hover: #0000, color_down: #0000, border_size: 0.0 }
+                        draw_text +: { color: (RBX_FG_SECONDARY) }
+                        text: "Account"
+                    }
+                    m_tab_preferences := RobrixNeutralIconButton {
+                        width: Fit, height: Fit,
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        spacing: 0, margin: 0,
+                        icon_walk: Walk{width: 0, height: 0, margin: 0}
+                        draw_bg +: { color: #0000, color_hover: #0000, color_down: #0000, border_size: 0.0 }
+                        draw_text +: { color: (RBX_FG_SECONDARY) }
+                        text: "Preferences"
+                    }
+                    m_tab_devices := RobrixNeutralIconButton {
+                        width: Fit, height: Fit,
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        spacing: 0, margin: 0,
+                        icon_walk: Walk{width: 0, height: 0, margin: 0}
+                        draw_bg +: { color: #0000, color_hover: #0000, color_down: #0000, border_size: 0.0 }
+                        draw_text +: { color: (RBX_FG_SECONDARY) }
+                        text: "Devices"
+                    }
+                    m_tab_labs := RobrixNeutralIconButton {
+                        width: Fit, height: Fit,
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        spacing: 0, margin: 0,
+                        icon_walk: Walk{width: 0, height: 0, margin: 0}
+                        draw_bg +: { color: #0000, color_hover: #0000, color_down: #0000, border_size: 0.0 }
+                        draw_text +: { color: (RBX_FG_SECONDARY) }
+                        text: "Labs"
+                    }
+                    m_tab_contribute := RobrixNeutralIconButton {
+                        width: Fit, height: Fit,
+                        padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                        spacing: 0, margin: 0,
+                        icon_walk: Walk{width: 0, height: 0, margin: 0}
+                        draw_bg +: { color: #0000, color_hover: #0000, color_down: #0000, border_size: 0.0 }
+                        draw_text +: { color: (RBX_FG_SECONDARY) }
+                        text: "Contribute"
+                    }
+                }
+
+                // hairline under the tabs
+                View {
+                    width: Fill, height: 1.0
+                    show_bg: true
+                    draw_bg +: { color: (RBX_STROKE_SOFT) }
+                }
+
+                // ---- Body: one page per category (same ids as Desktop) ----
+                settings_sections := PageFlip {
+                    width: Fill, height: Fill
+                    lazy_init: true,
+                    active_page: @account_settings_page
+
+                    account_settings_page := ScrollXYView {
+                        width: Fill, height: Fill
+                        flow: Down
+                        padding: Inset{left: (SPACE_LG), right: (SPACE_LG), top: (SPACE_MD), bottom: (SPACE_XXL)}
+                        account_settings := AccountSettings {}
+                    }
+
+                    preferences_settings_page := ScrollXYView {
+                        width: Fill, height: Fill
+                        flow: Down
+                        spacing: (SPACE_MD)
+                        padding: Inset{left: (SPACE_LG), right: (SPACE_LG), top: (SPACE_MD), bottom: (SPACE_XXL)}
+                        app_settings := AppSettings {}
+                    }
+
+                    devices_settings_page := ScrollXYView {
+                        width: Fill, height: Fill
+                        flow: Down
+                        padding: Inset{left: (SPACE_LG), right: (SPACE_LG), top: (SPACE_MD), bottom: (SPACE_XXL)}
+                        devices_settings := DevicesScreen {}
+                    }
+
+                    labs_settings_page := ScrollXYView {
+                        width: Fill, height: Fill
+                        flow: Down
+                        spacing: (SPACE_MD)
+                        padding: Inset{left: (SPACE_LG), right: (SPACE_LG), top: (SPACE_MD), bottom: (SPACE_XXL)}
+                        bot_settings := BotSettings {}
+                        translation_settings := TranslationSettings {}
+                    }
+
+                    contribute_settings_page := ScrollXYView {
+                        width: Fill, height: Fill
+                        flow: Down
+                        spacing: (SPACE_MD)
+                        padding: Inset{left: (SPACE_LG), right: (SPACE_LG), top: (SPACE_MD), bottom: (SPACE_XXL)}
+
+                        // About card (SectionCard recipe, spec §4.1)
+                        RoundedView {
+                            width: Fill, height: Fit
+                            flow: Down
+                            spacing: (SPACE_XS)
+                            padding: (SPACE_LG)
+                            show_bg: true
+                            draw_bg +: {
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_MD)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
+                            }
+
+                            about_title := Label {
+                                width: Fill, height: Fit
+                                draw_text +: {
+                                    color: (RBX_FG_PRIMARY)
+                                    text_style: RBX_TEXT_CARD_TITLE {}
+                                }
+                                text: "About Robrix"
+                            }
+                            about_description := Label {
+                                width: Fill, height: Fit
+                                draw_text +: {
+                                    color: (RBX_FG_SECONDARY)
+                                    text_style: RBX_TEXT_BODY {}
+                                }
+                                text: "Robrix is a multi-platform Matrix chat client built with Makepad and Robius."
+                            }
+                            contribute_current_version_label := Label {
+                                width: Fill, height: Fit
+                                margin: Inset{top: (SPACE_XS)}
+                                draw_text +: {
+                                    color: (RBX_FG_TERTIARY)
+                                    text_style: RBX_TEXT_META {}
+                                }
+                                text: "Current version: 0.0.0"
+                            }
+                            contribute_check_update_button := RobrixIconButton {
+                                width: Fit, height: Fit,
+                                margin: Inset{top: (SPACE_XS)}
+                                padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                                spacing: 0,
+                                icon_walk: Walk{width: 0, height: 0, margin: 0}
+                                draw_bg +: {
+                                    color: (RBX_ACCENT)
+                                    color_hover: (RBX_ACCENT_HOVER)
+                                    color_down: (RBX_ACCENT_PRESSED)
+                                    border_radius: (RBX_RADIUS_SM)
+                                }
+                                draw_text +: {
+                                    color: (RBX_FG_ON_ACCENT)
+                                    color_hover: (RBX_FG_ON_ACCENT)
+                                    color_down: (RBX_FG_ON_ACCENT)
+                                }
+                                text: "Check for Updates"
+                            }
+                        }
+
+                        // Contribute card
+                        RoundedView {
+                            width: Fill, height: Fit
+                            flow: Down
+                            spacing: (SPACE_XS)
+                            padding: (SPACE_LG)
+                            show_bg: true
+                            draw_bg +: {
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_MD)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
+                            }
+
+                            contribute_title := Label {
+                                width: Fill, height: Fit
+                                draw_text +: {
+                                    color: (RBX_FG_PRIMARY)
+                                    text_style: RBX_TEXT_CARD_TITLE {}
+                                }
+                                text: "Contribute"
+                            }
+                            contribute_description := Label {
+                                width: Fill, height: Fit
+                                draw_text +: {
+                                    color: (RBX_FG_SECONDARY)
+                                    text_style: RBX_TEXT_BODY {}
+                                }
+                                text: "Contribute to Robrix on GitHub:"
+                            }
+                            contribute_repo_link := LinkLabel {
+                                width: Fit, height: Fit,
+                                margin: Inset{top: (SPACE_XS)}
+                                spacing: 0,
+                                align: Align{x: 0.0}
+                                icon_walk: Walk{width: 0, height: 0}
+                                draw_text +: {
+                                    text_style: RBX_TEXT_BODY {}
+                                    color: (RBX_LINK),
+                                    color_hover: (RBX_ACCENT),
+                                }
+                                text: "https://github.com/Project-Robius-China/robrix2"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // We want all modals to appear in front of the settings screen.
         create_wallet_modal := Modal {
             content +: {
@@ -631,6 +898,10 @@ pub struct SettingsScreen {
 
     #[rust] selected_category: SettingsCategory,
     #[rust] app_language: AppLanguage,
+    /// Fires the frame AFTER the Desktop/Mobile AdaptiveView swaps in its variant,
+    /// so we can (re)apply tab styling + labels onto the now-instantiated widgets
+    /// (set_variant_selector only takes effect on the next draw — see AdaptiveView).
+    #[rust] resync_frame: NextFrame,
     #[rust] preferences_use_proxy_enabled: bool,
     #[rust] preferences_proxy_layout_width: f64,
     #[rust] language_popup_visible: bool,
@@ -648,6 +919,13 @@ impl Widget for SettingsScreen {
         }
         self.sync_update_widgets_text(cx);
         self.view.handle_event(cx, event, scope);
+
+        // After the AdaptiveView swaps Desktop<->Mobile, the new variant's
+        // widgets exist only now — (re)apply their labels and tab styling.
+        if self.resync_frame.is_event(event).is_some() {
+            self.sync_app_language(cx);
+            self.sync_selected_category(cx);
+        }
 
         // Close the pane if:
         // 1. The close button is clicked,
@@ -781,6 +1059,24 @@ impl Widget for SettingsScreen {
                 self.set_selected_category(cx, SettingsCategory::Contribute);
             }
 
+            // Mobile segmented tabs (only the active AdaptiveView variant's
+            // buttons exist, so the desktop & mobile handlers can coexist).
+            if self.view.button(cx, ids!(m_tab_account)).clicked(actions) {
+                self.set_selected_category(cx, SettingsCategory::Account);
+            }
+            else if self.view.button(cx, ids!(m_tab_preferences)).clicked(actions) {
+                self.set_selected_category(cx, SettingsCategory::Preferences);
+            }
+            else if self.view.button(cx, ids!(m_tab_devices)).clicked(actions) {
+                self.set_selected_category(cx, SettingsCategory::Devices);
+            }
+            else if self.view.button(cx, ids!(m_tab_labs)).clicked(actions) {
+                self.set_selected_category(cx, SettingsCategory::Labs);
+            }
+            else if self.view.button(cx, ids!(m_tab_contribute)).clicked(actions) {
+                self.set_selected_category(cx, SettingsCategory::Contribute);
+            }
+
             if !self.is_update_checking && (
                 self.view.button(cx, ids!(contribute_check_update_button)).clicked(actions)
             ) {
@@ -792,6 +1088,9 @@ impl Widget for SettingsScreen {
             }
 
             for action in actions {
+                if let Some(crate::settings::app_preferences::AppPreferencesAction::ViewModeChanged(new_mode)) = action.downcast_ref() {
+                    self.apply_settings_view_mode(cx, *new_mode);
+                }
                 if let HtmlLinkAction::Clicked { url, .. } = action.as_widget_action().cast() {
                     if url == CONTRIBUTE_REPO_URL {
                         if let Err(e) = robius_open::Uri::new(&url).open() {
@@ -916,6 +1215,24 @@ impl SettingsScreen {
             .set_text(cx, tr(self.app_language, I18nKey::SettingsCategoryLabs));
         self.view
             .button(cx, ids!(category_contribute_button))
+            .set_text(cx, tr(self.app_language, I18nKey::SettingsCategoryContribute));
+        // Mobile variant: page title + segmented category tabs (no-ops on the
+        // desktop variant, where these ids don't exist). Devices keeps its
+        // static label, matching the desktop category button.
+        self.view
+            .label(cx, ids!(m_settings_title))
+            .set_text(cx, tr(self.app_language, I18nKey::AllSettingsTitle));
+        self.view
+            .button(cx, ids!(m_tab_account))
+            .set_text(cx, tr(self.app_language, I18nKey::SettingsCategoryAccount));
+        self.view
+            .button(cx, ids!(m_tab_preferences))
+            .set_text(cx, tr(self.app_language, I18nKey::SettingsCategoryPreferences));
+        self.view
+            .button(cx, ids!(m_tab_labs))
+            .set_text(cx, tr(self.app_language, I18nKey::SettingsCategoryLabs));
+        self.view
+            .button(cx, ids!(m_tab_contribute))
             .set_text(cx, tr(self.app_language, I18nKey::SettingsCategoryContribute));
         self.view
             .label(cx, ids!(preferences_language_title))
@@ -1126,6 +1443,22 @@ impl SettingsScreen {
         }
     }
 
+    /// Drives the `settings_adaptive` AdaptiveView's Desktop/Mobile choice from
+    /// the app's view-mode override (mirrors `NavigationTabBar::apply_view_mode`),
+    /// so a forced wide/narrow layout also flips the settings screen.
+    fn apply_settings_view_mode(&mut self, cx: &mut Cx, mode: crate::settings::app_preferences::ViewModeOverride) {
+        if let Some(mut adaptive) = self.view
+            .child_by_path(ids!(settings_adaptive))
+            .borrow_mut::<AdaptiveView>()
+        {
+            adaptive.set_variant_selector(mode.variant_selector());
+        }
+        // The variant only swaps in on the next draw; re-sync labels + tab
+        // styling onto the freshly-instantiated variant on the frame after that.
+        self.resync_frame = cx.new_next_frame();
+        self.view.redraw(cx);
+    }
+
     fn set_selected_category(&mut self, cx: &mut Cx, category: SettingsCategory) {
         self.selected_category = category;
         self.sync_selected_category(cx);
@@ -1173,43 +1506,47 @@ impl SettingsScreen {
             self.view.app_settings(cx, ids!(app_settings)).populate(cx, &prefs, self.app_language);
         }
 
-        let mut category_account_button = self.view.button(cx, ids!(category_account_button));
-        let mut category_preferences_button = self.view.button(cx, ids!(category_preferences_button));
-        let mut category_devices_button = self.view.button(cx, ids!(category_devices_button));
-        let mut category_labs_button = self.view.button(cx, ids!(category_labs_button));
-        let mut category_contribute_button = self.view.button(cx, ids!(category_contribute_button));
+        // Style only the active variant's tabs. effective_is_desktop matches the
+        // AdaptiveView's Desktop/Mobile choice; the inactive variant's buttons
+        // don't exist, so we skip them rather than styling empty refs.
+        let is_desktop = crate::settings::app_preferences::effective_is_desktop(cx);
+        if is_desktop {
+            let mut category_account_button = self.view.button(cx, ids!(category_account_button));
+            let mut category_preferences_button = self.view.button(cx, ids!(category_preferences_button));
+            let mut category_devices_button = self.view.button(cx, ids!(category_devices_button));
+            let mut category_labs_button = self.view.button(cx, ids!(category_labs_button));
+            let mut category_contribute_button = self.view.button(cx, ids!(category_contribute_button));
 
-        if show_account {
-            apply_primary_button_style(cx, &mut category_account_button);
-        } else {
-            apply_neutral_button_style(cx, &mut category_account_button);
-        }
-        if show_preferences {
-            apply_primary_button_style(cx, &mut category_preferences_button);
-        } else {
-            apply_neutral_button_style(cx, &mut category_preferences_button);
-        }
-        if show_devices {
-            apply_primary_button_style(cx, &mut category_devices_button);
-        } else {
-            apply_neutral_button_style(cx, &mut category_devices_button);
-        }
-        if show_labs {
-            apply_primary_button_style(cx, &mut category_labs_button);
-        } else {
-            apply_neutral_button_style(cx, &mut category_labs_button);
-        }
-        if show_contribute {
-            apply_primary_button_style(cx, &mut category_contribute_button);
-        } else {
-            apply_neutral_button_style(cx, &mut category_contribute_button);
-        }
+            if show_account { apply_primary_button_style(cx, &mut category_account_button); } else { apply_neutral_button_style(cx, &mut category_account_button); }
+            if show_preferences { apply_primary_button_style(cx, &mut category_preferences_button); } else { apply_neutral_button_style(cx, &mut category_preferences_button); }
+            if show_devices { apply_primary_button_style(cx, &mut category_devices_button); } else { apply_neutral_button_style(cx, &mut category_devices_button); }
+            if show_labs { apply_primary_button_style(cx, &mut category_labs_button); } else { apply_neutral_button_style(cx, &mut category_labs_button); }
+            if show_contribute { apply_primary_button_style(cx, &mut category_contribute_button); } else { apply_neutral_button_style(cx, &mut category_contribute_button); }
 
-        category_account_button.reset_hover(cx);
-        category_preferences_button.reset_hover(cx);
-        category_devices_button.reset_hover(cx);
-        category_labs_button.reset_hover(cx);
-        category_contribute_button.reset_hover(cx);
+            category_account_button.reset_hover(cx);
+            category_preferences_button.reset_hover(cx);
+            category_devices_button.reset_hover(cx);
+            category_labs_button.reset_hover(cx);
+            category_contribute_button.reset_hover(cx);
+        } else {
+            let mut m_tab_account = self.view.button(cx, ids!(m_tab_account));
+            let mut m_tab_preferences = self.view.button(cx, ids!(m_tab_preferences));
+            let mut m_tab_devices = self.view.button(cx, ids!(m_tab_devices));
+            let mut m_tab_labs = self.view.button(cx, ids!(m_tab_labs));
+            let mut m_tab_contribute = self.view.button(cx, ids!(m_tab_contribute));
+
+            if show_account { apply_segment_selected_style(cx, &mut m_tab_account); } else { apply_segment_idle_style(cx, &mut m_tab_account); }
+            if show_preferences { apply_segment_selected_style(cx, &mut m_tab_preferences); } else { apply_segment_idle_style(cx, &mut m_tab_preferences); }
+            if show_devices { apply_segment_selected_style(cx, &mut m_tab_devices); } else { apply_segment_idle_style(cx, &mut m_tab_devices); }
+            if show_labs { apply_segment_selected_style(cx, &mut m_tab_labs); } else { apply_segment_idle_style(cx, &mut m_tab_labs); }
+            if show_contribute { apply_segment_selected_style(cx, &mut m_tab_contribute); } else { apply_segment_idle_style(cx, &mut m_tab_contribute); }
+
+            m_tab_account.reset_hover(cx);
+            m_tab_preferences.reset_hover(cx);
+            m_tab_devices.reset_hover(cx);
+            m_tab_labs.reset_hover(cx);
+            m_tab_contribute.reset_hover(cx);
+        }
         self.view.redraw(cx);
     }
 
@@ -1282,6 +1619,9 @@ impl SettingsScreen {
 
     /// Fetches the current user's profile and uses it to populate the settings screen.
     pub fn populate(&mut self, cx: &mut Cx, own_profile: Option<UserProfile>, bot_settings: &BotSettingsState, translation_config: &crate::room::translation::TranslationConfig, app_prefs: &AppPreferences, app_language: AppLanguage) {
+        // Ensure the AdaptiveView has selected the right Desktop/Mobile variant
+        // before we populate it, so populate targets the live variant's widgets.
+        self.apply_settings_view_mode(cx, app_prefs.view_mode);
         if let Some(profile) = own_profile.or_else(|| get_own_profile(cx)) {
             self.view.account_settings(cx, ids!(account_settings)).populate(cx, profile);
         } else {

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -6,6 +6,8 @@ pub mod animated_image;
 pub mod avatar;
 pub mod collapsible_header;
 pub mod design_tokens;
+pub mod status_badge;
+pub mod toggle_switch;
 pub mod expand_arrow;
 pub mod confirmation_modal;
 pub mod file_upload_modal;
@@ -39,6 +41,9 @@ pub fn script_mod(vm: &mut ScriptVm) {
     design_tokens::script_mod(vm);
     helpers::script_mod(vm);
     icon_button::script_mod(vm);
+    // Redesigned settings components (depend on design_tokens + icon_button).
+    status_badge::script_mod(vm);
+    toggle_switch::script_mod(vm);
     expand_arrow::script_mod(vm);
     unread_badge::script_mod(vm);
     collapsible_header::script_mod(vm);

--- a/src/shared/status_badge.rs
+++ b/src/shared/status_badge.rs
@@ -1,0 +1,134 @@
+//! StatusBadge — pill status badges for the redesigned (mobile) settings UI.
+//!
+//! These implement the spec §4.2 contract: a capsule (pill) with a light
+//! semantic background and a same-family dark foreground, used to surface a
+//! state (success / warning / danger / info / neutral) or a brand-accent
+//! emphasis. They are derived from `RobrixIconButton` so they inherit the
+//! focus-disabling animator (a badge is a *label*, not an action, so hover /
+//! down / focus must never change its appearance — every interaction color is
+//! pinned to the resting color).
+//!
+//! Usage (DSL): `RbxBadgeSuccess { text: "Connected" }`.
+//! The text is a normal `Button` `text:` prop, so it can be set at runtime via
+//! `view.button(cx, ids!(my_badge)).set_text(cx, "...")`.
+//!
+//! NOTE: inside `script_mod!` only `//` comments are allowed.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    // Shared pill skeleton: no icon, pill radius, no border, badge type scale.
+    // Every variant below only overrides the bg / fg color pair.
+    mod.widgets.RbxBadgeBase = mod.widgets.RobrixIconButton {
+        width: Fit, height: Fit,
+        spacing: 0,
+        margin: 0,
+        padding: Inset{left: (SPACE_SM), right: (SPACE_SM), top: 3.0, bottom: 3.0}
+        align: Align{x: 0.5, y: 0.5}
+        icon_walk: Walk{width: 0, height: 0, margin: 0}
+
+        draw_bg +: {
+            border_radius: (RBX_RADIUS_PILL)
+            border_size: 0.0
+            border_color: #0000
+            border_color_hover: #0000
+            border_color_down: #0000
+            border_color_focus: #0000
+            color_2: vec4(-1.0, -1.0, -1.0, -1.0)
+            border_color_2: vec4(-1.0, -1.0, -1.0, -1.0)
+        }
+
+        draw_text +: {
+            text_style: RBX_TEXT_BADGE {}
+        }
+        text: ""
+    }
+
+    // success = Connected / Healthy / Enabled / Active / Synced
+    mod.widgets.RbxBadgeSuccess = mod.widgets.RbxBadgeBase {
+        draw_bg +: {
+            color: (RBX_SUCCESS_BG)
+            color_hover: (RBX_SUCCESS_BG)
+            color_down: (RBX_SUCCESS_BG)
+        }
+        draw_text +: {
+            color: (RBX_SUCCESS_FG)
+            color_hover: (RBX_SUCCESS_FG)
+            color_down: (RBX_SUCCESS_FG)
+        }
+    }
+
+    // warning = Approval required / Pending / Waiting
+    mod.widgets.RbxBadgeWarning = mod.widgets.RbxBadgeBase {
+        draw_bg +: {
+            color: (RBX_WARNING_BG)
+            color_hover: (RBX_WARNING_BG)
+            color_down: (RBX_WARNING_BG)
+        }
+        draw_text +: {
+            color: (RBX_WARNING_FG)
+            color_hover: (RBX_WARNING_FG)
+            color_down: (RBX_WARNING_FG)
+        }
+    }
+
+    // danger = Failed / Rejected / Error / risk action
+    mod.widgets.RbxBadgeDanger = mod.widgets.RbxBadgeBase {
+        draw_bg +: {
+            color: (RBX_DANGER_BG)
+            color_hover: (RBX_DANGER_BG)
+            color_down: (RBX_DANGER_BG)
+        }
+        draw_text +: {
+            color: (RBX_DANGER_FG)
+            color_hover: (RBX_DANGER_FG)
+            color_down: (RBX_DANGER_FG)
+        }
+    }
+
+    // info = capability / linked object / neutral metadata highlight
+    mod.widgets.RbxBadgeInfo = mod.widgets.RbxBadgeBase {
+        draw_bg +: {
+            color: (RBX_INFO_BG)
+            color_hover: (RBX_INFO_BG)
+            color_down: (RBX_INFO_BG)
+        }
+        draw_text +: {
+            color: (RBX_INFO_FG)
+            color_hover: (RBX_INFO_FG)
+            color_down: (RBX_INFO_FG)
+        }
+    }
+
+    // neutral = Idle / secondary / disabled-ish
+    mod.widgets.RbxBadgeNeutral = mod.widgets.RbxBadgeBase {
+        draw_bg +: {
+            color: (RBX_NEUTRAL_BG)
+            color_hover: (RBX_NEUTRAL_BG)
+            color_down: (RBX_NEUTRAL_BG)
+        }
+        draw_text +: {
+            color: (RBX_NEUTRAL_FG)
+            color_hover: (RBX_NEUTRAL_FG)
+            color_down: (RBX_NEUTRAL_FG)
+        }
+    }
+
+    // accent = brand emphasis (e.g. "Agent-enabled"). Not a state pair:
+    // RBX_ACCENT_SOFT bg + RBX_ACCENT fg.
+    mod.widgets.RbxBadgeAccent = mod.widgets.RbxBadgeBase {
+        draw_bg +: {
+            color: (RBX_ACCENT_SOFT)
+            color_hover: (RBX_ACCENT_SOFT)
+            color_down: (RBX_ACCENT_SOFT)
+        }
+        draw_text +: {
+            color: (RBX_ACCENT)
+            color_hover: (RBX_ACCENT)
+            color_down: (RBX_ACCENT)
+        }
+    }
+}

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -479,3 +479,82 @@ pub fn apply_primary_button_style(cx: &mut Cx, button: &mut ButtonRef) {
         }
     });
 }
+
+// =============================================================================
+// New (RBX_*) button styles for the redesigned settings UI. These mirror the
+// helpers above but use the teal `RBX_ACCENT` family + the semantic token layer
+// (see `design_tokens.rs`). Inside `script_apply_eval!`, DSL tokens are
+// referenced directly as `mod.widgets.RBX_*` (no `#()` wrapping).
+// =============================================================================
+
+/// Applies the teal accent (primary CTA) styling to the given button — solid
+/// `RBX_ACCENT` fill with on-accent (white) text. Use for the mobile settings
+/// primary actions (e.g. a "Save changes" button).
+pub fn apply_accent_button_style(cx: &mut Cx, button: &mut ButtonRef) {
+    script_apply_eval!(cx, button, {
+        draw_bg +: {
+            color: mod.widgets.RBX_ACCENT,
+            color_hover: mod.widgets.RBX_ACCENT_HOVER,
+            color_down: mod.widgets.RBX_ACCENT_PRESSED,
+            border_color: #0000,
+            border_color_hover: #0000,
+            border_color_down: #0000,
+        }
+        draw_text +: {
+            color: mod.widgets.RBX_FG_ON_ACCENT,
+            color_hover: mod.widgets.RBX_FG_ON_ACCENT,
+            color_down: mod.widgets.RBX_FG_ON_ACCENT,
+        }
+        draw_icon +: {
+            color: mod.widgets.RBX_FG_ON_ACCENT,
+        }
+    });
+}
+
+/// Applies the *selected* segmented-tab styling — text-only: a transparent
+/// background with teal (`RBX_ACCENT`) text marking the active category.
+pub fn apply_segment_selected_style(cx: &mut Cx, button: &mut ButtonRef) {
+    script_apply_eval!(cx, button, {
+        draw_bg +: {
+            border_size: 0.0,
+            color: #0000,
+            color_hover: #0000,
+            color_down: #0000,
+            border_color: #0000,
+            border_color_hover: #0000,
+            border_color_down: #0000,
+        }
+        draw_text +: {
+            color: mod.widgets.RBX_ACCENT,
+            color_hover: mod.widgets.RBX_ACCENT,
+            color_down: mod.widgets.RBX_ACCENT,
+        }
+        draw_icon +: {
+            color: mod.widgets.RBX_ACCENT,
+        }
+    });
+}
+
+/// Applies the *idle* (unselected) segmented-tab styling — text-only: a
+/// transparent background with secondary-gray text.
+pub fn apply_segment_idle_style(cx: &mut Cx, button: &mut ButtonRef) {
+    script_apply_eval!(cx, button, {
+        draw_bg +: {
+            border_size: 0.0,
+            color: #0000,
+            color_hover: #0000,
+            color_down: #0000,
+            border_color: #0000,
+            border_color_hover: #0000,
+            border_color_down: #0000,
+        }
+        draw_text +: {
+            color: mod.widgets.RBX_FG_SECONDARY,
+            color_hover: mod.widgets.RBX_FG_SECONDARY,
+            color_down: mod.widgets.RBX_FG_SECONDARY,
+        }
+        draw_icon +: {
+            color: mod.widgets.RBX_FG_SECONDARY,
+        }
+    });
+}

--- a/src/shared/toggle_switch.rs
+++ b/src/shared/toggle_switch.rs
@@ -1,0 +1,41 @@
+//! ToggleSwitch — the iOS-style on/off switch for the redesigned (mobile)
+//! settings UI (spec §4.11).
+//!
+//! This is the built-in `Toggle` (a `CheckBox` variant that renders a sliding
+//! track + knob) restyled onto the `RBX_*` tokens: an off track of
+//! `RBX_STROKE_STRONG`, an on track of `RBX_ACCENT`, and a white knob in both
+//! states. Because it is a `CheckBox` under the hood, drive it in Rust via
+//! `view.check_box(cx, ids!(my_switch))`: `.changed(actions) -> Option<bool>`,
+//! `.active(cx) -> bool`, `.set_active(cx, bool, Animate::No)`.
+//!
+//! Usage (DSL): `my_switch := RbxToggle {}` (set `active: true` for default-on).
+//!
+//! NOTE: inside `script_mod!` only `//` comments are allowed.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.RbxToggle = Toggle {
+        width: Fit, height: Fit,
+        text: "",
+        active: false,
+
+        draw_bg +: {
+            size: 22.0
+            // off track
+            color: (RBX_STROKE_STRONG)
+            color_hover: (RBX_STROKE_STRONG)
+            color_down: (RBX_STROKE_STRONG)
+            border_color: (RBX_STROKE_STRONG)
+            // on track
+            color_active: (RBX_ACCENT)
+            border_color_active: (RBX_ACCENT)
+            // knob (white in both states)
+            mark_color: #fff
+            mark_color_active: #fff
+        }
+    }
+}


### PR DESCRIPTION
## What

Redesigns the **mobile** Settings UI toward the new "AI workspace" visual language (`docs/ui-visual-spec-zh.md` §5.1, matching the reference design). **Desktop is intentionally left unchanged this round.**

## How (architecture)

`SettingsScreen` and `AccountSettings` are now `AdaptiveView`-backed:
- `Desktop` variant = the original layout, verbatim → desktop renders exactly as before.
- `Mobile` variant = the redesign.
- Both variants reuse the **same child ids**, so all existing Rust logic drives whichever variant is live — no business-logic changes.
- Variant chosen via `ViewModeOverride::variant_selector()` (same pattern as `NavigationTabBar`), honoring Automatic / Force-wide / Force-narrow.

No `home_screen.rs` change was needed (the shared `CachedWidget` mount is untouched).

## Mobile changes

- Page canvas + "Settings" title + **text-only category tabs** (Account / Preferences / Devices / Labs / Contribute; selected = teal text).
- **Account** consolidated from 5 cards into one identity + accounts card plus a small actions card. Avatar upload/delete is hidden (desktop-only feature) and the non-functional "Manage Account" stub is dropped.
- **Contribute** re-skinned with the `SectionCard` recipe (white card + soft stroke).
- Preferences / Labs / Devices still embed the existing sub-widgets for now — to be re-skinned in follow-ups.

## New shared components

- `src/shared/status_badge.rs` — `RbxBadge{Success,Warning,Danger,Info,Neutral,Accent}` status pills.
- `src/shared/toggle_switch.rs` — `RbxToggle` (iOS-style switch on `RBX_*` tokens).
- `styles.rs` — `apply_accent_button_style`, `apply_segment_selected_style`, `apply_segment_idle_style`.

## Reviewer notes

- **AdaptiveView timing gotcha:** a variant is created on the next *draw* (not when `set_variant_selector` is called) and as a *fresh* widget. Work done in `populate()`/styling before the first draw lands on the soon-discarded default variant — this caused lost avatar/display-name and unstyled tabs. Fixed by re-applying labels + tab styling (`SettingsScreen`) and re-populating from the stored profile (`AccountSettings`) on a `NextFrame` after the swap.
- **Known gap:** Labs (`bot_settings` / `translation_settings`) can show empty fields on mobile until re-populate-on-tab is added — to be handled when Labs is re-skinned.
- No `cargo fmt` (per project convention). Tested manually on mobile (Force-narrow) and desktop.

## How to test

`cargo run` → open Settings via the profile avatar.
- Mobile (Force narrow or narrow window): new header, text tabs, consolidated Account; avatar/name load reliably.
- Desktop (Force wide / wide window): unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)