### PR TITLE
fix(room-filter): open search result on click

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -837,7 +837,7 @@ impl MatchEvent for App {
                 continue;
             }
 
-            if let RoomFilterResultAction::Clicked(target) = action.as_widget_action().cast() {
+            if let Some(RoomFilterResultAction::Clicked(target)) = action.downcast_ref::<RoomFilterResultAction>() {
                 self.ui.modal(cx, ids!(room_filter_modal)).close(cx);
                 match target {
                     RoomFilterResultTarget::LocalSpace { room_name_id: space_name_id, .. }


### PR DESCRIPTION
## Problem
Clicking a result in the room-filter search popup (the 🔍 search over "All Rooms") did nothing — no room opened, no DM started — for rooms, spaces, and users alike.

## Root cause
`RoomFilterSearchResultItem` emits `RoomFilterResultAction::Clicked` via `cx.action()` (a plain action), but `App::handle_actions` received it with `action.as_widget_action().cast()`, which only resolves **widget** actions. A plain action never matches that path, so the `if let` never fired and the click was silently dropped.

## Fix
Receive the action with `action.downcast_ref::<RoomFilterResultAction>()` (the plain-action channel, matching the sender). The existing `match` arms already clone their fields, so switching `target` to a reference needs no other changes.

## Verification
- `cargo check` passes.
- Manually verified: searching a user (`@octos:...`) and clicking the result now opens/creates the DM as intended.