### PR TITLE
fix(clippy): resolve derivable_impls and needless_borrow warnings

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -8058,7 +8058,7 @@ impl RoomScreen {
                 }
                 MessageAction::CancelDownload(mxc) => {
                     if let Some(tl) = self.tl_state.as_mut()
-                        && reset_pending_download(&mut tl.pending_downloads, &mxc)
+                        && reset_pending_download(&mut tl.pending_downloads, mxc)
                     {
                         tl.content_drawn_since_last_update.clear();
                         portal_list.redraw(cx);

--- a/src/settings/app_preferences.rs
+++ b/src/settings/app_preferences.rs
@@ -4,6 +4,7 @@ use makepad_widgets::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct AppPreferences {
     #[serde(default)]
     pub view_mode: ViewModeOverride,
@@ -20,17 +21,6 @@ pub struct AppPreferences {
     pub agent_chat_enabled: bool,
 }
 
-impl Default for AppPreferences {
-    fn default() -> Self {
-        Self {
-            view_mode: ViewModeOverride::default(),
-            send_on_enter: false,
-            thumbnail_max_height: ThumbnailMaxHeight::default(),
-            ui_zoom: UiZoom::default(),
-            agent_chat_enabled: false,
-        }
-    }
-}
 
 impl AppPreferences {
     pub fn on_view_mode_changed(&self, cx: &mut Cx) {


### PR DESCRIPTION
Two pre-existing clippy warnings, fixed mechanically (`cargo clippy --fix`):

- **`src/settings/app_preferences.rs`** — `impl Default for AppPreferences` replaced with `#[derive(Default)]` (`clippy::derivable_impls`). All fields' derived defaults match the previous manual values (bools default to `false`, others use `::default()`).
- **`src/home/room_screen.rs`** — drop a needless borrow `&mxc` → `mxc` (`clippy::needless_borrow`).

`cargo clippy` now reports **0 warnings**; `cargo check` passes.