### PR TITLE
fix(mobile): clamp Android safe-area inset + drop illegal wrap in account settings

### DIFF
--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -707,7 +707,15 @@ impl Widget for NavigationTabBar {
         // Keep the mobile bar clear of the bottom safe-area (iOS home indicator).
         // `safe_area_spacer` only exists in the Mobile variant; on Desktop the
         // query returns an empty ref and we skip.
-        let bottom_inset = cx.display_context.safe_area_insets.bottom;
+        //
+        // Clamp the inset: it is only ever a small home-indicator / gesture-nav
+        // gap (~34px on iOS, 0 on most devices). Some Android backends report an
+        // implausibly large value here; applied verbatim it inflates the bar and
+        // pushes the transparent, Fill-height tab buttons up over the room list,
+        // so a tap on the blank area lands on the middle "Add Room" tab. The
+        // ceiling sits well above any real iOS inset, so notch devices are
+        // unaffected.
+        let bottom_inset = cx.display_context.safe_area_insets.bottom.clamp(0.0, 48.0);
         if (bottom_inset - self.applied_safe_bottom).abs() > 0.5 {
             let mut spacer = self.view.view(cx, ids!(safe_area_spacer));
             if spacer.borrow().is_some() {

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -119,7 +119,10 @@ script_mod! {
 
             View {
                 width: Fill, height: Fit
-                flow: Right { wrap: true },
+                // NOTE: plain `flow: Right` (not wrap) — this row has a `width: Fill`
+                // action column child, and `flow: Right { wrap: true }` does not
+                // support Fill-width children (logs a turtle error every frame).
+                flow: Right,
                 align: Align{y: 0.5}
                 spacing: (SPACE_LG)
 


### PR DESCRIPTION
Verified on a physical Android device. Two related mobile fixes:

## 1. Android nav bar overlaps content → tap blank area enters "Add Room"
`navigation_tab_bar.rs` sizes its `safe_area_spacer` in `draw_walk` directly from `cx.display_context.safe_area_insets.bottom`. The bar is `flow: Down, Fit` → `[hairline · button-row(56) · spacer]`, and the tab buttons are transparent (`#00000000`) with `height: Fill`.

- **iOS**: small home-indicator inset (~34px) → bar sits at the bottom. Fine.
- **Android**: the backend reports an implausibly large `safe_area_insets.bottom`. Applied verbatim it inflates the bar and pushes the invisible tab buttons up over the room list, so a **tap (or swipe) on the blank Home area lands on the middle "Add Room" tab** → `GoToAddRoom`.

Localized via a branch *without* #209 (no bug) vs *with* #209 (bug); #209 introduced the `safe_area_insets.bottom` sizing.

**Fix:** clamp the inset to `[0, 48]`. Real iOS insets are well under the ceiling (unaffected); a bad platform value can no longer mis-size the bar.

## 2. `flow: Right { wrap: true }` turtle error spamming logcat
The account-settings avatar row used `flow: Right { wrap: true }` with a `width: Fill` action-column child. Makepad's wrapping Right flow does not support Fill-width children, so it logged `flow: Right { wrap: true } does not support width: Fill` every frame the Settings screen drew. Switched that one row to plain `flow: Right` (avatar + fill-rest column layout unchanged). All other wrap rows were audited and are legitimate (text-wrapping labels / Fit-width button rows).

## Verification
- `cargo build` ✓
- On-device Android: blank-area tap no longer enters Add Room; the bottom bar sits correctly; the turtle error no longer appears in logcat. (The raw over-reported inset was confirmed with temporary logging, since removed.)
