### PR TITLE
fix(mobile): white safe areas, single bottom inset, keyboard-safe composer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,7 @@ script_mod! {
             main_window := Window {
                 window.inner_size: vec2(1280, 800)
                 window.title: "Robrix"
-                pass.clear_color: (COLOR_SECONDARY)
+                pass.clear_color: (RBX_BG_SURFACE)
                 caption_bar +: {
                     draw_bg.color: #F3F3F3
                     caption_label +: {
@@ -62,7 +62,10 @@ script_mod! {
 
                 body +: {
                     show_bg: true
-                    draw_bg.color: (COLOR_SECONDARY)
+                    // White safe-area fill (status bar + home indicator regions),
+                    // unified with the white app chrome. The content inside is
+                    // inset by the platform safe-area via the padding below.
+                    draw_bg.color: (RBX_BG_SURFACE)
                     padding: Inset{
                         top: (mod.widgets.SAFE_INSET_PAD_TOP),
                         bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -305,13 +305,10 @@ script_mod! {
                     draw_icon +: { svg: (ICON_SETTINGS) }
                 }
             }
-
-            // Bottom safe-area inset (iOS home indicator). Height is set at
-            // runtime in `draw_walk` from `cx.display_context.safe_area_insets`;
-            // it is 0 on desktop / non-notch devices, so the bar stays 56px high.
-            safe_area_spacer := View {
-                width: Fill, height: 0.0
-            }
+            // No per-bar safe-area spacer: the window `body` already insets all
+            // content by the platform safe area (SAFE_INSET_PAD_*), so the bar is
+            // a consistent height on iOS and Android. (Supersedes the spacer inset
+            // clamp from #217 — there is no spacer left to inflate.)
         }
     }
 }
@@ -542,9 +539,6 @@ pub struct NavigationTabBar {
     #[rust] applied_selected_tab: Option<SelectedTab>,
     /// The language the tab labels are currently rendered in.
     #[rust] applied_language: Option<AppLanguage>,
-    /// The bottom safe-area inset currently applied to the mobile bar spacer.
-    /// `-1.0` forces a (re-)apply (initial draw / after a view-mode rebuild).
-    #[rust(-1.0)] applied_safe_bottom: f64,
 }
 
 impl ScriptHook for NavigationTabBar {
@@ -567,10 +561,9 @@ impl NavigationTabBar {
         self.view.set_variant_selector(mode.variant_selector());
         self.applied_view_mode = mode;
         // Switching variants rebuilds the (non-cached) mobile tab buttons, so
-        // force the labels, active highlight, and safe-area spacer to re-apply.
+        // force the labels and active highlight to re-apply.
         self.applied_selected_tab = None;
         self.applied_language = None;
-        self.applied_safe_bottom = -1.0;
     }
 
     /// Localize the mobile tab labels. (Harmless on Desktop, where the rail
@@ -704,27 +697,8 @@ impl Widget for NavigationTabBar {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        // Keep the mobile bar clear of the bottom safe-area (iOS home indicator).
-        // `safe_area_spacer` only exists in the Mobile variant; on Desktop the
-        // query returns an empty ref and we skip.
-        //
-        // Clamp the inset: it is only ever a small home-indicator / gesture-nav
-        // gap (~34px on iOS, 0 on most devices). Some Android backends report an
-        // implausibly large value here; applied verbatim it inflates the bar and
-        // pushes the transparent, Fill-height tab buttons up over the room list,
-        // so a tap on the blank area lands on the middle "Add Room" tab. The
-        // ceiling sits well above any real iOS inset, so notch devices are
-        // unaffected.
-        let bottom_inset = cx.display_context.safe_area_insets.bottom.clamp(0.0, 48.0);
-        if (bottom_inset - self.applied_safe_bottom).abs() > 0.5 {
-            let mut spacer = self.view.view(cx, ids!(safe_area_spacer));
-            if spacer.borrow().is_some() {
-                self.applied_safe_bottom = bottom_inset;
-                script_apply_eval!(cx, spacer, {
-                    height: #(bottom_inset)
-                });
-            }
-        }
+        // The bottom safe-area inset is handled globally by the window `body`
+        // padding (SAFE_INSET_PAD_*), so the bar needs no per-widget spacer.
         self.view.draw_walk(cx, scope, walk)
     }
 }

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -1060,26 +1060,26 @@ script_mod! {
                     flow: Down
                     spacing: 4
 
-                    // Composer on TOP, toolbar BELOW — matches the reference
-                    // design (message input above, actions + send beneath).
-                    // NOTE: on mobile this puts the toolbar/send below the focused
-                    // IME field, so the on-screen keyboard can cover it while
-                    // typing (keyboard avoidance only lifts the focused field).
-                    // Acceptable for the desktop-first redesign; revisit with an
-                    // adaptive (mobile = toolbar-on-top) layout if mobile needs it.
-                    message_row := View {
-                        width: Fill, height: Fit
-                        flow: Right
-                        mentionable_text_input := MessageInputField {}
-                    }
-
-                    // Action toolbar: left icon cluster + Filler + send (bottom-right).
+                    // Tool toolbar on TOP; the text input + send on the BOTTOM row.
+                    // makepad's KeyboardView lifts only the focused field (+ a small
+                    // gap), so the focused input — and the send button beside it —
+                    // must be the bottom-most elements to stay above the on-screen
+                    // keyboard, while the tool toolbar stays visible above it.
                     button_row := View {
                         width: Fill, height: Fit
                         flow: Right
                         align: Align{y: 0.5}
                         LeftActionButtons {}
                         Filler { height: Fit }
+                    }
+
+                    // Bottom row: message input (fill) + send button (right). This
+                    // is the focused row, so it rides just above the soft keyboard.
+                    message_row := View {
+                        width: Fill, height: Fit
+                        flow: Right
+                        align: Align{y: 1.0}
+                        mentionable_text_input := MessageInputField {}
                         RightActionButtons {}
                     }
                 }


### PR DESCRIPTION
Three mobile-chrome fixes found while device-testing the rooms-list redesign (#216). Visual/layout only; `cargo build` clean.

## 1. Safe areas → white
The window `body` fills its safe-area padding (status bar + home-indicator regions) with its own background, which was gray (`COLOR_SECONDARY`). Switched the body bg **and** the window `pass.clear_color` to white (`RBX_BG_SURFACE`) so the safe areas match the white app chrome.

## 2. Bottom tab bar — remove double inset
The window `body` already insets all content by the platform safe area (`SAFE_INSET_PAD_*`), and the mobile tab bar **also** added a `safe_area_spacer` of the same inset in `draw_walk` — so the bottom inset was applied **twice**, leaving an extra band under the bar (visible on iOS).

Dropped the redundant spacer (+ its field / reset / draw logic) and rely on the global body padding, which is uniform on iOS and Android.

> **Interaction with #217:** #217 clamped this spacer's inset to `[0,48]` to stop a bad Android value from inflating the bar. Removing the spacer makes that clamp moot (no spacer left to inflate) and fixes the deeper double-count. If the team prefers, the same `[0,48]` clamp can instead be applied to the body padding — happy to adjust.

## 3. Composer no longer hidden by the keyboard
makepad's Window `body` is a `KeyboardView` that lifts only the **focused field** (+ ~30px). The composer had the toolbar/send **below** the text input, so the keyboard covered them while typing (the original author flagged this in a comment).

Reordered the composer: **tool toolbar on top**, **`[input + send]` as the bottom-most (focused) row** — so the input and the send button beside it ride above the keyboard while the tools stay visible above. (This also reorders the desktop composer to tools-on-top; no keyboard there, so it's cosmetic. Can be made mobile-only adaptive if desktop should keep input-on-top.)

## Testing
Run-tested on iOS (`cargo run`): safe areas white, tab bar single-height, keyboard no longer covers the composer's tools/send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)