### PR TITLE
refactor(mobile): shrink room-view pool from 16 to 2 slots

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2449,31 +2449,22 @@ impl App {
         }
     }
 
-    /// Room StackNavigationView instances, one per stack depth.
-    /// Each depth gets its own dedicated view widget to avoid
-    /// complex state save/restore when views would otherwise be reused.
-    const ROOM_VIEW_IDS: [LiveId; 16] = [
-        live_id!(room_view_0),  live_id!(room_view_1),
-        live_id!(room_view_2),  live_id!(room_view_3),
-        live_id!(room_view_4),  live_id!(room_view_5),
-        live_id!(room_view_6),  live_id!(room_view_7),
-        live_id!(room_view_8),  live_id!(room_view_9),
-        live_id!(room_view_10), live_id!(room_view_11),
-        live_id!(room_view_12), live_id!(room_view_13),
-        live_id!(room_view_14), live_id!(room_view_15),
+    /// Room StackNavigationView slots, indexed by visual depth.
+    ///
+    /// Only TWO are needed: Makepad's `StackNavigation` keeps a single
+    /// `current_view` (its `depth()` returns 0 or 1), and a push transition
+    /// shows at most two views at once (outgoing + incoming). Per-room UI state
+    /// (scroll, draft, timeline) is preserved across reuse via the global
+    /// `TIMELINE_STATES` map (keyed by room, not by widget), so a 2-slot pool
+    /// loses nothing vs. a larger one.
+    const ROOM_VIEW_IDS: [LiveId; 2] = [
+        live_id!(room_view_0), live_id!(room_view_1),
     ];
 
     /// The RoomScreen widget IDs inside each room view,
     /// corresponding 1:1 with [`Self::ROOM_VIEW_IDS`].
-    const ROOM_SCREEN_IDS: [LiveId; 16] = [
-        live_id!(room_screen_0),  live_id!(room_screen_1),
-        live_id!(room_screen_2),  live_id!(room_screen_3),
-        live_id!(room_screen_4),  live_id!(room_screen_5),
-        live_id!(room_screen_6),  live_id!(room_screen_7),
-        live_id!(room_screen_8),  live_id!(room_screen_9),
-        live_id!(room_screen_10), live_id!(room_screen_11),
-        live_id!(room_screen_12), live_id!(room_screen_13),
-        live_id!(room_screen_14), live_id!(room_screen_15),
+    const ROOM_SCREEN_IDS: [LiveId; 2] = [
+        live_id!(room_screen_0), live_id!(room_screen_1),
     ];
 
     /// Returns the room view and room screen LiveIds for the given stack depth.

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -425,26 +425,16 @@ script_mod! {
                         }
                     }
 
-                    // Room views: multiple instances to support deep stacking
-                    // (e.g., room -> thread -> room -> thread -> ...).
-                    // Each stack depth gets its own dedicated view widget,
-                    // avoiding complex state save/restore when views are reused.
-                    room_view_0  := mod.widgets.RobrixRoomContentView { body +: { room_screen_0  := mod.widgets.RoomScreen {} } }
-                    room_view_1  := mod.widgets.RobrixRoomContentView { body +: { room_screen_1  := mod.widgets.RoomScreen {} } }
-                    room_view_2  := mod.widgets.RobrixRoomContentView { body +: { room_screen_2  := mod.widgets.RoomScreen {} } }
-                    room_view_3  := mod.widgets.RobrixRoomContentView { body +: { room_screen_3  := mod.widgets.RoomScreen {} } }
-                    room_view_4  := mod.widgets.RobrixRoomContentView { body +: { room_screen_4  := mod.widgets.RoomScreen {} } }
-                    room_view_5  := mod.widgets.RobrixRoomContentView { body +: { room_screen_5  := mod.widgets.RoomScreen {} } }
-                    room_view_6  := mod.widgets.RobrixRoomContentView { body +: { room_screen_6  := mod.widgets.RoomScreen {} } }
-                    room_view_7  := mod.widgets.RobrixRoomContentView { body +: { room_screen_7  := mod.widgets.RoomScreen {} } }
-                    room_view_8  := mod.widgets.RobrixRoomContentView { body +: { room_screen_8  := mod.widgets.RoomScreen {} } }
-                    room_view_9  := mod.widgets.RobrixRoomContentView { body +: { room_screen_9  := mod.widgets.RoomScreen {} } }
-                    room_view_10 := mod.widgets.RobrixRoomContentView { body +: { room_screen_10 := mod.widgets.RoomScreen {} } }
-                    room_view_11 := mod.widgets.RobrixRoomContentView { body +: { room_screen_11 := mod.widgets.RoomScreen {} } }
-                    room_view_12 := mod.widgets.RobrixRoomContentView { body +: { room_screen_12 := mod.widgets.RoomScreen {} } }
-                    room_view_13 := mod.widgets.RobrixRoomContentView { body +: { room_screen_13 := mod.widgets.RoomScreen {} } }
-                    room_view_14 := mod.widgets.RobrixRoomContentView { body +: { room_screen_14 := mod.widgets.RoomScreen {} } }
-                    room_view_15 := mod.widgets.RobrixRoomContentView { body +: { room_screen_15 := mod.widgets.RoomScreen {} } }
+                    // Only two room-view slots are needed: Makepad's
+                    // StackNavigation keeps a single current view (its depth()
+                    // returns 0/1) and a push transition shows at most two at
+                    // once (outgoing + incoming). Per-room UI state (scroll,
+                    // draft, timeline) is preserved across reuse via the global
+                    // TIMELINE_STATES map (keyed by room, not by widget), so
+                    // reusing these two across all rooms loses nothing. Kept in
+                    // sync with `App::ROOM_VIEW_IDS` / `ROOM_SCREEN_IDS`.
+                    room_view_0 := mod.widgets.RobrixRoomContentView { body +: { room_screen_0 := mod.widgets.RoomScreen {} } }
+                    room_view_1 := mod.widgets.RobrixRoomContentView { body +: { room_screen_1 := mod.widgets.RoomScreen {} } }
 
                     invite_view := mod.widgets.RobrixContentView {
                         body +: {


### PR DESCRIPTION
## Summary

The mobile room-view pool declares **16** `StackNavigationView` slots (`room_view_0..15`, each wrapping its own `RoomScreen`), indexed by `App::room_ids_for_depth(depth)`. But Makepad's `StackNavigation` keeps only a single `current_view` — **`depth()` returns 0 or 1, never a real stack height** — so `room_ids_for_depth` only ever addressed slots **0 and 1**. `room_view_2..15` / `room_screen_2..15` are dead: instantiated at startup but never used (14 idle `RoomScreen` widgets in the view tree).

This shrinks the pool to **2 slots**.

## Why 2 is sufficient and lossless

- A push transition shows at most two views at once (outgoing + incoming), so two slots cover the slide animation.
- Per-room UI state (scroll position, input draft, full timeline) lives in the global `TIMELINE_STATES` map **keyed by room (`TimelineKind`), not by widget**. `RoomScreen` checks a room's state in via `show_timeline` and out via `save_state`/`hide_timeline`, and `Drop` guarantees it's returned. So reusing two `RoomScreen`s across all rooms preserves scroll/draft/timeline exactly as 16 dedicated ones would.

Net: a behavior-preserving cleanup that removes 14 idle `RoomScreen` instances from the mobile widget tree.

## Changes
- `src/app.rs` — `ROOM_VIEW_IDS` / `ROOM_SCREEN_IDS` `[LiveId; 16]` → `[LiveId; 2]` (+ explanatory doc). `room_ids_for_depth` unchanged (still clamps).
- `src/home/home_screen.rs` — removed `room_view_2..15` from the `view_stack` StackNavigation (kept `room_view_0`/`room_view_1`).

## Testing
- `cargo build` clean; `typos` clean.
- Manual mobile sanity check recommended: open a room, open a thread, back-navigate, switch between rooms — scroll/draft preserved on return (state comes from `TIMELINE_STATES`, unaffected by the slot count).

> Note: touches the same `room_view_*` lines as #207 (RoomTopBar); whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)