### PR TITLE
feat(desktop): dark navy left navigation rail + spaces/dock fixes

### DIFF
--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -303,6 +303,10 @@ script_mod! {
 
                 show_bg: true
                 draw_bg +: {
+                    // Neutral desktop backdrop (NOT navy — a navy backdrop showed
+                    // through as a dark ring around the content). The rail covers its
+                    // own column edge-to-edge (SolidView) and the dock sits flush
+                    // against it, so this backdrop is barely visible.
                     color: (COLOR_SECONDARY)
                 }
 

--- a/src/home/light_themed_dock.rs
+++ b/src/home/light_themed_dock.rs
@@ -132,17 +132,20 @@ script_mod! {
         draw_text +: {
             text_style: theme.font_regular {}
 
-            color: #000
-            color_hover: #fe8610
-            color_active: COLOR_PRIMARY
+            // Unified palette: dark text on the neutral unselected tab, white on the
+            // teal selected tab. (No more orange hover text.)
+            color: (RBX_FG_PRIMARY)
+            color_hover: (RBX_FG_PRIMARY)
+            color_active: (COLOR_PRIMARY)
         }
 
         draw_bg +: {
-            // Light blue-ish color, de-saturated from COLOR_ACTIVE_PRIMARY
-            color: #E1EEFA
-            // A slightly darker shade of the tab color for hover visibility
-            color_hover: #C8DDEF
-            color_active: COLOR_ACTIVE_PRIMARY
+            // Unselected tabs: subtle neutral surface. Selected tab: teal accent
+            // (RBX_ACCENT) — the unified UI selection color, replacing the legacy
+            // bright blue COLOR_ACTIVE_PRIMARY.
+            color: (RBX_BG_SURFACE_SUBTLE)
+            color_hover: (RBX_BG_HOVER)
+            color_active: (RBX_ACCENT)
             // Remove the border and rounded corners from the default Tab style
             border_size: 0.0
             border_radius: 3.0
@@ -225,6 +228,18 @@ script_mod! {
 
         round_corner +: {
             color: COLOR_SECONDARY
+
+            // Flat dock: draw NO rounded-corner slivers. The panels stay flush
+            // rectangles (rooms list butts square against the navy rail; the
+            // main/timeline panel is square too). The round-corner trick paints a
+            // small corner sliver in the BACKDROP color to fake rounding — but that
+            // only works when the sliver color matches whatever is behind the panel.
+            // Once the desktop backdrop went navy, the grey slivers showed up as
+            // grey notches at the panel corners (e.g. the tab bar's top-right corner
+            // against navy). Drawing nothing keeps every corner clean on any backdrop.
+            pixel: fn() {
+                return #x00000000
+            }
         }
 
         padding: Inset{left: theme.dock_border_size, top: 0, right: theme.dock_border_size, bottom: theme.dock_border_size}

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -24,8 +24,9 @@ script_mod! {
             height: Fill,
             padding: 0,
             spacing: 0,
-            // Align the dock with the RoomFilterInputBar. Not sure why we need this...
-            margin: Inset{left: 1.75}
+            // Sit flush against the dark navigation rail: no left margin, so the
+            // rooms-list panel butts directly against the rail with no grey gutter gap.
+            margin: 0
 
             tab_bar +: {
                 CloseableTab := mod.widgets.RobrixTab { closeable: true }

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -65,37 +65,100 @@ script_mod! {
         spacing: 0,
 
         draw_bg +: {
-            color: (COLOR_NAVIGATION_TAB_BG)
-            color_hover: (COLOR_NAVIGATION_TAB_BG_HOVER)
-            color_down: (COLOR_NAVIGATION_TAB_BG_HOVER)
-            color_active: (COLOR_NAVIGATION_TAB_BG_ACTIVE)
-            color_focus: (COLOR_NAVIGATION_TAB_BG_ACTIVE)
+            // Dark navy nav-rail item (visual spec §5.6 / RBX_NAV_* tokens):
+            // transparent when idle so the navy rail shows through, a navy "pill"
+            // on hover/active, plus a teal accent bar on the left of the *active*
+            // item to echo the app-wide teal selection language.
+            color: #0000
+            color_hover: (RBX_NAV_ITEM_HOVER_BG)
+            color_down: (RBX_NAV_ITEM_HOVER_BG)
+            color_active: (RBX_NAV_ITEM_ACTIVE_BG)
+            color_focus: #0000
+            accent_color: instance((RBX_ACCENT))
 
             border_size: 0.0
-            border_radius: (RADIUS_MD)
+            border_radius: (RBX_RADIUS_SM)
             border_color: #0000
             border_color_hover: #0000
             border_color_down: #0000
             border_color_active: #0000
             border_color_focus: #0000
+
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                sdf.box(
+                    self.border_size,
+                    self.border_size,
+                    self.rect_size.x - self.border_size * 2.0,
+                    self.rect_size.y - self.border_size * 2.0,
+                    self.border_radius
+                )
+                let color_fill = self.color
+                    .mix(self.color_focus, self.focus)
+                    .mix(self.color_active, self.active)
+                    .mix(self.color_hover, self.hover)
+                    .mix(self.color_down, self.down)
+                sdf.fill(color_fill)
+                // Teal selection bar on the left edge, shown only when active.
+                let bar_inset = 12.0
+                sdf.box(
+                    0.0,
+                    bar_inset,
+                    3.0,
+                    self.rect_size.y - bar_inset * 2.0,
+                    1.5
+                )
+                sdf.fill(mix(vec4(0.0, 0.0, 0.0, 0.0), self.accent_color, self.active))
+                return sdf.result
+            }
         }
 
         draw_text +: {
-            color: (COLOR_NAVIGATION_TAB_FG)
-            color_hover: (COLOR_NAVIGATION_TAB_FG_HOVER)
-            color_down: (COLOR_NAVIGATION_TAB_FG_HOVER)
-            color_active: (COLOR_NAVIGATION_TAB_FG_ACTIVE)
-            color_focus: (COLOR_NAVIGATION_TAB_FG_ACTIVE)
+            // Labels are hidden on the desktop rail (label_walk is zero-sized),
+            // but keep the colors on the nav palette for correctness.
+            color: (RBX_NAV_FG)
+            color_hover: (RBX_NAV_FG_ACTIVE)
+            color_down: (RBX_NAV_FG_ACTIVE)
+            color_active: (RBX_NAV_FG_ACTIVE)
+            color_focus: (RBX_NAV_FG)
 
             text_style: theme.font_bold {font_size: 9}
         }
 
         draw_icon +: {
-            color: (COLOR_NAVIGATION_TAB_FG)
-            color_hover: (COLOR_NAVIGATION_TAB_FG_HOVER)
-            color_down: (COLOR_NAVIGATION_TAB_FG_HOVER)
-            color_active: (COLOR_NAVIGATION_TAB_FG_ACTIVE)
-            color_focus: (COLOR_NAVIGATION_TAB_FG_ACTIVE)
+            // DrawSvg has no per-state color mixing, so the active/idle icon color
+            // is driven by the animator's `active` apply blocks below (white when
+            // selected, muted grey otherwise) — mirrors MobileTabButton.
+            color: (RBX_NAV_FG)
+        }
+
+        // Custom animator: drive the pill (draw_bg amounts), the (hidden) label and
+        // — crucially — the icon color from the active/hover states. Selecting a tab
+        // snaps the icon to white (RBX_NAV_FG_ACTIVE); deselecting returns it to the
+        // muted RBX_NAV_FG. Mirrors the base RadioButton animator + MobileTabButton's
+        // draw_icon trick.
+        animator: Animator {
+            disabled: {
+                default: @off
+                off: AnimatorState { from: {all: Forward {duration: 0.0}} apply: { draw_bg: {disabled: 0.0} draw_text: {disabled: 0.0} } }
+                on:  AnimatorState { from: {all: Forward {duration: 0.2}} apply: { draw_bg: {disabled: 1.0} draw_text: {disabled: 1.0} } }
+            }
+            hover: {
+                default: @off
+                off:  AnimatorState { from: {all: Forward {duration: 0.15}} apply: { draw_bg: {down: snap(0.0), hover: 0.0} draw_text: {down: snap(0.0), hover: 0.0} } }
+                on:   AnimatorState { from: {all: Snap} apply: { draw_bg: {down: snap(0.0), hover: 1.0} draw_text: {down: snap(0.0), hover: 1.0} } }
+                down: AnimatorState { from: {all: Forward {duration: 0.2}} apply: { draw_bg: {down: snap(1.0), hover: 1.0} draw_text: {down: snap(1.0), hover: 1.0} } }
+            }
+            active: {
+                default: @off
+                off: AnimatorState { from: {all: Forward {duration: 0.2}} apply: { draw_bg: {active: 0.0} draw_text: {active: 0.0} draw_icon: {color: (RBX_NAV_FG)} } }
+                on:  AnimatorState { from: {all: Forward {duration: 0.0}} apply: { draw_bg: {active: 1.0} draw_text: {active: 1.0} draw_icon: {color: (RBX_NAV_FG_ACTIVE)} } }
+            }
+            focus: {
+                default: @off
+                off: AnimatorState { from: {all: Forward {duration: 0.2}} apply: { draw_bg: {focus: 0.0} draw_text: {focus: 0.0} } }
+                on:  AnimatorState { from: {all: Forward {duration: 0.0}} apply: { draw_bg: {focus: 1.0} draw_text: {focus: 1.0} } }
+            }
         }
     }
 
@@ -223,20 +286,22 @@ script_mod! {
         draw_icon +: { svg: (ICON_ADD) }
     }
 
-    mod.widgets.Separator = LineH { margin: (SPACE_SM) }
+    mod.widgets.Separator = LineH { margin: (SPACE_SM), draw_bg.color: (RBX_NAV_DIVIDER) }
 
     mod.widgets.NavigationTabBar = #(NavigationTabBar::register_widget(vm)) {
-        Desktop := RoundedView {
+        Desktop := SolidView {
             flow: Down,
             align: Align{x: 0.5}
             padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_XS), right: (SPACE_XS)}
-            width: (NAVIGATION_TAB_BAR_SIZE), 
+            width: (NAVIGATION_TAB_BAR_SIZE),
             height: Fill
 
-            draw_bg +: {
-                color: (COLOR_SECONDARY)
-                border_radius: (RADIUS_LG)
-            }
+            show_bg: true
+            // Dark navy anchor rail (visual spec §2/§5.6). SolidView fills its column
+            // edge-to-edge (no rounded-SDF anti-aliased border), so the navy is
+            // perfectly flush to the window's left edge AND to the rooms list — no
+            // stray hairline gap on either side.
+            draw_bg.color: (RBX_NAV_BG)
 
             CachedWidget {
                 profile_icon := mod.widgets.ProfileIcon {}

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{RoomDisplayName, RoomState};
 use ruma::{OwnedRoomAliasId, OwnedRoomId, room::JoinRuleSummary};
 
 use crate::{
-    app::AppState, home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, room_filter_input_bar::MainFilterAction}, sliding_sync::AccountSwitchAction, utils::{self, RoomNameId}
+    app::AppState, home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, design_tokens::{RBX_FG_SECONDARY, RBX_NAV_FG}, room_filter_input_bar::MainFilterAction}, sliding_sync::AccountSwitchAction, utils::{self, RoomNameId}
 };
 
 script_mod! {
@@ -41,8 +41,12 @@ script_mod! {
             active: instance(0.0)
 
             color: instance(#0000)
-            color_hover: instance((COLOR_NAVIGATION_TAB_BG_HOVER))
-            color_active: instance((COLOR_NAVIGATION_TAB_BG_ACTIVE))
+            // Teal selection wash, kept translucent so it reads on BOTH the dark
+            // desktop rail AND the light mobile spaces strip (this entry template is
+            // shared by both). The strong selection signal is the teal bar below.
+            color_hover: instance(#x119FB324)
+            color_active: instance(#x119FB33D)
+            accent_color: instance((RBX_ACCENT))
 
             border_color: instance(#0000)
             border_size: uniform(0.0)
@@ -74,6 +78,16 @@ script_mod! {
                 if self.border_size > 0.0 {
                     sdf.stroke(self.border_color, self.border_size)
                 }
+                // Teal selection bar on the left edge, shown only when active.
+                let bar_inset = 16.0
+                sdf.box(
+                    0.0,
+                    bar_inset,
+                    3.0,
+                    self.rect_size.y - bar_inset * 2.0,
+                    1.5
+                )
+                sdf.fill(mix(vec4(0.0, 0.0, 0.0, 0.0), self.accent_color, self.active))
                 return sdf.result;
             }
         }
@@ -81,9 +95,10 @@ script_mod! {
         avatar := Avatar {
             width: mod.widgets.NAVIGATION_TAB_BAR_AVATAR_SIZE
             height: mod.widgets.NAVIGATION_TAB_BAR_AVATAR_SIZE
-            // If no avatar picture, use white text on a dark background.
+            // If no avatar picture, use white text on the teal identity square
+            // (RBX_IDENTITY_TEAL) — reads well on both the dark rail and light strip.
             text_view +: {
-                draw_bg.color: (COLOR_FG_DISABLED),
+                draw_bg.color: (RBX_IDENTITY_TEAL),
                 text +: {
                     draw_text +: {
                         text_style: theme.font_regular { font_size: mod.widgets.NAVIGATION_TAB_BAR_AVATAR_FONT_SIZE },
@@ -107,9 +122,9 @@ script_mod! {
                 hover: instance(0.0)
                 down: instance(0.0)
 
-                color: (COLOR_NAVIGATION_TAB_FG)
-                color_hover: uniform(COLOR_NAVIGATION_TAB_FG_HOVER)
-                color_active: uniform(COLOR_NAVIGATION_TAB_FG_ACTIVE)
+                color: (RBX_NAV_FG)
+                color_hover: uniform(RBX_NAV_FG_ACTIVE)
+                color_active: uniform(RBX_NAV_FG_ACTIVE)
 
                 // text_style: theme.font_bold {font_size: 9}
                 text_style: REGULAR_TEXT {font_size: 9}
@@ -188,7 +203,10 @@ script_mod! {
             flow: Flow.Right{wrap: true},
             align: Align{ x: 0.5, y: 0.5 }
             draw_text +: {
-                color: (MESSAGE_TEXT_COLOR),
+                // Default to the light nav-rail foreground (desktop). The mobile
+                // strip overrides this to a darker tone at runtime in draw_walk,
+                // since this status label is shared across both view modes.
+                color: (RBX_NAV_FG),
                 text_style: REGULAR_TEXT {font_size: 9}
             }
         }
@@ -218,7 +236,10 @@ script_mod! {
         Desktop := View {
             align: Align{x: 0.5, y: 0.5}
             padding: 0,
-            width: (NAVIGATION_TAB_BAR_SIZE), 
+            // Fill the rail's content width (rail is NAVIGATION_TAB_BAR_SIZE wide with
+            // SPACE_XS padding); a fixed NAVIGATION_TAB_BAR_SIZE here overflows that
+            // padded area and pushes the avatars off-center vs the Home/Add buttons.
+            width: Fill,
             height: Fill
 
             CachedWidget {
@@ -607,6 +628,17 @@ impl Widget for SpacesBar {
         let app_language = scope.data.get::<AppState>()
             .map(|app_state| app_state.app_language)
             .unwrap_or_default();
+        let is_desktop = effective_is_desktop(cx);
+
+        // Safety net for the intermittent "no joined spaces" bug. Space updates are
+        // normally drained in handle_event on Event::Signal, but if they were enqueued
+        // before this (cached) widget was ready to receive that Signal, they can sit
+        // undrained in the queue until some later update happens to fire another Signal
+        // — leaving the bar stuck on "no joined spaces". If the queue still has items
+        // at draw time, re-arm the UI signal so they get drained next frame.
+        if !PENDING_SPACE_UPDATES.is_empty() {
+            SignalToUI::set_ui_signal();
+        }
 
         while let Some(widget_to_draw) = self.view.draw_walk(cx, scope, walk).step() {
             // We only care about drawing the portal list.
@@ -615,7 +647,7 @@ impl Widget for SpacesBar {
 
             // AdaptiveView + CachedWidget does not properly handle DSL-level style overrides,
             // so we must manually apply the different style choices here when drawing it.
-            if effective_is_desktop(cx) {
+            if is_desktop {
                 script_apply_eval!(cx, list, {
                     flow: #(Flow::Down),
                 });
@@ -639,10 +671,23 @@ impl Widget for SpacesBar {
                                 tr_key(app_language, "spaces_bar.status.none_joined")
                             }
                         );
+                        // Status text is shared across view modes: light on the dark
+                        // desktop rail, darker on the light mobile strip.
+                        let mut status_label = item.label(cx, ids!(label));
+                        let status_color = if effective_is_desktop(cx) { RBX_NAV_FG } else { RBX_FG_SECONDARY };
+                        script_apply_eval!(cx, status_label, { draw_text +: { color: #(status_color) } });
                         item
                     } else {
                         list.item(cx, portal_list_index, id!(BottomFiller))
                     };
+                    // Desktop: stretch each item to the rail content width so its
+                    // centered avatar/label aligns with the Home/Add buttons (PortalList
+                    // does not center fixed-width items on the cross axis). Mobile keeps
+                    // the template's fixed width for the horizontal strip.
+                    if is_desktop {
+                        let mut item_w = item.clone();
+                        script_apply_eval!(cx, item_w, { width: #(Size::fill()) });
+                    }
                     item.draw_all(cx, scope);
                 }
             }
@@ -719,11 +764,24 @@ impl Widget for SpacesBar {
                             }
                         };
                         item.label(cx, ids!(label)).set_text(cx, &text);
+                        // Status text is shared across view modes: light on the dark
+                        // desktop rail, darker on the light mobile strip.
+                        let mut status_label = item.label(cx, ids!(label));
+                        let status_color = if effective_is_desktop(cx) { RBX_NAV_FG } else { RBX_FG_SECONDARY };
+                        script_apply_eval!(cx, status_label, { draw_text +: { color: #(status_color) } });
                         item
                     }
                     else {
                         list.item(cx, portal_list_index, id!(BottomFiller))
                     };
+                    // Desktop: stretch each item to the rail content width so its
+                    // centered avatar/label aligns with the Home/Add buttons (PortalList
+                    // does not center fixed-width items on the cross axis). Mobile keeps
+                    // the template's fixed width for the horizontal strip.
+                    if is_desktop {
+                        let mut item_w = item.clone();
+                        script_apply_eval!(cx, item_w, { width: #(Size::fill()) });
+                    }
                     item.draw_all(cx, scope);
                 }
             }
@@ -767,12 +825,17 @@ impl SpacesBar {
                 SpacesListUpdate::AddJoinedSpace(joined_space) => {
                     let space_id = joined_space.space_name_id.room_id().clone();
                     let should_display = (self.display_filter)(&joined_space);
-                    let replaced = self.all_joined_spaces.insert(space_id.clone(), joined_space);
-                    if replaced.is_none() {
-                        adjust_displayed_spaces(false, should_display, space_id, &mut self.displayed_spaces);
-                    } else {
-                        error!("BUG: Added joined space {space_id} that already existed");
-                    }
+                    // Idempotent upsert. A space is legitimately (re-)added while it
+                    // already exists: the space service calls add_new_space() again on
+                    // state-settle Set diffs (e.g. None -> Joined) and on the SDK's
+                    // clear()+append() recomputes that can arrive without an intervening
+                    // ClearSpaces. The previous code logged a BUG and DROPPED the re-add,
+                    // which left the space in `all_joined_spaces` but missing from
+                    // `displayed_spaces` (the Vec that draw_walk iterates) — i.e. the
+                    // intermittent "spaces don't show" bug. So reconcile every time.
+                    let was_displayed = self.displayed_spaces.contains(&space_id);
+                    self.all_joined_spaces.insert(space_id.clone(), joined_space);
+                    adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
                 }
 
                 SpacesListUpdate::UpdateCanonicalAlias { space_id, new_canonical_alias } => {


### PR DESCRIPTION
## What & why

The desktop left rail (navigation tabs + spaces bar) used an orphan light-grey palette (`COLOR_NAVIGATION_TAB_*`) that matched neither the legacy blue nor the new RBX design system, so it looked disconnected from the rest of the (re-skinned) UI. This re-skins it to the **dark navy anchor** the visual spec always intended (`RBX_NAV_*`, spec §2 / §5.6, ref `docs/ui-reference/02-desktop-workbench.png`). **Mobile is intentionally untouched.**

Scope = the user-chosen "narrow dark re-skin" (kept the 76px icon rail; did not widen to a labelled panel).

## Changes

**`navigation_tab_bar.rs`**
- Desktop rail is a flush navy `SolidView` (edge-to-edge, no anti-aliased hairline).
- Home/Add buttons: navy pill on hover/active + a teal `RBX_ACCENT` left accent bar when active; icon driven white (active) / grey (idle) via a custom animator (DrawSvg has no per-state color).
- Separator → `RBX_NAV_DIVIDER`.

**`spaces_bar.rs`**
- `SpacesBarEntry` is shared with the light mobile spaces strip, so selection uses a translucent teal wash + teal accent bar that reads on both dark and light; no-image avatars use `RBX_IDENTITY_TEAL`; the status label is colored per view-mode at runtime.
- Entries are centered on desktop (PortalList doesn't center fixed-width items) by stretching each item to `Fill` only in desktop mode.
- Fix intermittent **"no joined spaces"**: the `AddJoinedSpace` handler is now an idempotent upsert (re-adds are legitimate and were being dropped), and `draw_walk` re-arms the UI signal if space updates are still pending (covers updates enqueued before the cached widget was ready for the `Signal`).

**`light_themed_dock.rs`**
- Flat dock panels (the `round_corner` overlay draws nothing) so panels stay flush against the navy rail on any backdrop, instead of grey corner notches.
- Selected dock tab uses teal `RBX_ACCENT` (was the legacy bright blue `COLOR_ACTIVE_PRIMARY`); unselected/hover go neutral.

**`main_desktop_ui.rs` / `home_screen.rs`**
- Dock sits flush against the rail (`margin: 0`); desktop backdrop kept neutral.

## Testing

- `cargo build` passes; smoke-run shows no DSL/shader/runtime errors.
- Verified visually on desktop: flush navy rail, teal selection, flush rooms list, teal-selected tabs, no dark border ring.
- Mobile layout untouched (shared `SpacesBarEntry` colors chosen to work on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)