### PR TITLE
style(room-screen): reduce bot message card corner radius

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2081,7 +2081,7 @@ script_mod! {
                         show_bg: true
                         draw_bg +: {
                             color: (mod.widgets.COLOR_BOT_CARD_BG)
-                            border_radius: 14.0
+                            border_radius: 6.0
                             border_size: 1.0
                             border_color: (mod.widgets.COLOR_BOT_CARD_BORDER)
                         }
@@ -2273,7 +2273,7 @@ script_mod! {
                         show_bg: true
                         draw_bg +: {
                             color: (mod.widgets.COLOR_BOT_CARD_BG)
-                            border_radius: 14.0
+                            border_radius: 6.0
                             border_size: 1.0
                             border_color: (mod.widgets.COLOR_BOT_CARD_BORDER)
                         }


### PR DESCRIPTION
## What
Lower the bot message bubble (`bot_body_card`) corner radius from `border_radius: 14.0` to `6.0`, on both the desktop and adaptive layout variants.

## Why
14.0 looked overly round on the short bot reply cards (e.g. "DONE", "Hi! What can I help you with?"). 6.0 matches the existing message bubble radius used in `html_or_plaintext` for a cleaner, more consistent look.

## Scope
Single property change, two occurrences (desktop + adaptive). `cargo check` passes. Verified visually in-app.