### PR TITLE
fix(room-screen): stop white-flash on send/receive from transient timeline clear

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -6857,11 +6857,21 @@ impl RoomScreen {
                     if new_items.is_empty() {
                         if !tl.items.is_empty() {
                             log!("process_timeline_updates(): timeline (had {} items) was cleared for room {}", tl.items.len(), tl.kind.room_id());
-                            // For now, we paginate a cleared timeline in order to be able to show something at least.
-                            // A proper solution would be what's described below, which would be to save a few event IDs
-                            // and then either focus on them (if we're not close to the end of the timeline)
-                            // or paginate backwards until we find them (only if we are close the end of the timeline).
+                            // The matrix SDK frequently emits a *transient* `Clear` (an empty
+                            // snapshot) immediately before re-pushing the rebuilt timeline --
+                            // e.g. on every message send/receive in some sliding-sync setups.
+                            // If we applied this empty snapshot, the portal list would render
+                            // nothing for a frame or two, exposing the near-white room
+                            // background as a jarring "white flash", and we'd blank the viewport
+                            // before the rebuilt items arrive.
+                            //
+                            // Instead, keep the currently-rendered items in place and skip
+                            // applying this empty snapshot entirely. We still kick off a
+                            // backwards pagination so a genuinely-cleared timeline can be
+                            // refilled; the follow-up rebuild (or that pagination) delivers the
+                            // full item list and refreshes the UI without any blank frame.
                             should_continue_backwards_pagination = true;
+                            continue;
                         }
 
                         // If the bottom of the timeline (the last event) is visible, then we should


### PR DESCRIPTION
## Problem

When a message is sent or received in a room — most visibly when chatting with a bot whose history is under one screen — the timeline briefly **flashes white** and shows the top *"Loading earlier messages"* bar, then the content fills back in, looking like a broken fake-streaming effect.

## Root cause

On many timeline updates, the matrix SDK emits a **transient `Clear`** (an empty timeline snapshot) immediately before re-pushing the rebuilt timeline. `process_timeline_updates()` applied that empty snapshot (`tl.items = []`), so the `PortalList` rendered nothing for a frame or two. The `Timeline` view has no background of its own, so the blank frame exposed the near-white room background (`COLOR_PRIMARY_DARKER = #fefefe`) — the "white flash". The empty snapshot also kicked off a spurious backwards pagination that flashed the green `top_space` *"Loading earlier messages"* bar, and the viewport-fill auto-pagination amplified this into a churn loop on short rooms.

Confirmed from runtime logs (repeating on every send/receive):

```
process_timeline_updates(): timeline (had 25 items) was cleared for room ...
process_timeline_updates(): jumping to bottom: curr_first_tl_idx 24 is out of bounds for 0 new items
```

## Fix

In `process_timeline_updates()`, when `new_items.is_empty()` but we still have items rendered, **keep the currently-rendered items and skip applying the empty snapshot**. The SDK's follow-up rebuild (and the backwards pagination still kicked off for a genuinely-cleared timeline) refreshes the UI without any blank frame. One file, `src/home/room_screen.rs` (+14/−4).

## Testing

- `cargo check` passes.
- Root cause confirmed from runtime logs against a local `robrix2 → palpo → octos` bot setup; on-device validation of the eliminated flash is in progress.

## Follow-up (not in this PR)

A brief flash of the top *"Loading earlier messages"* bar can still occur because backwards pagination unconditionally shows `top_space`. A follow-up can suppress that indicator for non-user-initiated (viewport-fill / rebuild) paginations.
