### PR TITLE
fix(clippy): resolve clippy warnings in notification + roomlist code

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -8041,7 +8041,7 @@ impl RoomScreen {
                             .unwrap_or(tr_key(self.app_language, "room_screen.fallback.unnamed_room")),
                     );
                     let tl_kind_retry = tl.kind.clone();
-                    let direction_retry = direction.clone();
+                    let direction_retry = direction;
                     enqueue_notification(NotificationItem {
                         kind: PopupKind::Error,
                         title: Some("Pagination failed".into()),
@@ -8051,7 +8051,7 @@ impl RoomScreen {
                                 submit_async_request(MatrixRequest::PaginateTimeline {
                                     timeline_kind: tl_kind_retry.clone(),
                                     num_events: 30,
-                                    direction: direction_retry.clone(),
+                                    direction: direction_retry,
                                 });
                             }),
                             NotificationAction::new("Copy details", NotifActionStyle::Neutral, move |cx| {

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -505,25 +505,14 @@ impl RoomsListEntryContent {
             RBX_BG_SUNKEN, RBX_FG_PRIMARY, RBX_FG_SECONDARY, RBX_FG_TERTIARY,
         };
 
-        let message_text_color;
-        let room_name_color;
-        let timestamp_color;
-        let code_bg_color;
-
         // The selected row uses a soft teal wash (RBX_BG_SELECTED) plus a teal
         // accent outline (see the draw_bg shader) to signal the active room, so
-        // the text stays dark and fully legible in both states.
-        if is_selected {
-            message_text_color = RBX_FG_SECONDARY;
-            room_name_color = RBX_FG_PRIMARY;
-            timestamp_color = RBX_FG_TERTIARY;
-            code_bg_color = RBX_BG_SUNKEN;
-        } else {
-            message_text_color = RBX_FG_SECONDARY;
-            room_name_color = RBX_FG_PRIMARY;
-            timestamp_color = RBX_FG_TERTIARY;
-            code_bg_color = RBX_BG_SUNKEN;
-        }
+        // the text stays dark and fully legible in both states — i.e. the text
+        // colors are identical for selected and unselected rows.
+        let message_text_color = RBX_FG_SECONDARY;
+        let room_name_color = RBX_FG_PRIMARY;
+        let timestamp_color = RBX_FG_TERTIARY;
+        let code_bg_color = RBX_BG_SUNKEN;
 
         // Toggle the background color via the animator (handles selected/deselected bg).
         self.animator_toggle(cx, is_selected, Animate::No, ids!(selected.on), ids!(selected.off));

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -941,9 +941,7 @@ impl Widget for SettingsScreen {
                                 message: tr_fmt(self.app_language, "room_screen.popup.open_url_failed", &[("url", url.as_str())]).into(),
                                 actions: vec![
                                     NotificationAction::new("Retry", NotifActionStyle::Primary, move |_cx| {
-                                        if let Err(_) = robius_open::Uri::new(&url_for_retry).open() {
-                                            // Silently ignore retry failure
-                                        }
+                                        let _ = robius_open::Uri::new(&url_for_retry).open();
                                     }),
                                     NotificationAction::new("Copy error", NotifActionStyle::Neutral, move |cx| {
                                         cx.copy_to_clipboard(&error_msg);

--- a/src/shared/popup_list.rs
+++ b/src/shared/popup_list.rs
@@ -162,6 +162,9 @@ pub enum NotifActionStyle {
     Danger,
 }
 
+/// Click handler stored for a notification action button.
+pub type ActionCallback = Box<dyn FnMut(&mut Cx) + Send>;
+
 /// A custom button shown in the footer of a notification card.
 ///
 /// `on_click` runs (with `&mut Cx`) when the button is tapped; the card then
@@ -170,7 +173,7 @@ pub enum NotifActionStyle {
 pub struct NotificationAction {
     pub label: Cow<'static, str>,
     pub style: NotifActionStyle,
-    pub on_click: Box<dyn FnMut(&mut Cx) + Send>,
+    pub on_click: ActionCallback,
 }
 
 impl NotificationAction {
@@ -478,7 +481,7 @@ struct PopupEntry {
     is_notification: bool,
     /// Click handlers for action buttons 0..N, parallel to the visible buttons.
     /// Empty for toasts and for action-less notifications.
-    actions: Vec<Box<dyn FnMut(&mut Cx) + Send>>,
+    actions: Vec<ActionCallback>,
 }
 
 /// The overlay host that owns and draws all live popups.
@@ -571,7 +574,7 @@ impl Widget for RobrixPopupNotification {
             cx.begin_root_turtle(size, self.layout);
             self.draw_bg.begin(cx, self.walk, self.layout);
             for popup in self.popups.iter_mut() {
-                let _ = popup.view.draw_all(cx, scope);
+                popup.view.draw_all(cx, scope);
             }
             self.draw_bg.end(cx);
             cx.end_pass_sized_turtle();
@@ -622,9 +625,9 @@ impl RobrixPopupNotification {
 
     fn add_toast(&mut self, cx: &mut Cx, item: PopupItem, desktop: bool) {
         let ptr = if desktop { self.toast_desktop } else { self.toast_mobile };
-        let mut view = view_from_live_ptr(cx, ptr);
+        let view = view_from_live_ptr(cx, ptr);
         view.label(cx, ids!(toast_label)).set_text(cx, &item.message);
-        apply_kind_visuals(cx, &mut view, item.kind, NotificationIcon::Auto);
+        apply_kind_visuals(cx, &view, item.kind, NotificationIcon::Auto);
 
         self.enforce_toast_cap(cx, desktop);
 
@@ -667,7 +670,7 @@ impl RobrixPopupNotification {
 
     fn instantiate_notification(&mut self, cx: &mut Cx, mut ni: NotificationItem, desktop: bool) {
         let ptr = if desktop { self.notif_desktop } else { self.notif_mobile };
-        let mut view = view_from_live_ptr(cx, ptr);
+        let view = view_from_live_ptr(cx, ptr);
 
         let title = ni
             .title
@@ -675,14 +678,14 @@ impl RobrixPopupNotification {
             .unwrap_or_else(|| Cow::Borrowed(default_title(ni.kind)));
         view.label(cx, ids!(notif_title)).set_text(cx, &title);
         view.label(cx, ids!(notif_label)).set_text(cx, &ni.message);
-        apply_kind_visuals(cx, &mut view, ni.kind, ni.icon);
+        apply_kind_visuals(cx, &view, ni.kind, ni.icon);
 
         let mut actions: Vec<NotificationAction> = ni.actions.drain(..).collect();
         actions.truncate(3);
         let has_actions = !actions.is_empty();
         view.view(cx, ids!(actions_row)).set_visible(cx, has_actions);
 
-        let mut closures: Vec<Box<dyn FnMut(&mut Cx) + Send>> = Vec::new();
+        let mut closures: Vec<ActionCallback> = Vec::new();
         for (i, action) in actions.into_iter().enumerate() {
             let btn = match i {
                 0 => view.button(cx, ids!(action_btn_0)),
@@ -694,7 +697,7 @@ impl RobrixPopupNotification {
             style_action_button(cx, btn, action.style);
             closures.push(action.on_click);
         }
-        if closures.len() < 1 {
+        if closures.is_empty() {
             view.widget(cx, ids!(action_btn_0)).set_visible(cx, false);
         }
         if closures.len() < 2 {
@@ -825,10 +828,10 @@ fn popup_from_notification(ni: NotificationItem) -> PopupItem {
 /// or hides the circle entirely when there is nothing to show.
 fn apply_kind_visuals(cx: &mut Cx, view: &View, kind: PopupKind, icon: NotificationIcon) {
     let mut circle = view.view(cx, ids!(icon_circle));
-    let show = !matches!(icon, NotificationIcon::Hidden)
-        && !(kind == PopupKind::Blank && matches!(icon, NotificationIcon::Auto));
-    circle.set_visible(cx, show);
-    if !show {
+    let hide = matches!(icon, NotificationIcon::Hidden)
+        || (kind == PopupKind::Blank && matches!(icon, NotificationIcon::Auto));
+    circle.set_visible(cx, !hide);
+    if hide {
         return;
     }
 


### PR DESCRIPTION
Clears the 11 clippy warnings the CI lint job flagged after #218.

**`src/shared/popup_list.rs`** (notification widgets)
- `type ActionCallback = Box<dyn FnMut(&mut Cx) + Send>` alias — fixes two `clippy::type_complexity`.
- drop redundant `let _ =` on the unit-returning `draw_all` (`let_unit_value`).
- pass `&View` instead of `&mut` to `apply_kind_visuals` ×2 (`unnecessary_mut_passed`).
- `closures.is_empty()` instead of `len() < 1` (`len_zero`).
- simplify the icon-visibility boolean (`nonminimal_bool`).

**`src/settings/settings_screen.rs`** — `let _ = ...open()` instead of `if let Err(_) = ...` (`redundant_pattern_matching`).

**`src/home/room_screen.rs`** — drop `.clone()` on the `Copy` `PaginationDirection` ×2 (`clone_on_copy`).

**`src/home/rooms_list_entry.rs`** — collapse an identical `if is_selected {} else {}` (`if_same_then_else`). Both branches intentionally set the same text colors — selection is shown via the bg wash + teal outline, per the existing comment — so this is behavior-preserving.

Verified with a forced fresh `cargo clippy --lib`: 0 warnings, clean compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)