### PR TITLE
fix(invite): unblock invites on palpo (disable MSC3061 history share) + shrink modal corner radius

### DIFF
--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -582,7 +582,7 @@ script_mod! {
             show_bg: true
             draw_bg +: {
                 color: #fff
-                border_radius: 24.0
+                border_radius: 4.0
             }
 
             title_view := View {
@@ -661,7 +661,7 @@ script_mod! {
             show_bg: true
             draw_bg +: {
                 color: #fff
-                border_radius: 24.0
+                border_radius: 4.0
             }
 
             title_view := View {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -446,7 +446,10 @@ async fn build_client(
             backup_download_strategy: matrix_sdk::encryption::BackupDownloadStrategy::OneShot,
             auto_enable_backups: true,
         })
-        .with_enable_share_history_on_invite(true)
+        // Off: palpo's key backup 404s, so share_room_history() (MSC3061) aborts
+        // every invite — encrypted or not — before /invite is sent. Re-enable when
+        // the homeserver's key backup works.
+        .with_enable_share_history_on_invite(false)
         .handle_refresh_tokens();
 
     // Use a 60 second timeout for all requests to the homeserver.


### PR DESCRIPTION
## 1. Unblock invites on palpo (functional)

Inviting any user (e.g. the `@octos_mac` bot) failed with:

```
[404 / M_NOT_FOUND] Backup key not found for this user's room.
```

**Root cause** — robrix enabled `with_enable_share_history_on_invite(true)`. matrix-sdk's
`invite_user_by_id` runs `share_room_history()` (MSC3061) *before* sending the actual
`/invite`. Once cross-signing is set up, that path calls
`download_room_keys_for_room()` → `GET /_matrix/client/v3/room_keys/keys/{room}` →
palpo returns **404 "Backup key not found"** (its key backup is empty/incomplete) → the
`?` propagates and the invite aborts **before `/invite` is ever sent**. This affected
**encrypted and unencrypted rooms alike** — it is *not* about room encryption. Invites
issued very early (before cross-signing finished) happened to work because
`share_room_history` short-circuits when cross-signing isn't ready yet, which is why the
failure looked intermittent.

**Fix** — `with_enable_share_history_on_invite(false)`. Invites now go straight to
`/invite`. Trade-off: invitees don't auto-receive pre-join keys for encrypted history
(standard Matrix behaviour). Re-enable once the homeserver's key backup works.

## 2. Shrink Create Room / Start Chat modal corner radius (UI)

`CreateRoomModal` and `StartChatModal` cards used `border_radius: 24.0`, which looked
oversized next to every other modal. Match the invite modal's `4.0` for a consistent
small corner radius. (Both are structurally identical sibling cards — `width: 400`, same
padding — so both are changed together.)

## Testing
- [x] **Fully quit and relaunch** the app (the flag is read once when the client is
      built — an already-running instance keeps the old behaviour).
- [x] Invite `@octos_mac` into a room → succeeds (server receives `POST /rooms/{id}/invite`,
      no `Backup key not found`).
- [x] Create New Room / Start Chat dialogs show small corners matching the invite modal.

> Out of scope (palpo-side, tracked separately): the empty key backup that 404s, the
> `duplicate read receipts` timeline warning, and the earlier `auth_events` room.
