### PR TITLE
chore: bump version to 1.0.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "robrix"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 categories = ["gui"]
 repository = "https://github.com/Project-Robius-China/robrix2"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]


### PR DESCRIPTION
Bumps the crate version `1.0.0-alpha.1` → `1.0.0-alpha.2` (`Cargo.toml` + `Cargo.lock`).

Marks a release including the recently-merged work (notification redesign #218, mobile safe-area fixes #219).

After this merges, tag `v1.0.0-alpha.2` on the resulting `main` commit (this repo squash-merges, so the tag must point to the merged commit rather than this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)