### PR TITLE
feat(agent): AgentRegistry data layer + global bot identification source

### DIFF
--- a/specs/task-agent-registry-bot-source.spec.md
+++ b/specs/task-agent-registry-bot-source.spec.md
@@ -1,0 +1,129 @@
+spec: task
+name: "AgentRegistry 数据层 + 全局 bot 识别源"
+inherits: project
+tags: [agent, registry, bot, persistence, timeline, data-layer]
+estimate: 1d
+---
+
+## Intent
+
+为 Robrix2 的 agent 体系打地基:在 `AppState` 中新增并持久化 `AgentRegistry`，
+作为全局 agent 身份的真相源，并把现有房间级 `known_bot_user_ids` 提升为全局识别来源——
+timeline 的 bot 识别从"只认房间级 known_bot_user_ids"改为"认 AgentRegistry ∪ known_bot_user_ids"。
+这是 P0-A Agent 配置中心的依赖根(清单第 2、5、6 条);它不含任何列表 / 表单 / CRUD 界面,
+也不动 Settings,只交付数据模型、迁移、并集识别与 per-account 持久化。
+
+## Constraints
+
+- `AgentRegistry` 必须作为 `AppState` 的新字段持久化，复用既有 `latest_app_state.json` per-account 机制(`persistent_state_dir(user_id)`)，不得新建独立存储文件或目录
+- 新字段必须标注 `#[serde(default)]`，使缺少该字段的旧 `AppState` JSON 反序列化为空 registry 而不报错
+- 不得删除、重命名或停用现有 `known_bot_user_ids` 字段及其读写路径——`bot_binding_modal.rs` / BotFather 流程仍依赖它
+- timeline bot 识别必须取 `AgentRegistry ∪ known_bot_user_ids` 的并集，确保现有房间级识别不回退
+
+## Decisions
+
+- 存放位置:`AgentRegistry` 作为 `AppState` 新增字段 `#[serde(default)] pub agent_registry: AgentRegistry`，随既有 `save_app_state` / `load_app_state` 自动持久化
+- 数据模型:`AgentRegistry` 内部为 `BTreeMap<OwnedUserId, AgentEntry>`，key = `agent_mxid`;`BTreeMap` 保证去重与确定性 serde 顺序(便于 round-trip 单测)
+- `AgentEntry` 字段:`display_name: Option<String>`、`framework: AgentFramework`、`avatar: Option<OwnedMxcUri>`、`capabilities: Vec<AgentCapability>`、`trust_tier: TrustTier`
+- `AgentFramework` 枚举含 `Unknown`(默认)、`Octos`、`Hermes`、`OpenClaw` 变体;`TrustTier` 默认取最低信任档;`capabilities` 默认为空 `Vec`
+- 迁移:加载后若 `agent_registry` 为空，则用现有 `known_bot_user_ids` 播种——每个 mxid 生成 `framework: Unknown`、其余字段默认的 `AgentEntry`;已存在的 mxid 条目不被覆盖
+- 刀4 注入点:`room_screen.rs` 中现有以 `known_bot_user_ids: &[OwnedUserId]` 计算 `is_bot_sender` 的 sender 匹配 helper，改为同时查询 `AgentRegistry`，返回两者并集的判定
+- 损坏回退:沿用 `load_app_state` 既有行为——反序列化失败时回退 `AppState::default()` 并备份旧文件，不 panic
+
+## Boundaries
+
+### Allowed Changes
+- src/app.rs
+- src/home/room_screen.rs
+- src/persistence/app_state.rs
+- specs/task-agent-registry-bot-source.spec.md
+
+### Forbidden
+- 不要新增 agent 列表 / 表单 / 增删改的 UI 组件
+- 不要修改 `src/home/settings_screen.rs`
+- 不要删除 / 重命名 `known_bot_user_ids` 或其读写方法
+- 不要改动 `bot_binding_modal.rs` / `create_bot_modal.rs` / BotFather 业务流
+- 不要新建独立持久化文件或目录
+- 不要新增 cargo 依赖
+- 不要运行 `cargo fmt`
+
+## Out of Scope
+
+- 清单第 1 条:Lab / Settings 中的 Agent 配置中心 UI(列表 / 详情表单 / 增删改入口)
+- 清单第 3 条:绑定已有 Matrix 账号为 agent
+- 清单第 4 条:接入 BotFather 创建 bot 流程
+- CapabilityChip 等渲染 framework / trust_tier / capabilities 的可视组件
+- avatar 的实际拉取与渲染、capabilities 与 trust_tier 的界面展示
+
+## Completion Criteria
+
+场景: AgentRegistry serde round-trip 保持相等
+  测试: test_agent_registry_serde_roundtrip
+  假设 一个含两个 AgentEntry 的 AgentRegistry
+  当 将其序列化为 JSON 再反序列化
+  那么 反序列化结果与原 registry 相等
+  并且 两个条目的 framework 与 trust_tier 字段值保持不变
+
+场景: 迁移把 known_bot_user_ids 播种为 Unknown framework 条目
+  测试: test_migrate_known_bots_into_registry_as_unknown_framework
+  假设 AppState 的 agent_registry 为空且 known_bot_user_ids 含以下 mxid:
+    | mxid                  |
+    | @botA:example.org     |
+    | @botB:example.org     |
+  当 执行 registry 迁移播种
+  那么 agent_registry 含 "@botA:example.org" 且其 framework 为 Unknown
+  并且 agent_registry 含 "@botB:example.org" 且其 framework 为 Unknown
+
+场景: registry 中的 agent 在 timeline 被识别为 bot sender
+  测试: test_registry_agent_detected_as_bot_sender
+  假设 known_bot_user_ids 为空
+  并且 agent_registry 含 "@agent:example.org"
+  当 对 sender "@agent:example.org" 计算 is_bot_sender
+  那么 is_bot_sender 为 true
+
+场景: AgentRegistry 按账号持久化且不跨账号串号
+  测试: test_agent_registry_persists_per_account_no_cross_leak
+  假设 账号 "@alice:example.org" 的 `AgentRegistry` 含 "@agent:example.org"
+  并且 账号 "@bob:example.org" 的 `AgentRegistry` 为空
+  当 分别把两个账号的 `AppState` 持久化到各自的 `persistent_state_dir(user_id)` 再各自加载
+  那么 "@alice:example.org" 加载后的 `AgentRegistry` 含 "@agent:example.org"
+  并且 "@bob:example.org" 加载后的 `AgentRegistry` 为空
+
+场景: 旧 AppState JSON 缺少 agent_registry 字段反序列化为空 registry
+  测试: test_load_legacy_app_state_without_registry_field_defaults_empty
+  假设 一段不含 "agent_registry" 键的旧 AppState JSON
+  当 反序列化为 AppState
+  那么 反序列化成功且不 panic
+  并且 agent_registry 条目数量为 0
+
+场景: 重复 mxid 注册保持幂等
+  测试: test_register_duplicate_mxid_is_idempotent
+  假设 agent_registry 已含 "@agent:example.org"
+  当 再次以相同 mxid 注册一个 AgentEntry
+  那么 agent_registry 中该 mxid 仅有 1 个条目
+
+场景: 普通用户不被误判为 bot sender
+  测试: test_non_agent_user_not_detected_as_bot
+  假设 known_bot_user_ids 为空且 agent_registry 为空
+  当 对 sender "@human:example.org" 计算 is_bot_sender
+  那么 is_bot_sender 为 false
+
+场景: 空 registry 且无 known bot 时 timeline 不显示 bot 卡
+  测试: test_empty_registry_and_no_known_bots_shows_no_bot_card
+  假设 agent_registry 为空且 known_bot_user_ids 为空
+  当 对任一 sender 计算 timeline bot 渲染状态
+  那么 show_card 为 false
+
+场景: 迁移后 known_bot_user_ids 字段仍保留不被清空
+  测试: test_migration_preserves_known_bot_user_ids
+  假设 `known_bot_user_ids` 含 "@botA:example.org"
+  当 执行 registry 迁移播种后读取 `known_bot_user_ids`
+  那么 `known_bot_user_ids` 仍含 "@botA:example.org"
+  并且 `known_bot_user_ids` 条目数量不为 0
+
+场景: 损坏的 agent_registry JSON 回退到默认 AppState
+  测试: test_corrupt_registry_json_falls_back_to_default_state
+  假设 持久化文件中的 agent_registry 字段为结构损坏的 JSON
+  当 调用 load_app_state 加载该账号状态
+  那么 返回默认 AppState 且不 panic
+  并且 旧的损坏文件被备份保留

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,12 +6,12 @@
 use std::{fs::{File, OpenOptions}, io::Write, sync::Mutex};
 use std::{
     cell::RefCell,
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::{hash_map::DefaultHasher, BTreeMap, HashMap},
     hash::{Hash, Hasher},
     time::Duration,
 };
 use makepad_widgets::*;
-use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId, events::room::message::RoomMessageEventContent}};
+use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, UserId, events::room::message::RoomMessageEventContent}};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use crate::{
@@ -2573,9 +2573,136 @@ pub struct AppState {
     pub adding_account: bool,
     /// Local configuration and UI state for bot-assisted room binding.
     pub bot_settings: BotSettingsState,
+    /// Global source of truth for agent identities, keyed by agent MXID.
+    ///
+    /// Persisted per Matrix account. Old saved states that predate this field
+    /// deserialize to an empty registry via `#[serde(default)]`.
+    #[serde(default)]
+    pub agent_registry: AgentRegistry,
     /// Translation API configuration.
     #[serde(default)]
     pub translation: crate::room::translation::TranslationConfig,
+}
+
+/// The framework / runtime an agent is built on.
+///
+/// Agents migrated from the legacy known-bot list start as `Unknown`; the
+/// binding and BotFather-creation slices set a concrete framework when known.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentFramework {
+    /// Framework not yet identified.
+    #[default]
+    Unknown,
+    /// Octos app-service backed agent.
+    Octos,
+    /// Hermes external client integration.
+    Hermes,
+    /// OpenClaw external client integration.
+    OpenClaw,
+}
+
+/// How much the local user trusts an agent. The lowest tier is the default;
+/// higher tiers are added by the slice that lets the user grant trust.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TrustTier {
+    /// Default, least-privileged tier.
+    #[default]
+    Untrusted,
+}
+
+/// A single capability an agent advertises (free-form tag).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentCapability(pub String);
+
+/// A registered agent's metadata, keyed in [`AgentRegistry`] by its Matrix user ID.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct AgentEntry {
+    /// Human-readable name, if known.
+    pub display_name: Option<String>,
+    /// The framework / runtime backing this agent.
+    pub framework: AgentFramework,
+    /// Avatar MXC URI, if known.
+    pub avatar: Option<OwnedMxcUri>,
+    /// Capabilities the agent advertises.
+    pub capabilities: Vec<AgentCapability>,
+    /// Local trust level for this agent.
+    pub trust_tier: TrustTier,
+}
+
+/// Global source of truth for agent identities, persisted per Matrix account
+/// as part of [`AppState`]. Keyed by agent MXID for dedup and deterministic order.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct AgentRegistry {
+    agents: BTreeMap<OwnedUserId, AgentEntry>,
+}
+
+impl AgentRegistry {
+    /// Returns `true` if no agents are registered.
+    pub fn is_empty(&self) -> bool {
+        self.agents.is_empty()
+    }
+
+    /// Returns the number of registered agents.
+    pub fn len(&self) -> usize {
+        self.agents.len()
+    }
+
+    /// Returns `true` if an agent with the given MXID is registered.
+    pub fn contains(&self, user_id: &UserId) -> bool {
+        self.agents
+            .keys()
+            .any(|registered| registered.as_str() == user_id.as_str())
+    }
+
+    /// Returns the entry for the given MXID, if registered.
+    pub fn get(&self, user_id: &UserId) -> Option<&AgentEntry> {
+        self.agents
+            .iter()
+            .find(|(registered, _)| registered.as_str() == user_id.as_str())
+            .map(|(_, entry)| entry)
+    }
+
+    /// Registers an agent, keeping any existing entry for the same MXID (idempotent).
+    ///
+    /// Returns `true` if a new entry was inserted, `false` if one already existed.
+    pub fn register(&mut self, user_id: OwnedUserId, entry: AgentEntry) -> bool {
+        use std::collections::btree_map::Entry;
+        match self.agents.entry(user_id) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(entry);
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
+    }
+
+    /// All registered agent MXIDs, in deterministic (sorted) order.
+    pub fn agent_user_ids(&self) -> Vec<OwnedUserId> {
+        self.agents.keys().cloned().collect()
+    }
+}
+
+impl AppState {
+    /// Migration: if the agent registry is empty, seed it from the legacy
+    /// per-account known-bot list so upgraded users keep bot identification.
+    ///
+    /// Existing registry entries are never overwritten, and the legacy
+    /// `known_bot_user_ids` list is left intact (other flows still rely on it).
+    pub fn seed_agent_registry_from_known_bots(&mut self) {
+        if self.agent_registry.is_empty() {
+            for bot_user_id in self.bot_settings.known_bot_user_ids() {
+                self.agent_registry.register(
+                    bot_user_id,
+                    AgentEntry {
+                        framework: AgentFramework::Unknown,
+                        ..Default::default()
+                    },
+                );
+            }
+        }
+    }
 }
 
 /// Local bot integration settings persisted per Matrix account.
@@ -3124,9 +3251,106 @@ impl Eq for SelectedRoom {}
 
 #[cfg(test)]
 mod tests {
-    use super::{AppState, BotSettingsState, RoomBotBindingState, SavedDockState, SelectedRoom};
+    use super::{
+        AgentCapability, AgentEntry, AgentFramework, AgentRegistry, AppState, BotSettingsState,
+        RoomBotBindingState, SavedDockState, SelectedRoom, TrustTier,
+    };
     use crate::utils::RoomNameId;
     use matrix_sdk::{RoomDisplayName, ruma::{OwnedEventId, OwnedRoomId, OwnedUserId, UserId}};
+
+    #[test]
+    fn test_agent_registry_serde_roundtrip() {
+        let id_a: OwnedUserId = "@octosbot:example.org".try_into().unwrap();
+        let id_b: OwnedUserId = "@helper:example.org".try_into().unwrap();
+        let mut registry = AgentRegistry::default();
+        registry.register(id_a.clone(), AgentEntry {
+            display_name: Some("Octos".into()),
+            framework: AgentFramework::Octos,
+            avatar: Some("mxc://example.org/abc".try_into().unwrap()),
+            capabilities: vec![AgentCapability("translate".into())],
+            trust_tier: TrustTier::Untrusted,
+        });
+        registry.register(id_b.clone(), AgentEntry {
+            display_name: None,
+            framework: AgentFramework::Unknown,
+            trust_tier: TrustTier::Untrusted,
+            ..Default::default()
+        });
+
+        let json = serde_json::to_vec(&registry).unwrap();
+        let restored: AgentRegistry = serde_json::from_slice(&json).unwrap();
+
+        assert_eq!(restored, registry);
+        let entry_a = restored.get(id_a.as_ref()).unwrap();
+        assert_eq!(entry_a.display_name.as_deref(), Some("Octos"));
+        assert_eq!(entry_a.capabilities, vec![AgentCapability("translate".into())]);
+        assert_eq!(entry_a.framework, AgentFramework::Octos);
+        assert_eq!(entry_a.trust_tier, TrustTier::Untrusted);
+        assert_eq!(restored.get(id_b.as_ref()).unwrap().display_name, None);
+    }
+
+    #[test]
+    fn test_migrate_known_bots_into_registry_as_unknown_framework() {
+        let mut app_state = AppState::default();
+        app_state.bot_settings.record_known_bot_user_ids(vec![
+            "@botA:example.org".try_into().unwrap(),
+            "@botB:example.org".try_into().unwrap(),
+        ]);
+
+        app_state.seed_agent_registry_from_known_bots();
+
+        let bot_a: OwnedUserId = "@botA:example.org".try_into().unwrap();
+        let bot_b: OwnedUserId = "@botB:example.org".try_into().unwrap();
+        assert!(app_state.agent_registry.contains(bot_a.as_ref()));
+        assert_eq!(
+            app_state.agent_registry.get(bot_a.as_ref()).unwrap().framework,
+            AgentFramework::Unknown,
+        );
+        assert!(app_state.agent_registry.contains(bot_b.as_ref()));
+        assert_eq!(
+            app_state.agent_registry.get(bot_b.as_ref()).unwrap().framework,
+            AgentFramework::Unknown,
+        );
+        assert_eq!(app_state.agent_registry.len(), 2);
+    }
+
+    #[test]
+    fn test_migration_preserves_known_bot_user_ids() {
+        let mut app_state = AppState::default();
+        app_state.bot_settings.record_known_bot_user_ids(vec![
+            "@botA:example.org".try_into().unwrap(),
+        ]);
+
+        app_state.seed_agent_registry_from_known_bots();
+
+        let known = app_state.bot_settings.known_bot_user_ids();
+        assert!(known.iter().any(|id| id.as_str() == "@botA:example.org"));
+        assert!(!known.is_empty());
+    }
+
+    #[test]
+    fn test_load_legacy_app_state_without_registry_field_defaults_empty() {
+        // A previously-saved AppState JSON that predates the agent_registry field.
+        let legacy_json =
+            r#"{"logged_in":true,"bot_settings":{"enabled":true,"known_bot_user_ids":["@botA:example.org"]}}"#;
+        let app_state: AppState = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(app_state.agent_registry.len(), 0);
+        assert!(app_state.logged_in);
+    }
+
+    #[test]
+    fn test_register_duplicate_mxid_is_idempotent() {
+        let id: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut registry = AgentRegistry::default();
+        assert!(registry.register(id.clone(), AgentEntry::default()));
+        assert!(!registry.register(id.clone(), AgentEntry {
+            display_name: Some("changed".into()),
+            ..Default::default()
+        }));
+        assert_eq!(registry.len(), 1);
+        // The first entry is preserved, not overwritten by the duplicate register.
+        assert_eq!(registry.get(id.as_ref()).unwrap().display_name, None);
+    }
 
     fn joined_room(room_id_str: &str, name: &str) -> SelectedRoom {
         SelectedRoom::JoinedRoom {

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1424,6 +1424,30 @@ fn collect_room_bot_user_ids(
     room_bot_user_ids
 }
 
+/// Returns the set of MXIDs the timeline should treat as bots: the union of the
+/// app-service known-bot list (only when app-service is enabled) and every agent
+/// registered in the global [`AgentRegistry`] (always, independent of app-service).
+fn timeline_known_bot_user_ids(app_state: &AppState) -> Vec<OwnedUserId> {
+    let mut bot_user_ids = if app_state.bot_settings.enabled {
+        app_state.bot_settings.known_bot_user_ids()
+    } else {
+        Vec::new()
+    };
+    for agent_user_id in app_state.agent_registry.agent_user_ids() {
+        if bot_user_ids
+            .iter()
+            .all(|existing| existing.as_str() != agent_user_id.as_str())
+        {
+            bot_user_ids.push(agent_user_id);
+        }
+    }
+    bot_user_ids
+}
+
+fn room_props_known_bot_user_ids(app_state: &AppState) -> Vec<OwnedUserId> {
+    timeline_known_bot_user_ids(app_state)
+}
+
 fn compute_timeline_bot_context(
     app_state: Option<&AppState>,
     room_id: &OwnedRoomId,
@@ -1445,11 +1469,10 @@ fn compute_timeline_bot_context(
             } else {
                 None
             };
-            let known_bot_user_ids = if app_service_enabled {
-                app_state.bot_settings.known_bot_user_ids()
-            } else {
-                Vec::new()
-            };
+            // Union of the (app-service-gated) known-bot list and the global
+            // AgentRegistry, so registry agents are recognized even when the
+            // app-service integration is disabled.
+            let known_bot_user_ids = timeline_known_bot_user_ids(app_state);
             let room_bot_user_ids = room_members
                 .map(|members|
                     collect_room_bot_user_ids(
@@ -6344,11 +6367,7 @@ impl RoomScreen {
                     } else {
                         None
                     };
-                    let known_bot_user_ids = if app_service_enabled {
-                        app_state.bot_settings.known_bot_user_ids()
-                    } else {
-                        Vec::new()
-                    };
+                    let known_bot_user_ids = room_props_known_bot_user_ids(app_state);
                     let has_persisted_management_binding = resolved_parent_bot_user_id
                         .as_ref()
                         .is_some_and(|resolved_parent_bot_user_id|
@@ -12890,6 +12909,55 @@ mod tests {
             &room_bot_user_ids,
             &known_bot_user_ids,
         ));
+    }
+
+    #[test]
+    fn test_registry_agent_detected_as_bot_sender() {
+        // An agent known only via the global AgentRegistry (not the app-service
+        // known-bot list, and with a non-bot-like localpart) is still detected.
+        let agent_id: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state
+            .agent_registry
+            .register(agent_id.clone(), crate::app::AgentEntry::default());
+
+        let known_bot_user_ids = timeline_known_bot_user_ids(&app_state);
+        assert!(is_known_or_likely_bot(agent_id.as_ref(), None, &known_bot_user_ids));
+    }
+
+    #[test]
+    fn test_room_props_known_bot_user_ids_include_registry_agents() {
+        let agent_id: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state
+            .agent_registry
+            .register(agent_id.clone(), crate::app::AgentEntry::default());
+
+        let known_bot_user_ids = room_props_known_bot_user_ids(&app_state);
+
+        assert!(known_bot_user_ids.iter().any(|id| id == &agent_id));
+    }
+
+    #[test]
+    fn test_non_agent_user_not_detected_as_bot() {
+        // Empty registry, empty known-bot list, app-service disabled.
+        let app_state = AppState::default();
+        let human_id: OwnedUserId = "@human:example.org".try_into().unwrap();
+
+        let known_bot_user_ids = timeline_known_bot_user_ids(&app_state);
+        assert!(!is_known_or_likely_bot(human_id.as_ref(), None, &known_bot_user_ids));
+    }
+
+    #[test]
+    fn test_empty_registry_and_no_known_bots_shows_no_bot_card() {
+        let app_state = AppState::default();
+        let known_bot_user_ids = timeline_known_bot_user_ids(&app_state);
+        assert!(known_bot_user_ids.is_empty());
+
+        let sender_id: OwnedUserId = "@someone:example.org".try_into().unwrap();
+        let is_bot_sender = is_known_or_likely_bot(sender_id.as_ref(), None, &known_bot_user_ids);
+        let render_state = compute_bot_timeline_render_state("hello", is_bot_sender);
+        assert!(!render_state.show_card);
     }
 
     #[test]

--- a/src/persistence/app_state.rs
+++ b/src/persistence/app_state.rs
@@ -98,24 +98,38 @@ pub async fn load_app_state(user_id: &UserId) -> anyhow::Result<AppState> {
         }
         Err(e) => return Err(e.into())
     };
-    match serde_json::from_slice(&file_bytes) {
+    let mut app_state = deserialize_app_state_or_recover(&file_bytes, &state_path);
+    // Migration: upgraded users with a legacy known-bot list but no registry
+    // get their bots seeded into the global AgentRegistry on load.
+    app_state.seed_agent_registry_from_known_bots();
+    Ok(app_state)
+}
+
+/// Deserializes persisted app-state bytes, or — when the bytes are unreadable
+/// (e.g. an incompatible format from a previous version) — backs up the file
+/// and returns a default [`AppState`]. Never panics.
+fn deserialize_app_state_or_recover(
+    file_bytes: &[u8],
+    state_path: &std::path::Path,
+) -> AppState {
+    match serde_json::from_slice(file_bytes) {
         Ok(app_state) => {
             log!("Successfully loaded app state from persistent storage.");
-            Ok(app_state)
+            app_state
         }
         Err(e) => {
             error!("Failed to deserialize app state: {e}. This may be due to an incompatible format from a previous version.");
 
-            // Backup the old file to preserve user's data
+            // Backup the old file to preserve user's data.
             let backup_path = state_path.with_extension("json.bak");
-            if let Err(backup_err) = tokio::fs::rename(&state_path, &backup_path).await {
+            if let Err(backup_err) = std::fs::rename(state_path, &backup_path) {
                 error!("Failed to backup old app state file: {}", backup_err);
             } else {
                 log!("Old app state backed up to: {:?}", backup_path);
             }
 
             log!("Using default app state. Your previous tabs and selections will be reset.");
-            Ok(AppState::default())
+            AppState::default()
         }
     }
 }
@@ -142,4 +156,61 @@ pub fn load_window_state(window_ref: WindowRef, cx: &mut Cx) -> anyhow::Result<(
         "Robrix".to_string(),
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::AgentEntry;
+
+    #[tokio::test]
+    async fn test_agent_registry_persists_per_account_no_cross_leak() {
+        let alice: OwnedUserId = "@agent-registry-alice:example.org".try_into().unwrap();
+        let bob: OwnedUserId = "@agent-registry-bob:example.org".try_into().unwrap();
+        let _ = std::fs::remove_dir_all(persistent_state_dir(alice.as_ref()));
+        let _ = std::fs::remove_dir_all(persistent_state_dir(bob.as_ref()));
+
+        // Distinct accounts map to distinct storage paths, so one account's
+        // saved state can never overwrite another's.
+        assert_ne!(persistent_state_dir(&alice), persistent_state_dir(&bob));
+
+        let mut alice_state = AppState::default();
+        let agent: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        alice_state
+            .agent_registry
+            .register(agent.clone(), AgentEntry::default());
+        let bob_state = AppState::default();
+
+        save_app_state(alice_state, alice.clone()).unwrap();
+        save_app_state(bob_state, bob.clone()).unwrap();
+
+        let alice_loaded = load_app_state(alice.as_ref()).await.unwrap();
+        let bob_loaded = load_app_state(bob.as_ref()).await.unwrap();
+
+        assert!(alice_loaded.agent_registry.contains(agent.as_ref()));
+        assert!(bob_loaded.agent_registry.is_empty());
+
+        let _ = std::fs::remove_dir_all(persistent_state_dir(alice.as_ref()));
+        let _ = std::fs::remove_dir_all(persistent_state_dir(bob.as_ref()));
+    }
+
+    #[tokio::test]
+    async fn test_corrupt_registry_json_falls_back_to_default_state() {
+        let user_id: OwnedUserId = "@agent-registry-corrupt:example.org".try_into().unwrap();
+        let dir = persistent_state_dir(user_id.as_ref());
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let state_path = dir.join(LATEST_APP_STATE_FILE_NAME);
+        let corrupt = br#"{"agent_registry": this is not valid json"#;
+        std::fs::write(&state_path, corrupt).unwrap();
+
+        let recovered = load_app_state(user_id.as_ref()).await.unwrap();
+
+        // Falls back to a default AppState (empty registry) without panicking.
+        assert_eq!(recovered.agent_registry.len(), 0);
+        // The unreadable file is preserved as a backup.
+        assert!(state_path.with_extension("json.bak").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

Introduces **AgentRegistry** as the per-account source of truth for agent identities (P0-A checklist items 2, 5, and 6). The registry is persisted in `AppState`, and room-level `known_bot_user_ids` are promoted into a global bot-identification source. This PR is intentionally **data layer + detection wiring only**: no UI, no CRUD surface, and no Settings changes.

## Changes

- **Data model** (`app.rs`): adds `AppState.agent_registry` backed by `AgentRegistry { BTreeMap<OwnedUserId, AgentEntry> }`; adds `AgentEntry { display_name, framework, avatar, capabilities, trust_tier }`; adds `AgentFramework = Unknown | Octos | Hermes | OpenClaw`.
- **Persistence**: reuses the existing per-account `latest_app_state.json` mechanism; `#[serde(default)]` keeps older saved states without `agent_registry` loading cleanly.
- **Migration** (`app.rs` / `app_state.rs`): when loading state with an empty registry, seeds it from existing `known_bot_user_ids` using `framework: Unknown`; existing registry entries are not overwritten, and `known_bot_user_ids` is preserved.
- **Global bot identification** (`room_screen.rs`): timeline bot detection now uses `AgentRegistry ∪ known_bot_user_ids`; registry-based detection is independent of the app-service toggle, while existing room-level detection remains intact.

## Contract And Tests

- Spec: `specs/task-agent-registry-bot-source.spec.md` with 10 scenarios; `agent-spec lint` score is 100%.
- Bound tests cover serde round-trip, migration, union-based detection, per-account persistence, legacy-state compatibility, idempotent duplicate registration, non-agent false positives, empty-state rendering, corrupt-state recovery, and preserving `known_bot_user_ids`.
- Current verification: `cargo build`, `cargo test --lib`, `git diff --check`, and the task `agent-spec lifecycle` pass.

## Out Of Scope

The Labs Agent configuration center UI, binding existing Matrix accounts as agents, BotFather creation flow integration, and CapabilityChip-style visual components are intentionally left for later slices.
