### PR TITLE
feat(mobile): enable and refine room/people search on mobile

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ use crate::{
     }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, register::RegisterAction, room::BasicRoomDetails, shared::{confirmation_modal::{ConfirmationModalAction, ConfirmationModalContent, ConfirmationModalWidgetRefExt}, file_upload_modal::{FilePreviewerAction, FileUploadModalWidgetRefExt}, forward_modal::{ForwardMessageModalAction, ForwardMessageModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}, room_filter_input_bar::FilterAction}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, RemoteDirectorySearchKind, RemoteDirectorySearchResult, RoomSettingsFetchedAction, RoomAvatarUploadedAction, TimelineKind, AccountSwitchAction, current_user_id, get_client, submit_async_request, get_timeline_update_sender}, updater::{UpdateCheckOutcome, check_for_updates, load_skipped_update_version, save_skipped_update_version, update_release_page_url}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
-    }, settings::app_preferences::{AppPreferences, AppPreferencesAction, UiZoom}
+    }, settings::app_preferences::{AppPreferences, AppPreferencesAction, UiZoom, effective_is_desktop}
 };
 use crate::shared::room_filter_search_results::{RoomFilterResultAction, RoomFilterResultTarget};
 use crate::shared::room_filter_search_results::RoomFilterSearchResultsListWidgetRefExt;
@@ -1290,6 +1290,21 @@ impl MatchEvent for App {
             }
 
             if let Some(RoomsListHeaderAction::OpenRoomFilterModal) = action.downcast_ref() {
+                // Adapt the search modal to the platform: on mobile use a narrower
+                // width (screen minus side margins) and a shorter results area to
+                // avoid a large mostly-empty modal; on desktop keep 420 x 260.
+                // Numeric width avoids Fill collapsing to 0 in the modal's context.
+                let is_desktop = effective_is_desktop(cx);
+                let modal_width = if is_desktop { 420.0_f64 } else { (cx.display_context.screen_size.x - 24.0).max(280.0) };
+                let results_height = if is_desktop { 260.0_f64 } else { 180.0_f64 };
+                let mut modal_inner = self.ui.view(cx, ids!(room_filter_modal_inner));
+                script_apply_eval!(cx, modal_inner, {
+                    width: #(modal_width)
+                });
+                let mut results_scroll = self.ui.view(cx, ids!(room_filter_modal_inner.search_results_scroll));
+                script_apply_eval!(cx, results_scroll, {
+                    height: #(results_height)
+                });
                 self.ui.modal(cx, ids!(room_filter_modal)).open(cx);
                 let room_filter_input = self.ui.text_input(cx, ids!(room_filter_modal_inner.room_filter_input_bar.input));
                 room_filter_input.set_key_focus(cx);

--- a/src/home/rooms_sidebar.rs
+++ b/src/home/rooms_sidebar.rs
@@ -97,8 +97,9 @@ script_mod! {
                 }
 
                 rooms_list_header := RoomsListHeader {
+                    spacing: 10
                     open_room_filter_modal_button +: {
-                        visible: false
+                        visible: true
                     }
                 }
 


### PR DESCRIPTION
## Summary
Re-enables and polishes the room/people search on **mobile**. Previously the mobile rooms list had no way to search rooms/people or start a DM — the search modal button was hidden as a "TODO" back in #105. Its core defect (clicking a result did nothing) was fixed in #198, so the modal now works; this PR turns it back on for mobile and adapts it to the narrow layout.

## Changes
1. **Show the search button on mobile** — `rooms_sidebar.rs`: the `open_room_filter_modal_button` (🔍) in the mobile `RoomsListHeader` is now `visible: true`.
2. **Optimize the header layout on mobile** — increase header button `spacing` (3 → 10) so the directory / search / sync icons are no longer cramped (mobile instance override only; desktop unchanged).
3. **Optimize the search modal on mobile** — on open, size it per platform: mobile uses a narrower width (`screen_width - 24` for side margins) and a shorter results area (180 vs 260) to avoid a large mostly-empty modal. **Desktop keeps 420 × 260 unchanged.** Width is applied as a numeric value via `script_apply_eval!` because `Fill` collapses to 0 in this modal's content context.

## Notes
- Re-enables what @tyreseluo intentionally hid in #105 ("hide TODO search") — flagging for review since the original concern was an incomplete mobile search; the result-click fix (#198) addressed the core gap.
- Message-content search (`SearchMessagesButton`) is **not** part of this PR; still mobile-hidden.

## Verification
- `cargo check` passes.
- Verified on a real Android device: 🔍 appears, searching `@octos:...` and tapping the result opens the DM, modal has side margins and reduced height, desktop modal unchanged by construction.