### PR TITLE
feat(settings): redesign the Settings screen onto the design-token system

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -125,6 +125,7 @@ script_mod! {
                         // A modal to confirm sending out an invite to a room.
                         invite_confirmation_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill, align: Align{x: 0.5, y: 0.5},
                                 invite_confirmation_modal_inner := PositiveConfirmationModal {
                                     wrapper +: { buttons_view +: { accept_button +: {
                                         draw_icon +: { svg: (ICON_INVITE) }
@@ -320,6 +321,7 @@ script_mod! {
                         // A generic modal to confirm any positive action.
                         positive_confirmation_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill, align: Align{x: 0.5, y: 0.5},
                                 positive_confirmation_modal_inner := PositiveConfirmationModal { }
                             }
                         }
@@ -327,6 +329,7 @@ script_mod! {
                         // A modal to confirm any deletion/removal action.
                         delete_confirmation_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill, align: Align{x: 0.5, y: 0.5},
                                 delete_confirmation_modal_inner := NegativeConfirmationModal { }
                             }
                         }

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -97,18 +97,21 @@ script_mod! {
             }
         }
 
-        // --- Avatar card ---
+        // --- Identity card: Avatar + Display Name + User ID grouped together ---
         RoundedView {
             width: Fill, height: Fit
             flow: Down
-            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
+            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_MD), bottom: (SPACE_MD)}
             margin: Inset{top: (SPACE_SM)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
+            // -- Avatar --
             avatar_section_label := SubsectionLabel {
                 margin: Inset{top: 0, bottom: (SPACE_XS)}
                 text: "Your Avatar:"
@@ -118,90 +121,95 @@ script_mod! {
                 width: Fill, height: Fit
                 flow: Right { wrap: true },
                 align: Align{y: 0.5}
+                spacing: (SPACE_LG)
 
                 our_own_avatar := Avatar {
-                    width: 100,
-                    height: 100,
+                    width: 84,
+                    height: 84,
                     margin: (SPACE_SM),
                     text_view +: {
                         text +: {
                             draw_text +: {
-                                text_style: theme.font_regular { font_size: 35.0 }
+                                text_style: theme.font_regular { font_size: 30.0 }
                             }
                         }
                     }
                 }
 
+                // Compact action column: hint + small Upload / Remove buttons.
                 View {
-                    width: Fit, height: Fit
+                    width: Fill, height: Fit
                     flow: Down,
-                    align: Align{y: 0.5}
-                    padding: Inset{ left: (SPACE_SM), right: (SPACE_SM) }
                     spacing: (SPACE_SM)
 
+                    avatar_hint_label := Label {
+                        width: Fill, height: Fit
+                        flow: Flow.Right{wrap: true}
+                        draw_text +: {
+                            color: (RBX_FG_SECONDARY),
+                            text_style: REGULAR_TEXT { font_size: 10.5 }
+                        }
+                        text: "Upload a new avatar, or remove the current one."
+                    }
+
                     View {
-                        width: Fit, height: Fit
-                        flow: Right,
+                        width: Fill, height: Fit
+                        flow: Flow.Right{wrap: true},
                         align: Align{y: 0.5}
                         spacing: (SPACE_SM)
 
-                        upload_avatar_button := RobrixIconButton {
-                            width: 140,
-                            height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
-                            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_LG)}
+                        upload_avatar_button := SettingsPrimaryButton {
+                            width: Fit, height: Fit,
+                            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                             margin: 0,
-                            draw_bg +: { border_radius: (RADIUS_MD) }
+                            draw_bg +: {
+                                color: (RBX_ACCENT)
+                                color_hover: (RBX_ACCENT_HOVER)
+                                color_down: (RBX_ACCENT_PRESSED)
+                                border_radius: (RBX_RADIUS_SM)
+                            }
                             draw_icon.svg: (ICON_UPLOAD)
-                            icon_walk: Walk{width: 16, height: 16}
-                            text: "Upload Avatar"
+                            icon_walk: Walk{width: 15, height: 15}
+                            text: "Upload"
+                        }
+
+                        delete_avatar_button := RobrixNegativeIconButton {
+                            width: Fit, height: Fit,
+                            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
+                            margin: 0,
+                            draw_bg +: {
+                                color: #0000
+                                color_hover: (RBX_DANGER_BG)
+                                color_down: (RBX_DANGER_BG)
+                                border_size: 0.0
+                                border_color: #0000
+                                border_color_hover: #0000
+                                border_color_down: #0000
+                                border_radius: (RBX_RADIUS_SM)
+                            }
+                            draw_icon.svg: (ICON_TRASH)
+                            icon_walk: Walk{ width: 15, height: 15 }
+                            text: "Remove"
                         }
 
                         upload_avatar_spinner := LoadingSpinner {
                             width: 16, height: 16
                             visible: false
-                            draw_bg.color: (COLOR_ACTIVE_PRIMARY)
-                        }
-                    }
-
-                    View {
-                        width: Fit, height: Fit
-                        flow: Right,
-                        align: Align{y: 0.5}
-                        spacing: (SPACE_SM)
-
-                        delete_avatar_button := RobrixNegativeIconButton {
-                            width: 140,
-                            height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
-                            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_LG)}
-                            margin: 0,
-                            draw_bg +: { border_radius: (RADIUS_MD) }
-                            draw_icon.svg: (ICON_TRASH)
-                            icon_walk: Walk{ width: 16, height: 16 }
-                            text: "Delete Avatar"
+                            draw_bg.color: (RBX_ACCENT)
                         }
 
                         delete_avatar_spinner := LoadingSpinner {
                             width: 16, height: 16
                             visible: false
-                            draw_bg.color: (COLOR_ACTIVE_PRIMARY)
+                            draw_bg.color: (RBX_DANGER_FG)
                         }
                     }
                 }
             }
-        }
 
-        // --- Display Name card ---
-        RoundedView {
-            width: Fill, height: Fit
-            flow: Down
-            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
-            margin: Inset{top: (SPACE_SM)}
-            show_bg: true
-            draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
-            }
+            LineH { height: 1.0, margin: Inset{top: (SPACE_MD), bottom: (SPACE_MD)}, draw_bg.color: (RBX_STROKE_SOFT) }
 
+            // -- Display Name --
             display_name_section_label := SubsectionLabel {
                 margin: Inset{top: 0, bottom: (SPACE_XS)}
                 text: "Your Display Name:"
@@ -249,23 +257,13 @@ script_mod! {
                     width: 16, height: 16
                     margin: Inset{left: (SPACE_XS), top: 13} // vertically center with buttons
                     visible: false
-                    draw_bg.color: (COLOR_ACTIVE_PRIMARY)
+                    draw_bg.color: (RBX_ACCENT)
                 }
             }
-        }
 
-        // --- User ID card ---
-        RoundedView {
-            width: Fill, height: Fit
-            flow: Down
-            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
-            margin: Inset{top: (SPACE_SM)}
-            show_bg: true
-            draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
-            }
+            LineH { height: 1.0, margin: Inset{top: (SPACE_MD), bottom: (SPACE_MD)}, draw_bg.color: (RBX_STROKE_SOFT) }
 
+            // -- User ID --
             user_id_section_label := SubsectionLabel {
                 margin: Inset{top: 0, bottom: (SPACE_XS)}
                 text: "Your User ID:"
@@ -275,25 +273,36 @@ script_mod! {
                 width: Fill, height: Fit
                 flow: Right,
                 align: Align{y: 0.5}
-                spacing: (SPACE_SM)
-
-                copy_user_id_button := RobrixNeutralIconButton {
-                    enable_long_press: true,
-                    padding: (SPACE_MD),
-                    spacing: 0,
-                    draw_icon.svg: (ICON_COPY)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{right: -2} }
-                }
+                spacing: (SPACE_XS)
 
                 user_id := Label {
                     width: Fill, height: Fit
                     flow: Flow.Right{wrap: true},
-                    margin: Inset{top: 9}
                     draw_text +: {
                         color: (MESSAGE_TEXT_COLOR),
                         text_style: MESSAGE_TEXT_STYLE { font_size: 11.5 },
                     }
                     text: "You are not logged in."
+                }
+
+                // Copy button sits AFTER the id, small and ghost-styled.
+                copy_user_id_button := RobrixNeutralIconButton {
+                    enable_long_press: true,
+                    width: Fit, height: Fit,
+                    padding: (SPACE_XS),
+                    spacing: 0,
+                    draw_bg +: {
+                        color: #0000
+                        color_hover: (RBX_BG_HOVER)
+                        color_down: (RBX_BG_PRESSED)
+                        border_size: 0.0
+                        border_color: #0000
+                        border_color_hover: #0000
+                        border_color_down: #0000
+                        border_radius: (RBX_RADIUS_XS)
+                    }
+                    draw_icon +: { svg: (ICON_COPY), color: (RBX_FG_TERTIARY) }
+                    icon_walk: Walk{width: 13, height: 13}
                 }
             }
         }
@@ -306,13 +315,33 @@ script_mod! {
             margin: Inset{top: (SPACE_SM)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
-            multiple_accounts_section_label := SubsectionLabel {
+            View {
+                width: Fill, height: Fit
+                flow: Right
+                align: Align{y: 0.5}
+                spacing: (SPACE_SM)
                 margin: Inset{top: 0, bottom: (SPACE_XS)}
-                text: "Multiple Accounts:"
+
+                SettingsIconCircle {
+                    width: 30, height: 30
+                    draw_bg +: { color: (RBX_INFO_BG) }
+                    Icon {
+                        width: 16, height: 16
+                        draw_icon +: { svg: (ICON_ADD_USER), color: (RBX_INFO_FG) }
+                        icon_walk: Walk{width: 16, height: 16}
+                    }
+                }
+                multiple_accounts_section_label := SubsectionLabel {
+                    width: Fill
+                    margin: 0
+                    text: "Multiple Accounts:"
+                }
             }
 
             View {
@@ -330,29 +359,35 @@ script_mod! {
                 spacing: (SPACE_SM)
                 show_bg: true
                 draw_bg +: {
-                    color: (COLOR_ACCOUNT_ACTIVE_BG)
-                    border_radius: (RADIUS_LG)
+                    color: (RBX_ACCENT_SOFT)
+                    border_radius: (RBX_RADIUS_SM)
+                    border_size: 1.0
+                    border_color: (RBX_ACCENT)
                 }
 
-                View {
+                active_account_label := Label {
                     width: Fill, height: Fit
-                    flow: Down,
-                    spacing: 2
-
-                    active_account_label := Label {
-                        width: Fill, height: Fit
-                        draw_text +: {
-                            color: (COLOR_PRIMARY),
-                            text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
-                        }
-                        text: "@user:server"
+                    flow: Flow.Right{wrap: true}
+                    draw_text +: {
+                        color: (RBX_FG_PRIMARY),
+                        text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
                     }
+                    text: "@user:server"
+                }
+
+                // "Active" as a compact solid-teal pill, inline on the right.
+                active_account_status_pill := RoundedView {
+                    width: Fit, height: Fit
+                    align: Align{x: 0.5, y: 0.5}
+                    padding: Inset{left: 9, right: 9, top: 3, bottom: 3}
+                    show_bg: true
+                    draw_bg +: { color: (RBX_ACCENT), border_radius: (RBX_RADIUS_PILL) }
 
                     active_account_status_label := Label {
                         width: Fit, height: Fit
                         draw_text +: {
-                            color: (COLOR_PRIMARY),
-                            text_style: MESSAGE_TEXT_STYLE { font_size: 9 },
+                            color: (RBX_FG_ON_ACCENT),
+                            text_style: theme.font_bold { font_size: 9 },
                         }
                         text: "Active"
                     }
@@ -381,10 +416,10 @@ script_mod! {
                 visible: false
                 show_bg: true
                 draw_bg +: {
-                    color: (COLOR_SECONDARY)
-                    border_radius: (RADIUS_LG)
+                    color: (RBX_BG_SURFACE_SUBTLE)
+                    border_radius: (RBX_RADIUS_SM)
                     border_size: 1.0
-                    border_color: (COLOR_INACTIVE_BORDER)
+                    border_color: (RBX_STROKE_SOFT)
                 }
 
                 View {
@@ -402,7 +437,7 @@ script_mod! {
                     }
                 }
 
-                switch_account_button := RobrixIconButton {
+                switch_account_button := SettingsPrimaryButton {
                     width: Fit, height: Fit
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_SM), right: (SPACE_SM)}
                     draw_icon.svg: (ICON_JUMP)
@@ -421,7 +456,7 @@ script_mod! {
                 text: "1 account logged in"
             }
 
-            add_account_button := RobrixIconButton {
+            add_account_button := SettingsPrimaryButton {
                 width: Fit,
                 padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_LG)}
                 margin: Inset{top: (SPACE_XS)}
@@ -441,13 +476,33 @@ script_mod! {
             margin: Inset{top: (SPACE_SM), bottom: (SPACE_LG)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
-            other_actions_section_label := SubsectionLabel {
+            View {
+                width: Fill, height: Fit
+                flow: Right
+                align: Align{y: 0.5}
+                spacing: (SPACE_SM)
                 margin: Inset{top: 0, bottom: (SPACE_XS)}
-                text: "Other actions:"
+
+                SettingsIconCircle {
+                    width: 30, height: 30
+                    draw_bg +: { color: (RBX_ACCENT_SOFT) }
+                    Icon {
+                        width: 16, height: 16
+                        draw_icon +: { svg: (ICON_SETTINGS), color: (RBX_ACCENT) }
+                        icon_walk: Walk{width: 16, height: 16}
+                    }
+                }
+                other_actions_section_label := SubsectionLabel {
+                    width: Fill
+                    margin: 0
+                    text: "Other actions:"
+                }
             }
 
             View {
@@ -456,7 +511,7 @@ script_mod! {
                 align: Align{y: 0.5},
                 spacing: (SPACE_SM)
 
-                manage_account_button := RobrixIconButton {
+                manage_account_button := SettingsPrimaryButton {
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_LG)}
                     draw_bg +: { border_radius: (RADIUS_MD) }
                     draw_icon.svg: (ICON_EXTERNAL_LINK)
@@ -1170,98 +1225,109 @@ impl AccountSettings {
         enable: bool,
         delete_avatar_button: &ButtonRef,
     ) {
-        let (delete_button_fg_color, delete_button_bg_color) = if enable {
-            (COLOR_FG_DANGER_RED, COLOR_BG_DANGER_RED)
-        } else {
-            (COLOR_FG_DISABLED, COLOR_BG_DISABLED)
-        };
+        use crate::shared::design_tokens::{RBX_DANGER_BG, RBX_DANGER_FG, RBX_FG_DISABLED};
+        // Ghost "Remove" button: transparent fill, danger-red text/icon, red-tinted
+        // hover. Disabled = greyed text, still transparent.
+        let fg = if enable { RBX_DANGER_FG } else { RBX_FG_DISABLED };
         let mut delete_avatar_button = delete_avatar_button.clone();
         script_apply_eval!(cx, delete_avatar_button, {
             enabled: #(enable),
             draw_bg +: {
-                color: #(delete_button_bg_color),
-                border_color: #(delete_button_fg_color),
+                color: #00000000,
+                color_hover: #(RBX_DANGER_BG),
+                color_down: #(RBX_DANGER_BG),
+                border_size: 0.0,
+                border_color: #00000000,
             }
             draw_icon +: {
-                color: #(delete_button_fg_color),
+                color: #(fg),
             }
             draw_text +: {
-                color: #(delete_button_fg_color),
+                color: #(fg),
             }
         });
     }
 
-    /// Enable or disable the upload avatar button.
+    /// Enable or disable the upload avatar badge.
     fn enable_upload_avatar_button(
         cx: &mut Cx,
         enable: bool,
         upload_avatar_button: &ButtonRef,
     ) {
-        let (upload_button_fg_color, upload_button_bg_color) = if enable {
-            (COLOR_PRIMARY, COLOR_ACTIVE_PRIMARY)
+        use crate::shared::design_tokens::{
+            RBX_ACCENT, RBX_BG_DISABLED, RBX_FG_DISABLED, RBX_FG_ON_ACCENT,
+        };
+        // Teal "Upload" button (grey when disabled).
+        let (fg, bg) = if enable {
+            (RBX_FG_ON_ACCENT, RBX_ACCENT)
         } else {
-            (COLOR_FG_DISABLED, COLOR_BG_DISABLED)
+            (RBX_FG_DISABLED, RBX_BG_DISABLED)
         };
         let mut upload_avatar_button = upload_avatar_button.clone();
         script_apply_eval!(cx, upload_avatar_button, {
             enabled: #(enable),
             draw_bg +: {
-                color: #(upload_button_bg_color),
-                border_color: #(upload_button_fg_color),
+                color: #(bg),
             }
             draw_icon +: {
-                color: #(upload_button_fg_color),
+                color: #(fg),
             }
             draw_text +: {
-                color: #(upload_button_fg_color),
+                color: #(fg),
             }
         });
     }
 
-    /// Enable or disable the display name accept and cancel buttons.
+    /// Enable or disable the display name accept and cancel buttons. Styled to
+    /// match the rest of settings: Save = teal primary, Cancel = ghost neutral.
     fn enable_display_name_buttons(
         cx: &mut Cx,
         enable: bool,
         accept_display_name_button: &ButtonRef,
         cancel_display_name_button: &ButtonRef,
     ) {
-        let (accept_button_fg_color, accept_button_bg_color) = if enable {
-            (COLOR_FG_ACCEPT_GREEN, COLOR_BG_ACCEPT_GREEN)
-        } else {
-            (COLOR_FG_DISABLED, COLOR_BG_DISABLED)
+        use crate::shared::design_tokens::{
+            RBX_ACCENT, RBX_BG_DISABLED, RBX_BG_HOVER, RBX_BG_PRESSED, RBX_FG_DISABLED,
+            RBX_FG_ON_ACCENT, RBX_FG_SECONDARY,
         };
-        let (cancel_button_fg_color, cancel_button_bg_color) = if enable {
-            (COLOR_FG_DANGER_RED, COLOR_BG_DANGER_RED)
+        // Save Name: teal primary (grey when disabled).
+        let (accept_fg, accept_bg) = if enable {
+            (RBX_FG_ON_ACCENT, RBX_ACCENT)
         } else {
-            (COLOR_FG_DISABLED, COLOR_BG_DISABLED)
+            (RBX_FG_DISABLED, RBX_BG_DISABLED)
         };
-
         let mut accept_display_name_button = accept_display_name_button.clone();
         script_apply_eval!(cx, accept_display_name_button, {
             enabled: #(enable),
             draw_bg +: {
-                color: #(accept_button_bg_color),
-                border_color: #(accept_button_fg_color),
-            },
+                color: #(accept_bg),
+                border_size: 0.0,
+                border_color: #00000000,
+            }
             draw_text +: {
-                color: #(accept_button_fg_color),
-            },
+                color: #(accept_fg),
+            }
             draw_icon +: {
-                color: #(accept_button_fg_color),
+                color: #(accept_fg),
             }
         });
+        // Cancel: ghost neutral (transparent fill, subtle hover).
+        let cancel_fg = if enable { RBX_FG_SECONDARY } else { RBX_FG_DISABLED };
         let mut cancel_display_name_button = cancel_display_name_button.clone();
         script_apply_eval!(cx, cancel_display_name_button, {
             enabled: #(enable),
             draw_bg +: {
-                color: #(cancel_button_bg_color),
-                border_color: #(cancel_button_fg_color),
-            },
+                color: #00000000,
+                color_hover: #(RBX_BG_HOVER),
+                color_down: #(RBX_BG_PRESSED),
+                border_size: 0.0,
+                border_color: #00000000,
+            }
             draw_text +: {
-                color: #(cancel_button_fg_color),
-            },
+                color: #(cancel_fg),
+            }
             draw_icon +: {
-                color: #(cancel_button_fg_color),
+                color: #(cancel_fg),
             }
         });
     }

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -245,26 +245,58 @@ script_mod! {
                 width: Fill, height: Fit
                 flow: Right
                 align: Align{y: 0.5}
-                spacing: 6
+                spacing: 8
 
                 ui_zoom_minus_button := RobrixNeutralIconButton {
-                    width: 28, height: 28,
+                    width: 32, height: 32,
                     padding: 0
                     align: Align{x: 0.5, y: 0.5}
+                    draw_bg +: {
+                        color: (RBX_BG_SURFACE)
+                        color_hover: (RBX_BG_HOVER)
+                        color_down: (RBX_BG_PRESSED)
+                        border_size: 1.0
+                        border_radius: (RBX_RADIUS_XS)
+                        border_color: (RBX_STROKE_STRONG)
+                        border_color_hover: (RBX_ACCENT)
+                        border_color_down: (RBX_ACCENT)
+                    }
+                    draw_text +: {
+                        color: (RBX_FG_PRIMARY)
+                        color_hover: (RBX_FG_PRIMARY)
+                        color_down: (RBX_FG_PRIMARY)
+                        text_style: BOLD_TEXT { font_size: 14 }
+                    }
                     text: "-"
                 }
 
                 ui_zoom_input := RobrixTextInput {
-                    width: 80, height: Fit
-                    align: Align {y: 0.5}
+                    width: 72, height: 32
+                    align: Align {x: 0.5, y: 0.5}
                     padding: Inset{left: 8, right: 8, top: 5, bottom: 5}
                     empty_text: "100%"
                 }
 
                 ui_zoom_plus_button := RobrixNeutralIconButton {
-                    width: 28, height: 28,
+                    width: 32, height: 32,
                     padding: 0
                     align: Align{x: 0.5, y: 0.5}
+                    draw_bg +: {
+                        color: (RBX_BG_SURFACE)
+                        color_hover: (RBX_BG_HOVER)
+                        color_down: (RBX_BG_PRESSED)
+                        border_size: 1.0
+                        border_radius: (RBX_RADIUS_XS)
+                        border_color: (RBX_STROKE_STRONG)
+                        border_color_hover: (RBX_ACCENT)
+                        border_color_down: (RBX_ACCENT)
+                    }
+                    draw_text +: {
+                        color: (RBX_FG_PRIMARY)
+                        color_hover: (RBX_FG_PRIMARY)
+                        color_down: (RBX_FG_PRIMARY)
+                        text_style: BOLD_TEXT { font_size: 14 }
+                    }
                     text: "+"
                 }
             }
@@ -334,8 +366,8 @@ script_mod! {
             }
 
             agent_chat_enable_toggle := ToggleFlat {
+                width: Fit, height: Fit
                 margin: Inset{left: 6.5, top: 5, bottom: 5}
-                padding: Inset { left: 15}
                 active: false,
                 draw_bg +: { size: 21 }
                 text: ""

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -20,7 +20,7 @@ script_mod! {
         flow: Flow.Right{wrap: true}
         margin: Inset{left: 0.5, top: 0, bottom: 0, right: 5}
         draw_text +: {
-            color: #666,
+            color: (RBX_FG_SECONDARY),
             text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
         }
     }
@@ -33,7 +33,7 @@ script_mod! {
         draw_text +: {
             color: (MESSAGE_TEXT_COLOR),
             color_hover: (MESSAGE_TEXT_COLOR),
-            color_active: (COLOR_ACTIVE_PRIMARY_DARKER),
+            color_active: (RBX_ACCENT_HOVER),
             text_style: REGULAR_TEXT {},
         }
 
@@ -47,7 +47,7 @@ script_mod! {
             border_size: 0.0,
             border_radius: 3.0,
             mark_color: vec4(0.0, 0.0, 0.0, 0.0),
-            mark_color_active: (COLOR_ACTIVE_PRIMARY_DARKER),
+            mark_color_active: (RBX_ACCENT_HOVER),
         }
     }
 
@@ -87,15 +87,15 @@ script_mod! {
             color_down: (COLOR_PRIMARY),
             color_focus: (COLOR_PRIMARY),
             border_color: (COLOR_SECONDARY_DARKER),
-            border_color_hover: (COLOR_ACTIVE_PRIMARY),
-            border_color_focus: (COLOR_ACTIVE_PRIMARY_DARKER),
-            border_color_down: (COLOR_ACTIVE_PRIMARY_DARKER),
+            border_color_hover: (RBX_ACCENT),
+            border_color_focus: (RBX_ACCENT_HOVER),
+            border_color_down: (RBX_ACCENT_HOVER),
             border_size: 1.0,
             border_radius: 4.0,
             arrow_color: (MESSAGE_TEXT_COLOR),
-            arrow_color_hover: (COLOR_ACTIVE_PRIMARY_DARKER),
-            arrow_color_focus: (COLOR_ACTIVE_PRIMARY_DARKER),
-            arrow_color_down: (COLOR_ACTIVE_PRIMARY_DARKER),
+            arrow_color_hover: (RBX_ACCENT_HOVER),
+            arrow_color_focus: (RBX_ACCENT_HOVER),
+            arrow_color_down: (RBX_ACCENT_HOVER),
             pixel: fn() {
                 let sdf = Sdf2d.viewport(self.pos * self.rect_size)
 
@@ -163,12 +163,12 @@ script_mod! {
             color_focus: (COLOR_PRIMARY),
             color_down: (COLOR_PRIMARY),
             border_color: (COLOR_SECONDARY_DARKER),
-            border_color_hover: (COLOR_ACTIVE_PRIMARY),
-            border_color_active: (COLOR_ACTIVE_PRIMARY_DARKER),
-            border_color_focus: (COLOR_ACTIVE_PRIMARY_DARKER),
-            border_color_down: (COLOR_ACTIVE_PRIMARY_DARKER),
+            border_color_hover: (RBX_ACCENT),
+            border_color_active: (RBX_ACCENT_HOVER),
+            border_color_focus: (RBX_ACCENT_HOVER),
+            border_color_down: (RBX_ACCENT_HOVER),
             mark_color: vec4(0.0, 0.0, 0.0, 0.0),
-            mark_color_active: (COLOR_ACTIVE_PRIMARY_DARKER),
+            mark_color_active: (RBX_ACCENT_HOVER),
         }
     }
 
@@ -177,8 +177,25 @@ script_mod! {
         flow: Down,
         spacing: (SPACE_SM)
 
-        preferences_app_title := TitleLabel {
-            text: "App"
+        View {
+            width: Fill, height: Fit
+            flow: Right
+            align: Align{y: 0.5}
+            spacing: (SPACE_SM)
+
+            SettingsIconCircle {
+                width: 30, height: 30
+                draw_bg +: { color: (RBX_ACCENT_SOFT) }
+                Icon {
+                    width: 16, height: 16
+                    draw_icon +: { svg: (ICON_SETTINGS), color: (RBX_ACCENT) }
+                    icon_walk: Walk{width: 16, height: 16}
+                }
+            }
+            preferences_app_title := TitleLabel {
+                width: Fill
+                text: "App"
+            }
         }
 
         RoundedView {
@@ -187,8 +204,10 @@ script_mod! {
             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
             preferences_view_mode_label := SubsectionLabel {
@@ -211,8 +230,10 @@ script_mod! {
             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
             preferences_ui_zoom_label := SubsectionLabel {
@@ -258,8 +279,10 @@ script_mod! {
             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
             preferences_send_shortcut_label := SubsectionLabel {
@@ -268,8 +291,8 @@ script_mod! {
             }
 
             send_on_cmd_enter_toggle := ToggleFlat {
+                width: Fit, height: Fit
                 margin: Inset{left: 6.5, top: 5, bottom: 5}
-                padding: Inset { left: 15}
                 active: false,
                 draw_bg +: { size: 21 }
                 text: ""
@@ -283,7 +306,7 @@ script_mod! {
                 flow: Flow.Right{wrap: true}
                 margin: Inset{left: 0.5, top: 4, bottom: 0, right: 5}
                 draw_text +: {
-                    color: #666,
+                    color: (RBX_FG_SECONDARY),
                     text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
                 }
                 text: "Current setting: 'Enter' to send, 'Shift + Enter' for a new line"
@@ -299,8 +322,10 @@ script_mod! {
             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
             preferences_agent_chat_label := SubsectionLabel {
@@ -330,8 +355,10 @@ script_mod! {
             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
             show_bg: true
             draw_bg +: {
-                color: #F8F8FA
-                border_radius: (RADIUS_LG)
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
             preferences_thumb_height_label := SubsectionLabel {

--- a/src/settings/bot_settings.rs
+++ b/src/settings/bot_settings.rs
@@ -110,9 +110,25 @@ script_mod! {
             spacing: (SPACE_XS)
             margin: Inset{bottom: 2}
 
-            app_service_title := TitleLabel {
-                width: Fit
-                text: "App Service"
+            View {
+                width: Fill, height: Fit
+                flow: Right
+                align: Align{y: 0.5}
+                spacing: (SPACE_SM)
+
+                SettingsIconCircle {
+                    width: 30, height: 30
+                    draw_bg +: { color: (RBX_ACCENT_SOFT) }
+                    Icon {
+                        width: 16, height: 16
+                        draw_icon +: { svg: (ICON_HIERARCHY), color: (RBX_ACCENT) }
+                        icon_walk: Walk{width: 16, height: 16}
+                    }
+                }
+                app_service_title := TitleLabel {
+                    width: Fill
+                    text: "App Service"
+                }
             }
 
             description := mod.widgets.BotSettingsInfoLabel {
@@ -143,8 +159,8 @@ script_mod! {
                 active: false
                 draw_bg +: {
                     size: 20.0
-                    color_active: (COLOR_ACTIVE_PRIMARY)
-                    border_color_active: (COLOR_ACTIVE_PRIMARY)
+                    color_active: (RBX_ACCENT)
+                    border_color_active: (RBX_ACCENT)
                     mark_color_active: #fff
                 }
             }
@@ -228,22 +244,14 @@ script_mod! {
                 align: Align{y: 0.5}
                 margin: Inset{top: 2}
 
-                save_octos_service_button := RobrixIconButton {
+                save_octos_service_button := SettingsPrimaryButton {
                     padding: Inset{top: 8, bottom: 8, left: 16, right: 16}
                     icon_walk: Walk{width: 0, height: 0}
                     spacing: 0
                     text: "Save"
                 }
 
-                octos_health_status_label := Label {
-                    width: Fit
-                    height: Fit
-                    draw_text +: {
-                        color: (COLOR_DISABLED_TEXT)
-                        text_style: REGULAR_TEXT { font_size: 10.5 }
-                    }
-                    text: "Unknown"
-                }
+                octos_health_status_badge := SettingsStatusBadge {}
 
                 check_now_button := RobrixNeutralIconButton {
                     padding: Inset{top: 8, bottom: 8, left: 16, right: 16}
@@ -477,29 +485,38 @@ impl BotSettings {
     }
 
     fn set_octos_health_status_label(&mut self, cx: &mut Cx) {
-        let (text_key, color) = match self.octos_health.status {
+        use crate::shared::design_tokens::{
+            RBX_DANGER_BG, RBX_DANGER_FG, RBX_NEUTRAL_BG, RBX_NEUTRAL_FG,
+            RBX_SUCCESS_BG, RBX_SUCCESS_FG, RBX_WARNING_BG, RBX_WARNING_FG,
+        };
+        // (text key, foreground, pill background) per health state.
+        let (text_key, fg, bg) = match self.octos_health.status {
             OctosHealthStatus::Unknown => (
                 "settings.labs.app_service.health.status.unknown",
-                vec4(0.6, 0.6, 0.6, 1.0),
+                RBX_NEUTRAL_FG, RBX_NEUTRAL_BG,
             ),
             OctosHealthStatus::Checking => (
                 "settings.labs.app_service.health.status.checking",
-                vec4(0.6, 0.6, 0.6, 1.0),
+                RBX_WARNING_FG, RBX_WARNING_BG,
             ),
             OctosHealthStatus::Reachable => (
                 "settings.labs.app_service.health.status.reachable",
-                vec4(0.0, 0.6666667, 0.0, 1.0),
+                RBX_SUCCESS_FG, RBX_SUCCESS_BG,
             ),
             OctosHealthStatus::Unreachable => (
                 "settings.labs.app_service.health.status.unreachable",
-                vec4(0.8, 0.0, 0.0, 1.0),
+                RBX_DANGER_FG, RBX_DANGER_BG,
             ),
         };
-        let mut label = self.view.label(cx, ids!(octos_health_status_label));
+        let mut badge = self.view.view(cx, ids!(octos_health_status_badge));
+        script_apply_eval!(cx, badge, {
+            draw_bg +: { color: #(bg) }
+        });
+        let mut label = self.view.label(cx, ids!(octos_health_status_badge.badge_label));
         script_apply_eval!(cx, label, {
             text: #(tr_key(self.app_language, text_key)),
             draw_text +: {
-                color: #(color)
+                color: #(fg)
             }
         });
     }

--- a/src/settings/devices_settings.rs
+++ b/src/settings/devices_settings.rs
@@ -40,10 +40,10 @@ script_mod! {
         margin: Inset{top: 6, bottom: 6}
         show_bg: true
         draw_bg +: {
-            color: #xFFFFFF
-            border_radius: 8.0
+            color: (RBX_BG_SURFACE)
+            border_radius: (RBX_RADIUS_SM)
             border_size: 1.0
-            border_color: #xE5E5EA
+            border_color: (RBX_STROKE_SOFT)
         }
         spacing: 6
 
@@ -54,17 +54,22 @@ script_mod! {
             spacing: 12
             align: Align{y: 0.5}
 
-            // Generic device glyph. Matrix's `/devices` endpoint doesn't
-            // expose a device type, so we don't try to guess laptop vs
-            // phone vs browser — one icon for all.
-            device_card_icon := Label {
-                width: 36, height: 36
+            // Generic device glyph in a soft-tint circle. Matrix's `/devices`
+            // endpoint doesn't expose a device type, so we don't try to guess
+            // laptop vs phone vs browser — one icon for all.
+            device_card_icon_circle := CircleView {
+                width: 40, height: 40
                 align: Align{x: 0.5, y: 0.5}
-                draw_text +: {
-                    color: #x606066
-                    text_style: theme.font_regular { font_size: 22.0 }
+                show_bg: true
+                draw_bg +: { color: (RBX_INFO_BG) }
+                device_card_icon := Label {
+                    width: Fit, height: Fit
+                    align: Align{x: 0.5, y: 0.5}
+                    draw_text +: {
+                        text_style: theme.font_regular { font_size: 19.0 }
+                    }
+                    text: "💻"
                 }
-                text: "💻"
             }
 
             device_card_name_col := View {
@@ -76,7 +81,7 @@ script_mod! {
                     width: Fill, height: Fit
                     text: "Unknown device"
                     draw_text +: {
-                        color: #x101012
+                        color: (RBX_FG_PRIMARY)
                         text_style: theme.font_bold { font_size: 14.0 }
                     }
                 }
@@ -84,7 +89,7 @@ script_mod! {
                     width: Fill, height: Fit
                     text: ""
                     draw_text +: {
-                        color: #x606066
+                        color: (RBX_FG_SECONDARY)
                         text_style: theme.font_regular { font_size: 11.0 }
                     }
                 }
@@ -113,14 +118,14 @@ script_mod! {
                 device_card_last_active_label := Label {
                     text: "Last Active"
                     draw_text +: {
-                        color: #x606066
+                        color: (RBX_FG_SECONDARY)
                         text_style: theme.font_regular { font_size: 11.0 }
                     }
                 }
                 device_card_last_active_value := Label {
                     text: "—"
                     draw_text +: {
-                        color: #x101012
+                        color: (RBX_FG_PRIMARY)
                         text_style: theme.font_regular { font_size: 12.0 }
                     }
                 }
@@ -132,14 +137,14 @@ script_mod! {
                 device_card_id_label := Label {
                     text: "Device ID"
                     draw_text +: {
-                        color: #x606066
+                        color: (RBX_FG_SECONDARY)
                         text_style: theme.font_regular { font_size: 11.0 }
                     }
                 }
                 device_card_id_value := Label {
                     text: "—"
                     draw_text +: {
-                        color: #x101012
+                        color: (RBX_FG_PRIMARY)
                         text_style: theme.font_regular { font_size: 12.0 }
                     }
                 }
@@ -165,7 +170,7 @@ script_mod! {
                 width: Fill, height: Fit
                 text: "Where you're signed in"
                 draw_text +: {
-                    color: #x101012
+                    color: (RBX_FG_PRIMARY)
                     text_style: theme.font_bold { font_size: 16.0 }
                 }
             }
@@ -181,7 +186,7 @@ script_mod! {
             text: "0 devices"
             margin: Inset{top: 4}
             draw_text +: {
-                color: #x606066
+                color: (RBX_FG_SECONDARY)
                 text_style: theme.font_regular { font_size: 12.0 }
             }
         }
@@ -193,7 +198,7 @@ script_mod! {
             margin: Inset{top: 16, bottom: 16}
             align: Align{x: 0.5, y: 0.5}
             draw_text +: {
-                color: #x808080
+                color: (RBX_FG_TERTIARY)
                 text_style: theme.font_regular { font_size: 13.0 }
             }
         }

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -2,9 +2,51 @@
 use makepad_widgets::*;
 use url::Url;
 
-use crate::{app::{AppState, AppUpdateAction, BotSettingsState}, home::navigation_tab_bar::{NavigationBarAction, get_own_profile}, i18n::{AppLanguage, I18nKey, language_dropdown_labels, tr, tr_fmt, tr_key}, persistence, proxy_config::{validate_proxy_url_for_user_input, ProxyInputError}, profile::user_profile::UserProfile, settings::{account_settings::AccountSettingsWidgetExt, app_preferences::AppPreferences, app_settings::AppSettingsWidgetExt, bot_settings::BotSettingsWidgetExt, translation_settings::TranslationSettingsWidgetExt}, shared::{expand_arrow::ExpandArrow, popup_list::{PopupKind, enqueue_popup_notification}, styles::{apply_neutral_button_style, apply_primary_button_style}}, sliding_sync::current_user_id, updater::{UpdateCheckOutcome, check_for_updates}};
+use crate::{app::{AppState, AppUpdateAction, BotSettingsState}, home::navigation_tab_bar::{NavigationBarAction, get_own_profile}, i18n::{AppLanguage, I18nKey, language_dropdown_labels, tr, tr_fmt, tr_key}, persistence, proxy_config::{validate_proxy_url_for_user_input, ProxyInputError}, profile::user_profile::UserProfile, settings::{account_settings::AccountSettingsWidgetExt, app_preferences::AppPreferences, app_settings::AppSettingsWidgetExt, bot_settings::BotSettingsWidgetExt, translation_settings::TranslationSettingsWidgetExt}, shared::{expand_arrow::ExpandArrow, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::current_user_id, updater::{UpdateCheckOutcome, check_for_updates}};
 
 const CONTRIBUTE_REPO_URL: &str = "https://github.com/Project-Robius-China/robrix2";
+
+/// Teal "selected" style for a settings category tab (solid RBX_ACCENT + white
+/// text), matching the segmented-tab look of the design spec.
+fn apply_settings_tab_selected(cx: &mut Cx, button: &mut ButtonRef) {
+    script_apply_eval!(cx, button, {
+        draw_bg +: {
+            color: mod.widgets.RBX_ACCENT,
+            color_hover: mod.widgets.RBX_ACCENT_HOVER,
+            color_down: mod.widgets.RBX_ACCENT_PRESSED,
+            border_size: 0.0,
+            border_color: #0000,
+            border_color_hover: #0000,
+            border_color_down: #0000,
+        }
+        draw_text +: {
+            color: mod.widgets.RBX_FG_ON_ACCENT,
+            color_hover: mod.widgets.RBX_FG_ON_ACCENT,
+            color_down: mod.widgets.RBX_FG_ON_ACCENT,
+        }
+    });
+}
+
+/// Ghost "unselected" style for a settings category tab (transparent fill,
+/// secondary text, subtle hover wash).
+fn apply_settings_tab_unselected(cx: &mut Cx, button: &mut ButtonRef) {
+    script_apply_eval!(cx, button, {
+        draw_bg +: {
+            color: #0000,
+            color_hover: mod.widgets.RBX_BG_HOVER,
+            color_down: mod.widgets.RBX_BG_PRESSED,
+            border_size: 0.0,
+            border_color: #0000,
+            border_color_hover: #0000,
+            border_color_down: #0000,
+        }
+        draw_text +: {
+            color: mod.widgets.RBX_FG_SECONDARY,
+            color_hover: mod.widgets.RBX_FG_SECONDARY,
+            color_down: mod.widgets.RBX_FG_SECONDARY,
+        }
+    });
+}
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -18,23 +60,28 @@ script_mod! {
         width: Fill, height: Fill,
         flow: Overlay
 
-        View {
-            padding: Inset{top: (SPACE_SM), left: (SETTINGS_CONTENT_PADDING), right: (SETTINGS_CONTENT_PADDING), bottom: (SETTINGS_CONTENT_PADDING)},
+        SolidView {
+            show_bg: true
+            draw_bg.color: (RBX_BG_CANVAS)
+            padding: Inset{top: (SPACE_SM), left: (SETTINGS_CONTENT_PADDING), right: (SETTINGS_CONTENT_PADDING) },
             flow: Down
 
-            // The settings header shows a title, with a close button to the right.
+            // Header: "Settings" title + close button.
             settings_header := View {
                 flow: Right,
                 width: Fill, height: Fit
-                margin: Inset{top: (SPACE_SM), left: (SPACE_XS), right: (SPACE_XS)}
+                margin: Inset{top: (SPACE_SM), left: 0, right: (SPACE_XS)}
                 spacing: (SPACE_SM),
+                align: Align{y: 0.5}
 
                 settings_header_title := TitleLabel {
+                    width: Fill
                     padding: 0,
-                    margin: Inset{ left: 0, top: (SPACE_SM) },
-                    text: "Add/Explore Rooms"
+                    margin: 0,
+                    text: "Settings"
                     draw_text +: {
-                        text_style: theme.font_regular {font_size: 18},
+                        text_style: RBX_TEXT_PAGE_TITLE {},
+                        color: (RBX_FG_PRIMARY)
                     }
                 }
 
@@ -65,7 +112,7 @@ script_mod! {
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    draw_bg +: { border_radius: (RADIUS_MD) }
+                    draw_bg +: { border_radius: (RBX_RADIUS_XS) }
                     text: "Account"
                 }
 
@@ -74,7 +121,7 @@ script_mod! {
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    draw_bg +: { border_radius: (RADIUS_MD) }
+                    draw_bg +: { border_radius: (RBX_RADIUS_XS) }
                     text: "Preferences"
                 }
 
@@ -83,7 +130,7 @@ script_mod! {
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    draw_bg +: { border_radius: (RADIUS_MD) }
+                    draw_bg +: { border_radius: (RBX_RADIUS_XS) }
                     text: "Devices"
                 }
 
@@ -92,7 +139,7 @@ script_mod! {
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    draw_bg +: { border_radius: (RADIUS_MD) }
+                    draw_bg +: { border_radius: (RBX_RADIUS_XS) }
                     text: "Labs"
                 }
 
@@ -101,7 +148,7 @@ script_mod! {
                     padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                     spacing: 0,
                     icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    draw_bg +: { border_radius: (RADIUS_MD) }
+                    draw_bg +: { border_radius: (RBX_RADIUS_XS) }
                     text: "Contribute"
                 }
             }
@@ -145,13 +192,33 @@ script_mod! {
                             margin: Inset{top: (SPACE_XS)}
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
 
-                            preferences_application_language_label := SubsectionLabel {
+                            View {
+                                width: Fill, height: Fit
+                                flow: Right
+                                align: Align{y: 0.5}
+                                spacing: (SPACE_SM)
                                 margin: Inset{top: 0, bottom: (SPACE_XS)}
-                                text: "Application language"
+
+                                SettingsIconCircle {
+                                    width: 30, height: 30
+                                    draw_bg +: { color: (RBX_ACCENT_SOFT) }
+                                    Icon {
+                                        width: 16, height: 16
+                                        draw_icon +: { svg: (ICON_GLOBE), color: (RBX_ACCENT) }
+                                        icon_walk: Walk{width: 16, height: 16}
+                                    }
+                                }
+                                preferences_application_language_label := SubsectionLabel {
+                                    width: Fill
+                                    margin: 0
+                                    text: "Application language"
+                                }
                             }
 
                             // Custom language selector: button + popup list
@@ -259,8 +326,10 @@ script_mod! {
                             flow: Down
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
                             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_SM)}
                             margin: Inset{top: (SPACE_XS)}
@@ -268,9 +337,21 @@ script_mod! {
                             View {
                                 width: Fill, height: Fit
                                 flow: Right
-                                align: Align{x: 1.0, y: 0.5}
+                                align: Align{y: 0.5}
+                                spacing: (SPACE_SM)
+
+                                SettingsIconCircle {
+                                    width: 30, height: 30
+                                    draw_bg +: { color: (RBX_INFO_BG) }
+                                    Icon {
+                                        width: 16, height: 16
+                                        draw_icon +: { svg: (ICON_SHIELD), color: (RBX_INFO_FG) }
+                                        icon_walk: Walk{width: 16, height: 16}
+                                    }
+                                }
 
                                 preferences_proxy_use_label := SubsectionLabel {
+                                    width: Fill
                                     margin: Inset{top: 0, bottom: 0}
                                     text: "Use proxy"
                                 }
@@ -283,8 +364,8 @@ script_mod! {
                                     active: false
                                     draw_bg +: {
                                         size: 20.0
-                                        color_active: (COLOR_ACTIVE_PRIMARY)
-                                        border_color_active: (COLOR_ACTIVE_PRIMARY)
+                                        color_active: (RBX_ACCENT)
+                                        border_color_active: (RBX_ACCENT)
                                         mark_color_active: #fff
                                     }
                                 }
@@ -412,7 +493,7 @@ script_mod! {
                                 align: Align{x: 0.0, y: 0.5}
                                 margin: Inset{top: (SPACE_SM)}
 
-                                preferences_proxy_save_button := RobrixIconButton {
+                                preferences_proxy_save_button := SettingsPrimaryButton {
                                     width: Fit, height: Fit
                                     padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_SM)}
                                     align: Align{x: 0.5, y: 0.5}
@@ -451,8 +532,10 @@ script_mod! {
                             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
                             bot_settings := BotSettings {}
                         }
@@ -464,8 +547,10 @@ script_mod! {
                             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
                             translation_settings := TranslationSettings {}
                         }
@@ -477,8 +562,10 @@ script_mod! {
                             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
                             // The TSP wallet settings section.
                             tsp_settings_screen := TspSettingsScreen {}
@@ -502,13 +589,33 @@ script_mod! {
                             margin: Inset{top: (SPACE_XS)}
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
 
-                            contribute_title := SubsectionLabel {
+                            View {
+                                width: Fill, height: Fit
+                                flow: Right
+                                align: Align{y: 0.5}
+                                spacing: (SPACE_SM)
                                 margin: Inset{top: 0, bottom: (SPACE_XS)}
-                                text: "Contribute"
+
+                                SettingsIconCircle {
+                                    width: 30, height: 30
+                                    draw_bg +: { color: (RBX_ACCENT_SOFT) }
+                                    Icon {
+                                        width: 16, height: 16
+                                        draw_icon +: { svg: (ICON_LINK), color: (RBX_ACCENT) }
+                                        icon_walk: Walk{width: 16, height: 16}
+                                    }
+                                }
+                                contribute_title := SubsectionLabel {
+                                    width: Fill
+                                    margin: 0
+                                    text: "Contribute"
+                                }
                             }
 
                             contribute_description := Label {
@@ -531,7 +638,7 @@ script_mod! {
                                 icon_walk: Walk{width: 0, height: 0}
                                 draw_text +: {
                                     text_style: REGULAR_TEXT { font_size: 10.5 }
-                                    color: #x0000EE,
+                                    color: (RBX_LINK),
                                     color_hover: (COLOR_LINK_HOVER),
                                 }
                                 text: "https://github.com/Project-Robius-China/robrix2"
@@ -544,13 +651,33 @@ script_mod! {
                             padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_MD)}
                             show_bg: true
                             draw_bg +: {
-                                color: #F8F8FA
-                                border_radius: (RADIUS_LG)
+                                color: (RBX_BG_SURFACE)
+                                border_radius: (RBX_RADIUS_SM)
+                                border_size: 1.0
+                                border_color: (RBX_STROKE_SOFT)
                             }
 
-                            about_title := SubsectionLabel {
+                            View {
+                                width: Fill, height: Fit
+                                flow: Right
+                                align: Align{y: 0.5}
+                                spacing: (SPACE_SM)
                                 margin: Inset{top: 0, bottom: (SPACE_XS)}
-                                text: "About Robrix"
+
+                                SettingsIconCircle {
+                                    width: 30, height: 30
+                                    draw_bg +: { color: (RBX_INFO_BG) }
+                                    Icon {
+                                        width: 16, height: 16
+                                        draw_icon +: { svg: (ICON_INFO), color: (RBX_INFO_FG) }
+                                        icon_walk: Walk{width: 16, height: 16}
+                                    }
+                                }
+                                about_title := SubsectionLabel {
+                                    width: Fill
+                                    margin: 0
+                                    text: "About Robrix"
+                                }
                             }
 
                             about_description := Label {
@@ -577,13 +704,13 @@ script_mod! {
                                 text: "Current version: 0.0.0"
                             }
 
-                            contribute_check_update_button := RobrixIconButton {
+                            contribute_check_update_button := SettingsPrimaryButton {
                                 width: Fit, height: Fit,
                                 margin: Inset{left: (ICON_BUTTON_LEFT_PAD)}
                                 padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_MD), right: (SPACE_MD)}
                                 spacing: 0,
                                 icon_walk: Walk{width: 0, height: 0, margin: 0}
-                                draw_bg +: { border_radius: (RADIUS_MD) }
+                                draw_bg +: { border_radius: (RBX_RADIUS_XS) }
                                 text: "Check for Updates"
                             }
                         }
@@ -1180,29 +1307,29 @@ impl SettingsScreen {
         let mut category_contribute_button = self.view.button(cx, ids!(category_contribute_button));
 
         if show_account {
-            apply_primary_button_style(cx, &mut category_account_button);
+            apply_settings_tab_selected(cx, &mut category_account_button);
         } else {
-            apply_neutral_button_style(cx, &mut category_account_button);
+            apply_settings_tab_unselected(cx, &mut category_account_button);
         }
         if show_preferences {
-            apply_primary_button_style(cx, &mut category_preferences_button);
+            apply_settings_tab_selected(cx, &mut category_preferences_button);
         } else {
-            apply_neutral_button_style(cx, &mut category_preferences_button);
+            apply_settings_tab_unselected(cx, &mut category_preferences_button);
         }
         if show_devices {
-            apply_primary_button_style(cx, &mut category_devices_button);
+            apply_settings_tab_selected(cx, &mut category_devices_button);
         } else {
-            apply_neutral_button_style(cx, &mut category_devices_button);
+            apply_settings_tab_unselected(cx, &mut category_devices_button);
         }
         if show_labs {
-            apply_primary_button_style(cx, &mut category_labs_button);
+            apply_settings_tab_selected(cx, &mut category_labs_button);
         } else {
-            apply_neutral_button_style(cx, &mut category_labs_button);
+            apply_settings_tab_unselected(cx, &mut category_labs_button);
         }
         if show_contribute {
-            apply_primary_button_style(cx, &mut category_contribute_button);
+            apply_settings_tab_selected(cx, &mut category_contribute_button);
         } else {
-            apply_neutral_button_style(cx, &mut category_contribute_button);
+            apply_settings_tab_unselected(cx, &mut category_contribute_button);
         }
 
         category_account_button.reset_hover(cx);

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -85,15 +85,25 @@ script_mod! {
                     }
                 }
 
-                // The "X" close button on the top right
+                // The "X" close button on the top right — bare icon, no fill.
                 close_button := RobrixNeutralIconButton {
                     width: Fit,
                     height: Fit,
                     spacing: 0,
                     margin: 0,
-                    padding: (SPACE_LG),
-                    draw_icon.svg: (ICON_CLOSE)
-                    icon_walk: Walk{width: 12, height: 12}
+                    padding: (SPACE_MD),
+                    draw_bg +: {
+                        color: #0000
+                        color_hover: (RBX_BG_HOVER)
+                        color_down: (RBX_BG_PRESSED)
+                        border_size: 0.0
+                        border_color: #0000
+                        border_color_hover: #0000
+                        border_color_down: #0000
+                        border_radius: (RBX_RADIUS_XS)
+                    }
+                    draw_icon +: { svg: (ICON_CLOSE), color: (RBX_FG_SECONDARY) }
+                    icon_walk: Walk{width: 14, height: 14}
                 }
             }
 

--- a/src/settings/translation_settings.rs
+++ b/src/settings/translation_settings.rs
@@ -5,6 +5,10 @@ use crate::{
     i18n::{AppLanguage, tr_fmt, tr_key},
     persistence,
     room::translation::{self, TranslationConfig},
+    shared::design_tokens::{
+        RBX_DANGER_BG, RBX_DANGER_FG, RBX_NEUTRAL_BG, RBX_NEUTRAL_FG,
+        RBX_SUCCESS_BG, RBX_SUCCESS_FG, RBX_WARNING_BG, RBX_WARNING_FG,
+    },
     sliding_sync::current_user_id,
 };
 
@@ -61,8 +65,8 @@ script_mod! {
                 active: false
                 draw_bg +: {
                     size: 20.0
-                    color_active: (COLOR_ACTIVE_PRIMARY)
-                    border_color_active: (COLOR_ACTIVE_PRIMARY)
+                    color_active: (RBX_ACCENT)
+                    border_color_active: (RBX_ACCENT)
                     mark_color_active: #fff
                 }
             }
@@ -147,7 +151,7 @@ script_mod! {
                 spacing: (SPACE_SM)
                 margin: Inset{top: (SPACE_XS)}
 
-                save_button := RobrixIconButton {
+                save_button := SettingsPrimaryButton {
                     padding: Inset{top: 8, bottom: 8, left: 16, right: 16}
                     icon_walk: Walk{width: 0, height: 0}
                     spacing: 0
@@ -161,15 +165,10 @@ script_mod! {
                     text: "Test Connection"
                 }
 
-                test_result_label := Label {
-                    width: Fit, height: Fit
+                test_result_badge := SettingsStatusBadge {
+                    visible: false
                     margin: Inset{left: (SPACE_SM)}
                     align: Align{y: 0.5}
-                    draw_text +: {
-                        color: (COLOR_DISABLED_TEXT)
-                        text_style: REGULAR_TEXT { font_size: 10 }
-                    }
-                    text: ""
                 }
             }
         }
@@ -203,34 +202,22 @@ impl Widget for TranslationSettings {
                         log!("Test translation response: status={}, body={:?}",
                             response.status_code,
                             response.body_string().unwrap_or_default().chars().take(200).collect::<String>());
-                        let label = self.view.label(cx, ids!(test_result_label));
                         match translation::parse_translation_response(response) {
                             Ok(result) => {
-                                let mut lbl = label;
-                                script_apply_eval!(cx, lbl, {
-                                    draw_text +: { color: #x00AA00 }
-                                });
-                                lbl.set_text(cx, &tr_fmt(self.app_language, "settings.labs.translation.test.ok", &[("result", &result)]));
+                                let text = tr_fmt(self.app_language, "settings.labs.translation.test.ok", &[("result", &result)]);
+                                self.show_test_result(cx, RBX_SUCCESS_FG, RBX_SUCCESS_BG, &text);
                             }
                             Err(e) => {
-                                let mut lbl = label;
-                                script_apply_eval!(cx, lbl, {
-                                    draw_text +: { color: #xCC0000 }
-                                });
-                                lbl.set_text(cx, &tr_fmt(self.app_language, "settings.labs.translation.test.failed", &[("error", &e)]));
+                                let text = tr_fmt(self.app_language, "settings.labs.translation.test.failed", &[("error", &e)]);
+                                self.show_test_result(cx, RBX_DANGER_FG, RBX_DANGER_BG, &text);
                             }
                         }
-                        self.view.redraw(cx);
                     }
                 }
                 if let NetworkResponse::HttpError { request_id, error } = response {
                     if *request_id == TEST_TRANSLATION_REQUEST_ID {
-                        let mut label = self.view.label(cx, ids!(test_result_label));
-                        script_apply_eval!(cx, label, {
-                            draw_text +: { color: #xCC0000 }
-                        });
-                        label.set_text(cx, &tr_fmt(self.app_language, "settings.labs.translation.test.error", &[("error", &error.message)]));
-                        self.view.redraw(cx);
+                        let text = tr_fmt(self.app_language, "settings.labs.translation.test.error", &[("error", &error.message)]);
+                        self.show_test_result(cx, RBX_DANGER_FG, RBX_DANGER_BG, &text);
                     }
                 }
             }
@@ -291,20 +278,14 @@ impl WidgetMatchEvent for TranslationSettings {
             let model = self.view.text_input(cx, ids!(model_input)).text().trim().to_string();
 
             if api_url.is_empty() {
-                self.view
-                    .label(cx, ids!(test_result_label))
-                    .set_text(cx, tr_key(self.app_language, "settings.labs.translation.validation.api_url_empty"));
-                self.view.redraw(cx);
+                let text = tr_key(self.app_language, "settings.labs.translation.validation.api_url_empty").to_string();
+                self.show_test_result(cx, RBX_WARNING_FG, RBX_WARNING_BG, &text);
                 return;
             }
 
-            // Show testing status
-            let mut label = self.view.label(cx, ids!(test_result_label));
-            script_apply_eval!(cx, label, {
-                draw_text +: { color: #x999999 }
-            });
-            label.set_text(cx, tr_key(self.app_language, "settings.labs.translation.test.testing"));
-            self.view.redraw(cx);
+            // Show "testing…" status as a neutral pill.
+            let text = tr_key(self.app_language, "settings.labs.translation.test.testing").to_string();
+            self.show_test_result(cx, RBX_NEUTRAL_FG, RBX_NEUTRAL_BG, &text);
 
             // Send a test translation request
             let test_config = TranslationConfig {
@@ -339,6 +320,22 @@ impl TranslationSettings {
         self.app_language = app_language;
         self.app_language_initialized = true;
         self.sync_app_language(cx);
+    }
+
+    /// Show the connection-test result as a status pill: `fg`/`bg` are a semantic
+    /// foreground/background pair (success / warning / danger).
+    fn show_test_result(&mut self, cx: &mut Cx, fg: Vec4, bg: Vec4, text: &str) {
+        let mut badge = self.view.view(cx, ids!(test_result_badge));
+        badge.set_visible(cx, true);
+        script_apply_eval!(cx, badge, {
+            draw_bg +: { color: #(bg) }
+        });
+        let mut label = self.view.label(cx, ids!(test_result_badge.badge_label));
+        script_apply_eval!(cx, label, {
+            draw_text +: { color: #(fg) }
+        });
+        label.set_text(cx, text);
+        self.view.redraw(cx);
     }
 
     fn sync_app_language(&mut self, cx: &mut Cx) {
@@ -392,6 +389,11 @@ impl TranslationSettings {
     fn sync_ui(&mut self, cx: &mut Cx, config: &TranslationConfig) {
         self.view.view(cx, ids!(config_section))
             .set_visible(cx, config.enabled);
+
+        // The test-result pill is a transient per-test status; clear it whenever
+        // the section is (re)synced so a stale result doesn't reappear after a
+        // disable -> re-enable cycle.
+        self.view.view(cx, ids!(test_result_badge)).set_visible(cx, false);
 
         self.view.check_box(cx, ids!(translation_switch))
             .set_active(cx, config.enabled, Animate::No);

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -13,15 +13,18 @@ script_mod! {
     // A confirmation modal with no icons in the buttons.
     // The accept button is blue and the cancel button is gray.
     mod.widgets.ConfirmationModal = #(ConfirmationModal::register_widget(vm)) {
-        width: Fit
+        // Responsive: caps at 520 on desktop, shrinks to fit narrow / mobile
+        // widths so the action buttons never overflow off-screen.
+        width: Fill { max: 520 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
         wrapper := RoundedView {
-            width: 560
+            width: Fill
             height: Fit
             align: Align{x: 0.5}
             flow: Down
-            padding: Inset{top: 30, right: 40, bottom: 20, left: 40}
+            padding: Inset{top: 28, right: 28, bottom: 18, left: 28}
 
             show_bg: true
             draw_bg +: {
@@ -60,11 +63,10 @@ script_mod! {
 
             buttons_view := View {
                 width: Fill, height: Fit
-                flow: Right,
-                padding: Inset{top: 20, bottom: 20}
-                margin: Inset{right: -15}
+                flow: Flow.Right{wrap: true},
+                padding: Inset{top: 18, bottom: 12}
                 align: Align{x: 1.0, y: 0.5}
-                spacing: 20
+                spacing: 12
 
                 cancel_button := RobrixNeutralIconButton {
                     width: 120,

--- a/src/shared/icon_button.rs
+++ b/src/shared/icon_button.rs
@@ -125,4 +125,52 @@ script_mod! {
             color_down: (COLOR_TEXT)
         }
     }
+
+    // Teal primary button for the settings screen (accent CTA — Upload, Save,
+    // Check for Updates, etc.). Uses the RBX_ACCENT brand color instead of the
+    // legacy blue so settings stays on-theme.
+    mod.widgets.SettingsPrimaryButton = mod.widgets.RobrixIconButton {
+        draw_bg +: {
+            color: (RBX_ACCENT)
+            color_hover: (RBX_ACCENT_HOVER)
+            color_down: (RBX_ACCENT_PRESSED)
+            color_disabled: (RBX_BG_DISABLED)
+            border_color: #0000
+            border_color_hover: #0000
+            border_color_down: #0000
+            border_radius: (RBX_RADIUS_SM)
+        }
+        draw_icon.color: (RBX_FG_ON_ACCENT)
+        draw_text +: {
+            color: (RBX_FG_ON_ACCENT)
+            color_hover: (RBX_FG_ON_ACCENT)
+            color_down: (RBX_FG_ON_ACCENT)
+        }
+    }
+
+    // Leading round icon badge for a settings card header / row. Soft accent
+    // tint by default — override `draw_bg.color` for a different tint, and drop
+    // an `Icon { ... }` child inside per use.
+    mod.widgets.SettingsIconCircle = CircleView {
+        width: 34, height: 34
+        align: Align{x: 0.5, y: 0.5}
+        show_bg: true
+        draw_bg +: { color: (RBX_ACCENT_SOFT) }
+    }
+
+    // Status pill: soft-tinted, fully-rounded badge with a bold label. Neutral by
+    // default — override draw_bg.color + badge_label's color for success / warning
+    // / danger / info / accent states.
+    mod.widgets.SettingsStatusBadge = RoundedView {
+        width: Fit, height: Fit
+        align: Align{x: 0.5, y: 0.5}
+        padding: Inset{left: 10, right: 10, top: 4, bottom: 4}
+        show_bg: true
+        draw_bg +: { color: (RBX_NEUTRAL_BG), border_radius: (RBX_RADIUS_PILL) }
+        badge_label := Label {
+            width: Fit, height: Fit
+            draw_text +: { text_style: RBX_TEXT_BADGE {}, color: (RBX_NEUTRAL_FG) }
+            text: ""
+        }
+    }
 }


### PR DESCRIPTION
## What

Re-skins the entire **Settings** screen to the `RBX_*` design-token language used by the room screen and the visual spec. **All existing settings/content are kept** — this is a visual + token-alignment pass, not a behavior change.

### Shell
- Page background → `RBX_BG_CANVAS` so the white cards read as distinct surfaces.
- Header: "Settings" title + close button.
- Category tabs → **teal segmented chips** (selected = solid `RBX_ACCENT` + white text, unselected = ghost), radius matched to the composer (`RBX_RADIUS_XS`).
- Every card normalized to white + `RBX_STROKE_SOFT` border + `RBX_RADIUS_SM`.

### New shared widgets (`src/shared/icon_button.rs`)
- `SettingsPrimaryButton` (teal CTA — replaces the 8 legacy blue buttons), `SettingsIconCircle` (leading round icon badge), `SettingsStatusBadge` (status pill).

### Account
- Avatar + Display Name + User ID **merged into one card** with hairline dividers.
- Compact teal **Upload** + ghost **Remove** avatar actions (wrap on narrow width).
- Copy-user-id button moved **after** the id and shrunk to a ghost icon.
- Multiple-accounts active highlight → soft-teal card + inline **Active** pill.
- Display-name Save/Cancel unified to teal-primary / ghost-neutral.

### Preferences / Devices / Labs
- Token-aligned cards + teal toggles/dropdowns; fixed the clipped send-message toggle; devices page de-hardcoded + device glyph in a tint circle.
- **Octos health** and **translation test result** are now semantic **status pills** (success/warning/danger/neutral); the translation pill is cleared on re-sync so a stale result can't linger.
- Leading circle icons on the major card headers (Multiple Accounts, Other actions, App, Application language, Use proxy, App Service, Contribute, About).

### Shared confirmation modal
- Made responsive (`Fill { max: 520 }` + `Fill` content slots in the Modal mounts) so its action buttons no longer overflow off-screen on mobile.

## Testing
Manually tested on macOS across all five settings categories (avatar upload/remove + delete-confirm dialog, display-name save/cancel, multiple-accounts, language, proxy, devices list, Labs app-service/translation). `cargo build` clean; an adversarial review pass over the diff (id-paths / Makepad pitfalls / behavior) found and fixed a stale-pill regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)