### PR TITLE
fix: open-chat desktop nav + stop event-cache sync-worker panic (patched matrix-sdk fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -3344,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "anymap2",
  "aquamarine",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "aes",
  "aquamarine",
@@ -4065,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-sqlite"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -4123,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "base64",
  "blake3",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-ui"
 version = "0.16.0"
-source = "git+https://github.com/project-robius/matrix-rust-sdk?branch=space_room_suggested#627563bb87e4746c0758560efe2c3fdc034faac6"
+source = "git+https://github.com/Project-Robius-China/matrix-rust-sdk?branch=space_room_suggested-event-cache-no-panic#9ca2c265d4ca2db322160428fa6a269d281257f0"
 dependencies = [
  "as_variant",
  "async-rx",
@@ -8165,7 +8165,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ imghdr = "0.7.0"
 linkify = "0.10.0"
 mime = "0.3"
 mime_guess = "2.0"
-matrix-sdk-base = { git = "https://github.com/project-robius/matrix-rust-sdk", branch = "space_room_suggested" }
-matrix-sdk = { git = "https://github.com/project-robius/matrix-rust-sdk", branch = "space_room_suggested", default-features = false, features = [
+matrix-sdk-base = { git = "https://github.com/Project-Robius-China/matrix-rust-sdk", branch = "space_room_suggested-event-cache-no-panic" }
+matrix-sdk = { git = "https://github.com/Project-Robius-China/matrix-rust-sdk", branch = "space_room_suggested-event-cache-no-panic", default-features = false, features = [
     "e2e-encryption",
     "automatic-room-key-forwarding",
     "markdown",
@@ -55,7 +55,7 @@ matrix-sdk = { git = "https://github.com/project-robius/matrix-rust-sdk", branch
     "bundled-sqlite",
     "sso-login",
 ] }
-matrix-sdk-ui = { git = "https://github.com/project-robius/matrix-rust-sdk", branch = "space_room_suggested", default-features = false, features = [
+matrix-sdk-ui = { git = "https://github.com/Project-Robius-China/matrix-rust-sdk", branch = "space_room_suggested-event-cache-no-panic", default-features = false, features = [
     "rustls-tls",
 ] }
 ## Use the same ruma version as what's specified in matrix-sdk's Cargo.toml.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2534,9 +2534,14 @@ impl App {
             room_to_close,
         );
 
-        // Before we navigate to the room, if the AddRoom tab is currently shown,
-        // then we programmatically navigate to the Home tab to show the actual room.
-        if matches!(self.app_state.selected_tab, SelectedTab::AddRoom) {
+        // Before we navigate to the room, if a non-room tab is currently shown
+        // (AddRoom, or Settings — e.g. tapping "Open chat" on a registered agent
+        // in Settings ▸ Labs), programmatically navigate to the Home tab so the
+        // actual room becomes visible. On mobile the pushed StackNavigation view
+        // covers everything regardless; but on desktop the layout is driven by
+        // `selected_tab`, so without this the room opens in the dock *behind* the
+        // still-shown Settings page and nothing appears to happen.
+        if matches!(self.app_state.selected_tab, SelectedTab::AddRoom | SelectedTab::Settings) {
             cx.action(NavigationBarAction::GoToHome);
         }
         cx.widget_action(


### PR DESCRIPTION
## 1. Open chat on desktop (original)

Tapping **Open chat** on a registered agent in Settings ▸ Labs (Agent Registry)
did nothing on desktop — the room opened in the Dock *behind* the still-shown
Settings page. `navigate_to_room()` only handled the `AddRoom` tab; it now also
navigates Home when the `Settings` tab is shown, so the room surfaces.

## 2. Stop the event-cache sync-worker panic (added)

robrix's live-sync worker panicked (`event_cache … InvalidItemIndex`) whenever
the homeserver produced an inconsistent event graph — reproduced with palpo,
which created room `!1zJYqxVghLZ2GYI1Jp` with **incomplete `auth_events`**
(`palpo::event::pdu hash_sign: missing state event in auth_events` for the
`m.room.member` / `m.room.power_levels` of an appservice user). The crash was a
`.expect("failed to remove an event")` in matrix-sdk's `remove_events()`.

Fix = depend on a **one-commit patched fork** of the SDK:
`Project-Robius-China/matrix-rust-sdk@space_room_suggested-event-cache-no-panic`
(forked off `project-robius@627563bb` + a single patch). It logs a warning and
continues with a possibly-incomplete dedup instead of panicking the worker, so
one bad room no longer takes down live sync for every room.

> This is a **client-side bleeding-stop only**. The palpo-side root cause (a
> room built with broken `auth_events`) is tracked separately and handled later.

### Cargo diff
`matrix-sdk` / `matrix-sdk-base` / `matrix-sdk-ui` git url
`project-robius` → `Project-Robius-China`, branch
`space_room_suggested` → `space_room_suggested-event-cache-no-panic`.
Builds clean (`cargo build`, 0 errors).

## Testing
- [x] Desktop: "Open chat" from Agent Registry opens the room
- [x] Desktop + Android: open/sync the previously-crashing room — **no panic**,
      live sync keeps working (expect a `failed to remove an event by position
      during dedup, skipping` warn in the log instead of a crash)
