### PR TITLE
fix(register): route form & status feedback to popup notifications

### DIFF
--- a/src/register/register_screen.rs
+++ b/src/register/register_screen.rs
@@ -15,6 +15,7 @@ use crate::homeserver::{CapabilityProbeAction, HsCapabilities};
 use crate::login::login_screen::LoginAction;
 use crate::register::{RegisterAction, RegisterMode};
 use crate::register::validation::{normalize_homeserver_url, HomeserverUrlError};
+use crate::shared::popup_list::{enqueue_popup_notification, PopupKind};
 use crate::sliding_sync::{submit_async_request, MatrixRequest};
 
 fn can_start_capability_discovery(registration_pending: bool, awaiting_sync_startup: bool) -> bool {
@@ -196,24 +197,6 @@ script_mod! {
                         text: "Next"
                     }
 
-                    status_area := View {
-                        width: Fill,
-                        height: Fit,
-                        flow: Down,
-                        visible: false
-                        padding: Inset{top: 2, bottom: 2, left: 4, right: 4}
-
-                        status_label := Label {
-                            width: Fill,
-                            height: Fit,
-                            draw_text +: {
-                                color: (RBX_FG_SECONDARY)
-                                text_style: REGULAR_TEXT {font_size: 10.5}
-                            }
-                            text: ""
-                        }
-                    }
-
                     registration_form := View {
                         width: Fill,
                         height: Fit,
@@ -239,16 +222,6 @@ script_mod! {
                             flow: Right,
                             empty_text: "Confirm password"
                             is_password: true,
-                        }
-
-                        form_error_label := Label {
-                            width: Fill, height: Fit,
-                            visible: false
-                            draw_text +: {
-                                color: (RBX_DANGER_FG)
-                                text_style: REGULAR_TEXT {font_size: 10.5}
-                            }
-                            text: ""
                         }
 
                         submit_button := mod.widgets.RegisterPrimaryButton {
@@ -378,9 +351,7 @@ impl WidgetMatchEvent for RegisterScreen {
                     // Prevent submit-against-stale-server in the Next→response window.
                     self.last_discovery = None;
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
-                    self.clear_form_error(cx);
-
-                    self.show_status(cx, "Checking server capabilities...");
+                    self.show_status("Checking server capabilities...", PopupKind::Info);
                     self.discovery_pending = true;
                     self.view.button(cx, ids!(next_button)).set_text(cx, "Checking...");
                     self.last_discovery_input_url = Some(url.clone());
@@ -390,13 +361,13 @@ impl WidgetMatchEvent for RegisterScreen {
                     });
                 }
                 Err(HomeserverUrlError::Empty) => {
-                    self.show_status(cx, "Please enter a homeserver URL (e.g. matrix.org).");
+                    self.show_status("Please enter a homeserver URL (e.g. matrix.org).", PopupKind::Error);
                 }
                 Err(HomeserverUrlError::UnsupportedScheme(s)) => {
-                    self.show_status(cx, &format!("Unsupported scheme: {s}. Only http(s) is allowed."));
+                    self.show_status(&format!("Unsupported scheme: {s}. Only http(s) is allowed."), PopupKind::Error);
                 }
                 Err(HomeserverUrlError::Invalid) => {
-                    self.show_status(cx, "That URL looks invalid. Please check and try again.");
+                    self.show_status("That URL looks invalid. Please check and try again.", PopupKind::Error);
                 }
             }
         }
@@ -425,16 +396,15 @@ impl WidgetMatchEvent for RegisterScreen {
             let localpart = match validate_localpart(&username) {
                 Ok(l) => l,
                 Err(LocalpartError::Empty) => {
-                    self.show_form_error(cx, "Please enter a username.");
+                    self.show_form_error("Please enter a username.");
                     return;
                 }
                 Err(LocalpartError::TooLong) => {
-                    self.show_form_error(cx, "Username is too long (max 255 characters).");
+                    self.show_form_error("Username is too long (max 255 characters).");
                     return;
                 }
                 Err(LocalpartError::InvalidChars) => {
                     self.show_form_error(
-                        cx,
                         "Username can contain only lowercase letters, digits, and . _ = - /",
                     );
                     return;
@@ -444,17 +414,17 @@ impl WidgetMatchEvent for RegisterScreen {
             if let Err(e) = validate_passwords_match(&password, &confirm) {
                 match e {
                     PasswordError::Empty => {
-                        self.show_form_error(cx, "Please enter and confirm a password.");
+                        self.show_form_error("Please enter and confirm a password.");
                     }
                     PasswordError::Mismatch => {
-                        self.show_form_error(cx, "Passwords don't match. Please re-enter.");
+                        self.show_form_error("Passwords don't match. Please re-enter.");
                     }
                 }
                 return;
             }
 
             let Some(caps) = self.last_discovery.as_ref() else {
-                self.show_form_error(cx, "Please check the homeserver first (click Next).");
+                self.show_form_error("Please check the homeserver first (click Next).");
                 return;
             };
 
@@ -467,7 +437,6 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.last_discovery = None;
                     self.last_discovery_input_url = None;
                     self.show_form_error(
-                        cx,
                         "The homeserver URL looks invalid. Please fix it and click Next again.",
                     );
                     return;
@@ -478,7 +447,6 @@ impl WidgetMatchEvent for RegisterScreen {
                 self.last_discovery = None;
                 self.last_discovery_input_url = None;
                 self.show_form_error(
-                    cx,
                     "The homeserver changed since the last check. Click Next to verify this server before creating an account.",
                 );
                 return;
@@ -486,8 +454,7 @@ impl WidgetMatchEvent for RegisterScreen {
 
             let homeserver_url = caps.base_url.clone();
 
-            self.clear_form_error(cx);
-            self.show_status(cx, "Creating your account...");
+            self.show_status("Creating your account...", PopupKind::Info);
             self.registration_pending = true;
             submit.set_text(cx, "Creating...");
             self.view.redraw(cx);
@@ -503,19 +470,17 @@ impl WidgetMatchEvent for RegisterScreen {
             match action.downcast_ref::<LoginAction>() {
                 Some(LoginAction::LoginSuccess) => {
                     self.awaiting_sync_startup = false;
-                    self.view.view(cx, ids!(status_area)).set_visible(cx, false);
-                    self.view.label(cx, ids!(status_label)).set_text(cx, "");
                 }
                 Some(LoginAction::LoginFailure(msg)) if self.awaiting_sync_startup => {
                     // Account already exists on the server; don't frame as registration failure.
                     self.awaiting_sync_startup = false;
                     Cx::post_action(LoginAction::ClearFailureState);
                     self.show_status(
-                        cx,
                         &format!(
                             "Your account was created, but we couldn't start a session:\n{msg}\n\n\
                              Please click ← Back to Login and sign in with your new account."
                         ),
+                        PopupKind::Warning,
                     );
                 }
                 _ => {}
@@ -535,49 +500,46 @@ impl WidgetMatchEvent for RegisterScreen {
                     match caps.mode() {
                         RegisterMode::MasWebOnly => {
                             self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
-                            self.clear_form_error(cx);
                             match caps.mas_signup_url.as_deref() {
                                 Some(url) => match robius_open::Uri::new(url).open() {
                                     Ok(()) => {
                                         self.show_status(
-                                            cx,
                                             "Browser opened. Complete registration in your web browser, \
                                              then click ← Back to Login and sign in with your new account.",
+                                            PopupKind::Info,
                                         );
                                     }
                                     Err(e) => {
                                         log!("robius_open failed for MAS signup url {url}: {e:?}");
                                         self.show_status(
-                                            cx,
                                             &format!(
                                                 "Could not open the browser automatically. Please visit this URL manually:\n{url}"
                                             ),
+                                            PopupKind::Warning,
                                         );
                                     }
                                 },
                                 None => {
                                     self.show_status(
-                                        cx,
                                         "This server advertises browser-based registration but no signup URL was found.",
+                                        PopupKind::Warning,
                                     );
                                 }
                             }
                         }
                         RegisterMode::Uiaa => {
                             self.view.view(cx, ids!(registration_form)).set_visible(cx, true);
-                            self.clear_form_error(cx);
                             self.show_status(
-                                cx,
                                 "This homeserver allows direct registration. Fill in your details below to create an account.",
+                                PopupKind::Info,
                             );
                         }
                         RegisterMode::Disabled => {
                             self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
-                            self.clear_form_error(cx);
                             self.show_status(
-                                cx,
                                 "This server does not allow registration. Please choose a different homeserver \
                                  or sign in with an existing account.",
+                                PopupKind::Warning,
                             );
                         }
                     }
@@ -590,8 +552,7 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.discovery_pending = false;
                     self.view.button(cx, ids!(next_button)).set_text(cx, "Next");
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
-                    self.clear_form_error(cx);
-                    self.show_status(cx, &format!("Could not reach that server: {error}"));
+                    self.show_status(&format!("Could not reach that server: {error}"), PopupKind::Error);
                     self.last_discovery = None;
                     self.last_discovery_input_url = None;
                 }
@@ -618,21 +579,15 @@ impl WidgetMatchEvent for RegisterScreen {
                     self.last_discovery = None;
                     self.last_discovery_input_url = None;
                     self.view.view(cx, ids!(registration_form)).set_visible(cx, false);
-                    self.clear_form_error(cx);
-
                     // Bridging feedback during the ~100-200ms SyncService::build window.
-                    self.show_status(cx, "Account created! Loading your account...");
+                    self.show_status("Account created! Loading your account...", PopupKind::Success);
                     self.awaiting_sync_startup = true;
                 }
                 Some(RegisterAction::RegistrationFailed(err)) => {
                     self.registration_pending = false;
                     self.awaiting_sync_startup = false;
                     self.view.button(cx, ids!(submit_button)).set_text(cx, "Create Account");
-                    self.show_form_error(cx, err);
-                    self.show_status(
-                        cx,
-                        "Registration didn't go through. Please check the error above and retry.",
-                    );
+                    self.show_form_error(&format!("Registration didn't go through: {err}"));
                 }
                 _ => {}
             }
@@ -641,23 +596,17 @@ impl WidgetMatchEvent for RegisterScreen {
 }
 
 impl RegisterScreen {
-    fn show_status(&mut self, cx: &mut Cx, message: &str) {
-        self.view.view(cx, ids!(status_area)).set_visible(cx, true);
-        self.view.label(cx, ids!(status_label)).set_text(cx, message);
-        self.view.redraw(cx);
+    /// Surface a status/feedback message through the global popup notification
+    /// overlay. This replaces the old inline status area: the popup card wraps
+    /// long messages (no right-edge truncation on the narrow register card), and
+    /// the overlay renders above every screen — including this pre-auth one.
+    /// Popups auto-dismiss so transient/stale messages don't pile up.
+    fn show_status(&self, message: &str, kind: PopupKind) {
+        enqueue_popup_notification(message.to_string(), kind, Some(6.0));
     }
 
-    fn show_form_error(&mut self, cx: &mut Cx, message: &str) {
-        let label = self.view.label(cx, ids!(form_error_label));
-        label.set_text(cx, message);
-        label.set_visible(cx, true);
-        self.view.redraw(cx);
-    }
-
-    fn clear_form_error(&mut self, cx: &mut Cx) {
-        let label = self.view.label(cx, ids!(form_error_label));
-        label.set_text(cx, "");
-        label.set_visible(cx, false);
+    fn show_form_error(&self, message: &str) {
+        self.show_status(message, PopupKind::Error);
     }
 }
 


### PR DESCRIPTION
## Problem

On narrow (mobile) widths, the **Create Account** screen truncated long messages instead of wrapping them. The username validation rule rendered as `...lowercase letto` and the homeserver status as `...registratio` — both clipped at the right edge of the register card.

## Why the inline fix didn't work

The status/error were plain `Label`s with `width: Fill, height: Fit`. By Makepad's source a `Label` defaults to a wrapping flow and `width: Fill` yields a bounded width, so it *should* wrap — but inside the centered register card it didn't. A `draw_text` `wrap` property has **no effect**: `DrawText` has no such field, so it is silently ignored. Verified on device that the inline approach kept truncating.

## Fix

Route **all** register-screen feedback through the existing global popup notification overlay (`enqueue_popup_notification`) instead of inline labels:

- The popup card wraps long messages correctly, eliminating truncation.
- The overlay (`PopupList {}`) is mounted at the app root, so it renders above the pre-auth register screen.
- Each message gets a semantic `PopupKind`:
  - **Info** — progress / neutral status (Checking…, Creating…, "allows direct registration", browser opened)
  - **Success** — Account created! Loading…
  - **Warning** — restricted / soft-failure (server doesn't allow registration, browser couldn't auto-open, no signup URL, account created but session didn't start)
  - **Error** — validation failures + "couldn't reach server" + registration failure
- Popups auto-dismiss after 6s so transient messages don't pile up.

## Cleanup

- Removed the now-dead inline `status_area`, `status_label`, `form_error_label`, and `clear_form_error` (+ its 7 call sites).
- Merged the redundant double message on registration failure (`show_form_error(err)` + a separate "check the error above" status) into a single error popup. "above" no longer applied once errors became popups.
- `show_form_error` is now a thin semantic alias for `show_status(msg, Error)` — one real implementation, no duplicated logic.

Net **+29 / −80**. `cargo build` clean. Verified on a physical mobile device.