### PR TITLE
feat(mobile): Rooms | Workspace tabs on the home screen

### DIFF
--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -416,15 +416,8 @@ script_mod! {
                             }
                         }
 
-                        // Show the SpacesBar right above the navigation tab bar.
-                        // We wrap it in the SpacesBarWrapper in order to animate it in or out,
-                        // and wrap *that* in a CachedWidget in order to maintain its shown/hidden state
-                        // across AdaptiveView transitions between Mobile view mode and Desktop view mode.
-                        //
-                        // ... Then we wrap *that* in a ... <https://www.youtube.com/watch?v=evUWersr7pc>
-                        CachedWidget {
-                            spaces_bar_wrapper := mod.widgets.SpacesBarWrapper {}
-                        }
+                        // (The toggled SpacesBar strip was removed: the SpacesBar now
+                        // lives in the home screen's `Workspace` tab — see RoomsSideBar.)
 
                         // At the bottom of the root view, show the navigation tab bar horizontally.
                         CachedWidget {

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -116,12 +116,16 @@ pub fn script_mod(vm: &mut ScriptVm) {
     invite_screen::script_mod(vm);
     tombstone_footer::script_mod(vm);
     room_screen::script_mod(vm);
+    // `spaces_bar` must be registered BEFORE `rooms_sidebar` and `navigation_tab_bar`,
+    // which both reference `mod.widgets.SpacesBar` in their DSL (the Workspace tab and
+    // the desktop rail). Registering it after would fail with "property SpacesBar not
+    // found in prototype chain".
+    spaces_bar::script_mod(vm);
     rooms_sidebar::script_mod(vm);
     welcome_screen::script_mod(vm);
     light_themed_dock::script_mod(vm);
     main_mobile_ui::script_mod(vm);
     main_desktop_ui::script_mod(vm);
-    spaces_bar::script_mod(vm);
     navigation_tab_bar::script_mod(vm);
     // Note: upload_progress::script_mod is called earlier in app.rs
     // because RoomInputBar depends on it.

--- a/src/home/rooms_list_header.rs
+++ b/src/home/rooms_list_header.rs
@@ -48,50 +48,8 @@ script_mod! {
             }
         },
 
-        // Spaces toggle (shows/hides the SpacesBar). Only shown in the Mobile
-        // layout — see `RoomsSideBar` (Desktop always shows the SpacesBar in its
-        // left rail, so it overrides this to `visible: false`).
-        toggle_spaces_bar_button := View {
-            visible: false,
-            width: Fit,
-            height: Fit
-            margin: Inset{right: 1}
-            flow: Overlay,
-
-            Icon {
-                draw_icon +: {
-                    svg: (ICON_SQUARES)
-                    color: (RBX_FG_SECONDARY)
-                }
-                icon_walk: Walk{width: 18, height: Fit, margin: Inset{bottom: 2}}
-            }
-
-            spaces_click_area := Button {
-                width: Fill,
-                height: Fill
-                padding: Inset{top: 6, bottom: 6, left: 6, right: 6}
-                spacing: 0,
-                text: ""
-                draw_bg +: {
-                    color: #0000
-                    color_hover: #0000
-                    color_down: #0000
-                    border_color: #0000
-                    border_color_hover: #0000
-                    border_color_down: #0000
-                    border_color_focus: #0000
-                    border_size: 0.0
-                    border_radius: 0.0
-                }
-                draw_text +: {
-                    color: #0000
-                    color_hover: #0000
-                    color_down: #0000
-                    color_focus: #0000
-                }
-                icon_walk: Walk{width: 0, height: 0}
-            }
-        }
+        // (The mobile "spaces" toggle icon was removed: switching to spaces is now
+        // the `Workspace` tab in the home screen's tab row — see `RoomsSideBar`.)
 
         open_directory_button := View {
             width: Fit,
@@ -235,9 +193,6 @@ impl Widget for RoomsListHeader {
             self.set_app_language(cx, app_language);
         }
         if let Event::Actions(actions) = event {
-            if self.view.button(cx, ids!(toggle_spaces_bar_button.spaces_click_area)).clicked(actions) {
-                cx.action(NavigationBarAction::ToggleSpacesBar);
-            }
             if self.view.button(cx, ids!(open_directory_button.directory_click_area)).clicked(actions) {
                 cx.action(NavigationBarAction::GoToDirectory);
             }

--- a/src/home/rooms_sidebar.rs
+++ b/src/home/rooms_sidebar.rs
@@ -10,12 +10,51 @@
 use makepad_widgets::*;
 
 use crate::home::rooms_list::RoomsListWidgetExt;
+use crate::home::navigation_tab_bar::NavigationBarAction;
 use crate::settings::app_preferences::{AppPreferencesGlobal, AppPreferencesAction, ViewModeOverride};
 use crate::shared::room_filter_input_bar::{MainFilterAction, RoomFilterInputBarWidgetExt};
 
 script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
+
+    // A `Rooms`/`Workspace` home tab — mirrors the room screen's RoomTopBarTab
+    // (src/room/room_top_bar.rs): a RadioButtonFlatter (no radio dot) whose custom
+    // shader draws a teal accent underline that fades in with the `active` state.
+    // Active = dark text + teal underline; inactive = secondary-grey text.
+    mod.widgets.HomeTopBarTab = RadioButtonFlatter {
+        width: Fit, height: Fill,
+        align: Align{x: 0.5, y: 0.5}
+        padding: Inset{left: 14, right: 14, top: 0, bottom: 0}
+        icon_walk: Walk{ width: 0, height: 0, margin: 0 }
+        label_walk: Walk{ width: Fit, height: Fit, margin: 0 }
+
+        draw_bg +: {
+            underline_color: instance((RBX_ACCENT))
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                let h = 3.0
+                sdf.box(
+                    0.0,
+                    self.rect_size.y - h,
+                    self.rect_size.x,
+                    h,
+                    1.5
+                )
+                sdf.fill(mix(#0000, self.underline_color, self.active))
+                return sdf.result
+            }
+        }
+
+        draw_text +: {
+            color: (RBX_FG_SECONDARY)
+            color_hover: (RBX_FG_PRIMARY)
+            color_down: (RBX_FG_PRIMARY)
+            color_active: (RBX_FG_PRIMARY)
+            color_focus: (RBX_FG_PRIMARY)
+            text_style: theme.font_bold { font_size: 11.0 }
+        }
+    }
 
 
     mod.widgets.RoomsSideBar = #(RoomsSideBar::register_widget(vm)) {
@@ -37,10 +76,9 @@ script_mod! {
         Mobile := View {
             width: Fill, height: Fill
             flow: Down,
-            
-            // White app-bar: title row + filter field. A clear bottom divider
-            // (below) gives depth over the white room list, mirroring the bottom
-            // tab bar's top divider.
+
+            // White app-bar: title row + filter field. (The workspace/squares icon
+            // is gone — switching to spaces is now the `Workspace` tab below.)
             SolidView {
                 width: Fill, height: Fit
                 padding: Inset{top: 15, left: 15, right: 15, bottom: 10}
@@ -52,11 +90,6 @@ script_mod! {
                 rooms_list_header := RoomsListHeader {
                     spacing: 10
                     open_room_filter_modal_button +: {
-                        visible: true
-                    }
-                    // Mobile reaches the SpacesBar via this header toggle (the
-                    // bottom tab bar no longer carries a Spaces button).
-                    toggle_spaces_bar_button +: {
                         visible: true
                     }
                 }
@@ -76,22 +109,52 @@ script_mod! {
                 }
             }
 
-            // App-bar bottom divider — clearer line for depth (symmetric with the
-            // tab bar's top divider).
+            // `Rooms | Workspace` tab row (mirrors the room screen's top-bar tabs).
+            SolidView {
+                width: Fill, height: 44,
+                flow: Right,
+                align: Align{y: 1.0}
+                padding: Inset{left: 8, right: 8}
+                spacing: 2
+                show_bg: true
+                draw_bg.color: (RBX_BG_SURFACE)
+
+                rooms_tab := mod.widgets.HomeTopBarTab { text: "Rooms" }
+                workspace_tab := mod.widgets.HomeTopBarTab { text: "Workspace" }
+            }
+
+            // Bottom divider under the tab row — clear line for depth.
             LineH {
                 width: Fill, height: 1.5
                 draw_bg.color: (RBX_STROKE_STRONG)
             }
 
-            SolidView {
+            // Body: the Rooms list OR the vertical Workspace (spaces) list. The
+            // SpacesBar singleton (also used by the desktop rail) lives here on
+            // mobile so it stays in the widget tree and keeps draining its updates.
+            home_body := PageFlip {
                 width: Fill, height: Fill
-                padding: Inset{left: 15, right: 15}
-                show_bg: true
-                // White room list between the gray app-bar and gray tab bar.
-                draw_bg.color: (RBX_BG_SURFACE)
+                active_page: @rooms_page
 
-                CachedWidget {
-                    rooms_list := RoomsList {}
+                rooms_page := SolidView {
+                    width: Fill, height: Fill
+                    padding: Inset{left: 15, right: 15}
+                    show_bg: true
+                    draw_bg.color: (RBX_BG_SURFACE)
+
+                    CachedWidget {
+                        rooms_list := RoomsList {}
+                    }
+                }
+
+                workspace_page := SolidView {
+                    width: Fill, height: Fill
+                    show_bg: true
+                    draw_bg.color: (RBX_BG_SURFACE)
+
+                    CachedWidget {
+                        root_spaces_bar := mod.widgets.SpacesBar {}
+                    }
                 }
             }
         }
@@ -110,6 +173,10 @@ pub struct RoomsSideBar {
     #[deref] view: AdaptiveView,
 
     #[rust] applied_view_mode: ViewModeOverride,
+    /// Mobile only: whether the home tabs (Rooms/Workspace) have had their initial
+    /// active highlight applied. The Mobile variant is built lazily on first draw,
+    /// so this can't be done in `on_after_new`.
+    #[rust] home_tab_initialized: bool,
 }
 
 impl ScriptHook for RoomsSideBar {
@@ -128,6 +195,22 @@ impl RoomsSideBar {
     fn apply_view_mode(&mut self, mode: ViewModeOverride) {
         self.view.set_variant_selector(mode.variant_selector());
         self.applied_view_mode = mode;
+        // A variant switch rebuilds the (lazy) Mobile tabs, so re-apply the default
+        // highlight next chance.
+        self.home_tab_initialized = false;
+    }
+
+    /// Switch the mobile home body to the Rooms tab and highlight it. Used on
+    /// startup and when a space is opened from the Workspace tab (which shows that
+    /// space's rooms). No-ops on desktop, where these ids don't exist.
+    fn show_rooms_tab(&mut self, cx: &mut Cx) {
+        self.view.page_flip(cx, ids!(home_body)).set_active_page(cx, id!(rooms_page));
+        if let Some(mut rb) = self.view.radio_button(cx, ids!(rooms_tab)).borrow_mut() {
+            rb.animator_play(cx, ids!(active.on));
+        }
+        if let Some(mut rb) = self.view.radio_button(cx, ids!(workspace_tab)).borrow_mut() {
+            rb.animator_play(cx, ids!(active.off));
+        }
     }
 }
 impl Widget for RoomsSideBar {
@@ -138,6 +221,16 @@ impl Widget for RoomsSideBar {
             if let Some(keywords) = self.view.room_filter_input_bar(cx, ids!(room_filter_input_bar)).changed(actions) {
                 cx.action(MainFilterAction::Changed(keywords));
             }
+
+            // Mobile home tabs: switch the body PageFlip between the Rooms list and
+            // the Workspace (spaces) list. The radio set de-selects the other tab.
+            let home_tabs = self.view.radio_button_set(cx, ids_array!(rooms_tab, workspace_tab));
+            match home_tabs.selected(cx, actions) {
+                Some(0) => { self.view.page_flip(cx, ids!(home_body)).set_active_page(cx, id!(rooms_page)); }
+                Some(1) => { self.view.page_flip(cx, ids!(home_body)).set_active_page(cx, id!(workspace_page)); }
+                _ => {}
+            }
+
             for action in actions {
                 if let Some(AppPreferencesAction::ViewModeChanged(new_mode)) = action.downcast_ref() {
                     if *new_mode != self.applied_view_mode {
@@ -145,9 +238,23 @@ impl Widget for RoomsSideBar {
                         self.view.redraw(cx);
                     }
                 }
+                // Tapping a space in the Workspace tab opens that space's rooms, so
+                // jump back to the Rooms tab to show them.
+                if let Some(NavigationBarAction::GoToSpace { .. }) = action.downcast_ref() {
+                    self.show_rooms_tab(cx);
+                }
             }
         }
         self.view.handle_event(cx, event, scope);
+
+        // The Mobile variant's tabs are built lazily on first draw, so apply the
+        // default Rooms-tab highlight the first time they exist. No-ops on desktop.
+        if !self.home_tab_initialized
+            && self.view.radio_button(cx, ids!(rooms_tab)).borrow().is_some()
+        {
+            self.home_tab_initialized = true;
+            self.show_rooms_tab(cx);
+        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -188,6 +188,104 @@ script_mod! {
         }
     }
 
+    // A full-width "workspace row" for the mobile Workspace tab's vertical spaces
+    // list: [avatar] [space name (Fill)] [room count] [chevron]. It is a SECOND
+    // template of the SpacesBarEntry widget, so it reuses the same tap handling
+    // (SpacesBarAction::ButtonClicked -> GoToSpace) and selection animator contract
+    // — only the layout differs from the desktop rail's avatar-box entry.
+    mod.widgets.SpacesListRow = #(SpacesBarEntry::register_widget(vm)) {
+        width: Fill,
+        height: 56,
+        flow: Right,
+        align: Align{x: 0.0, y: 0.5}
+        padding: Inset{left: 14, right: 12}
+        margin: 0,
+        cursor: MouseCursor.Hand
+
+        show_bg: true
+        draw_bg +: {
+            hover: instance(0.0)
+            active: instance(0.0)
+            down: instance(0.0)
+            // Transparent default; a faint dark wash on hover/press (reads on the
+            // white mobile surface), plus a teal accent bar on the left edge.
+            color: instance(#0000)
+            color_hover: instance(#x00000010)
+            accent_color: instance((RBX_ACCENT))
+
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                sdf.rect(0.0, 0.0, self.rect_size.x, self.rect_size.y)
+                sdf.fill(mix(self.color, self.color_hover, self.hover))
+                let bar_inset = 14.0
+                sdf.box(
+                    0.0,
+                    bar_inset,
+                    3.0,
+                    self.rect_size.y - bar_inset * 2.0,
+                    1.5
+                )
+                sdf.fill(mix(vec4(0.0, 0.0, 0.0, 0.0), self.accent_color, self.active))
+                return sdf.result;
+            }
+        }
+
+        avatar := Avatar {
+            width: 36, height: 36,
+            text_view +: {
+                draw_bg.color: (RBX_IDENTITY_TEAL),
+                text +: {
+                    draw_text +: {
+                        text_style: theme.font_regular { font_size: 15 },
+                        color: (COLOR_PRIMARY),
+                    }
+                }
+            }
+        }
+
+        space_name := Label {
+            width: Fill, height: Fit,
+            margin: Inset{left: 12}
+            max_lines: 1,
+            text_overflow: Ellipsis,
+            draw_text +: {
+                color: (RBX_FG_PRIMARY)
+                text_style: theme.font_bold { font_size: 11.5 }
+            }
+            text: ""
+        }
+
+        room_count := Label {
+            width: Fit, height: Fit,
+            margin: Inset{left: 8, right: 8}
+            draw_text +: {
+                color: (RBX_FG_SECONDARY)
+                text_style: REGULAR_TEXT { font_size: 9.5 }
+            }
+            text: ""
+        }
+
+        chevron := Icon {
+            width: 16, height: 16,
+            draw_icon +: { svg: (ICON_CHEVRON_RIGHT), color: (RBX_FG_TERTIARY) }
+            icon_walk: Walk{ width: 16, height: 16 }
+        }
+
+        animator: Animator {
+            hover: {
+                default: @off
+                off: AnimatorState { from: {all: Forward {duration: 0.15}} apply: { draw_bg: {down: snap(0.0), hover: 0.0} } }
+                on: AnimatorState { from: {all: Snap} apply: { draw_bg: {down: snap(0.0), hover: 1.0} } }
+                down: AnimatorState { from: {all: Forward {duration: 0.1}} apply: { draw_bg: {down: snap(1.0), hover: 1.0} } }
+            }
+            active: {
+                default: @off
+                off: AnimatorState { from: {all: Snap} apply: { draw_bg: {active: 0.0} } }
+                on: AnimatorState { from: {all: Snap} apply: { draw_bg: {active: 1.0} } }
+            }
+        }
+    }
+
     mod.widgets.SpacesStatusLabel = View {
         width: (NAVIGATION_TAB_BAR_SIZE),
         height: (NAVIGATION_TAB_BAR_SIZE),
@@ -225,6 +323,7 @@ script_mod! {
         }
 
         spaces_bar_entry := mod.widgets.SpacesBarEntry {}
+        spaces_list_row := mod.widgets.SpacesListRow {}
         StatusLabel := mod.widgets.SpacesStatusLabel {}
         BottomFiller := View {
             width: (NAVIGATION_TAB_BAR_SIZE)
@@ -247,11 +346,14 @@ script_mod! {
             }
         }
 
+        // Mobile: a full-height VERTICAL list of workspace rows (the Workspace tab
+        // body on the home screen). Was previously a short horizontal avatar strip
+        // toggled by a header icon; it is now a proper tab pane.
         Mobile := View {
-            align: Align{x: 0.5, y: 0.5}
+            align: Align{x: 0.5, y: 0.0}
             padding: 0,
             width: Fill,
-            height: (NAVIGATION_TAB_BAR_SIZE)
+            height: Fill
 
             CachedWidget {
                 spaces_list := mod.widgets.SpacesList { }
@@ -646,16 +748,11 @@ impl Widget for SpacesBar {
             let Some(mut list) = portal_list_ref.borrow_mut() else { continue };
 
             // AdaptiveView + CachedWidget does not properly handle DSL-level style overrides,
-            // so we must manually apply the different style choices here when drawing it.
-            if is_desktop {
-                script_apply_eval!(cx, list, {
-                    flow: #(Flow::Down),
-                });
-            } else {
-                script_apply_eval!(cx, list, {
-                    flow: #(Flow::right()),
-                });
-            }
+            // so we apply it here. Both the desktop rail and the mobile Workspace tab
+            // now render the spaces VERTICALLY (the old mobile horizontal strip is gone).
+            script_apply_eval!(cx, list, {
+                flow: #(Flow::Down),
+            });
 
             let len = self.displayed_spaces.len();
             if len == 0 {
@@ -680,11 +777,9 @@ impl Widget for SpacesBar {
                     } else {
                         list.item(cx, portal_list_index, id!(BottomFiller))
                     };
-                    // Desktop: stretch each item to the rail content width so its
-                    // centered avatar/label aligns with the Home/Add buttons (PortalList
-                    // does not center fixed-width items on the cross axis). Mobile keeps
-                    // the template's fixed width for the horizontal strip.
-                    if is_desktop {
+                    // Stretch every item to fill the list width: desktop avatar boxes
+                    // center their avatar within the rail; mobile rows span full width.
+                    {
                         let mut item_w = item.clone();
                         script_apply_eval!(cx, item_w, { width: #(Size::fill()) });
                     }
@@ -698,10 +793,25 @@ impl Widget for SpacesBar {
                         .get(portal_list_index)
                         .and_then(|space_id| self.all_joined_spaces.get(space_id))
                     {
-                        let item = list.item(cx, portal_list_index, id!(spaces_bar_entry));
-                        // Populate the space name and avatar (although this isn't visible by default).
+                        // Desktop rail uses the compact avatar-box entry; the mobile
+                        // Workspace tab uses the full-width row (avatar + name + count
+                        // + chevron). Both are SpacesBarEntry widgets, so the avatar /
+                        // space_name population and set_metadata below work for either.
+                        let item = if is_desktop {
+                            list.item(cx, portal_list_index, id!(spaces_bar_entry))
+                        } else {
+                            list.item(cx, portal_list_index, id!(spaces_list_row))
+                        };
+                        // Populate the space name (zero-height on the desktop entry,
+                        // visible on the mobile row) and, on mobile, the room count.
                         let space_name = space.space_name_id.to_string();
                         item.label(cx, ids!(space_name)).set_text(cx, &space_name);
+                        if !is_desktop {
+                            item.label(cx, ids!(room_count)).set_text(
+                                cx,
+                                &format!("{} rooms", space.children_count),
+                            );
+                        }
                         let avatar_ref = item.avatar(cx, ids!(avatar));
                         match &space.space_avatar {
                             FetchedRoomAvatar::Text(text) => {
@@ -774,11 +884,9 @@ impl Widget for SpacesBar {
                     else {
                         list.item(cx, portal_list_index, id!(BottomFiller))
                     };
-                    // Desktop: stretch each item to the rail content width so its
-                    // centered avatar/label aligns with the Home/Add buttons (PortalList
-                    // does not center fixed-width items on the cross axis). Mobile keeps
-                    // the template's fixed width for the horizontal strip.
-                    if is_desktop {
+                    // Stretch every item to fill the list width: desktop avatar boxes
+                    // center their avatar within the rail; mobile rows span full width.
+                    {
                         let mut item_w = item.clone();
                         script_apply_eval!(cx, item_w, { width: #(Size::fill()) });
                     }


### PR DESCRIPTION
## What & why

On the **mobile home screen**, the top-bar "spaces" (squares) icon that toggled a sliding horizontal `SpacesBar` strip is replaced by a **`Rooms | Workspace` tab row** below the app bar — mirroring the room screen's top-bar tabs (teal underline). This makes switching between all rooms and your spaces an explicit, discoverable tab instead of a hidden toggle. **Desktop is unchanged.**

## Changes

- **`rooms_sidebar.rs` (Mobile)** — adds the `Rooms | Workspace` tab row (`HomeTopBarTab`, modeled on `RoomTopBarTab`) and a `PageFlip` body that switches between the `RoomsList` (Rooms) and the `SpacesBar` (Workspace). Tapping a space in the Workspace list jumps back to the Rooms tab to show that space's rooms (reuses the existing `GoToSpace` flow). Default highlight is applied lazily once the Mobile variant's tabs exist.
- **`spaces_bar.rs`** — the mobile `SpacesBar` now renders a **vertical list of workspace rows** (avatar + name + room count + chevron) via a second `SpacesBarEntry` template (`SpacesListRow`), instead of the old horizontal avatar strip. Desktop rail rendering is untouched.
- **`rooms_list_header.rs`** — removes the spaces/squares toggle icon and its `ToggleSpacesBar` handler.
- **`home_screen.rs` (Mobile)** — drops the toggled `SpacesBarWrapper` strip; the `SpacesBar` singleton now lives in the Workspace tab (still shared with the desktop rail via `CachedWidget`).
- **`home/mod.rs`** — registers `spaces_bar` **before** `rooms_sidebar` / `navigation_tab_bar`, which reference `mod.widgets.SpacesBar` in their DSL.

## Crash fixed

Opening the Workspace tab initially panicked at `adaptive_view.rs` (`Option::unwrap()` on `None`). Root cause: `rooms_sidebar`'s DSL referenced `mod.widgets.SpacesBar` but `spaces_bar::script_mod` was registered *after* it, so the template wasn't found ("property SpacesBar not found in prototype chain") → an empty `AdaptiveView` → unwrap panic. Fixed by the `home/mod.rs` registration-order change (Makepad requires a widget template to be registered before any DSL that references it).

## Testing

- `cargo build` clean; smoke runs (incl. a forced-mobile + Workspace-default reproduction) show no DSL/registration/runtime errors.
- Verified the original crash no longer reproduces.

## Follow-up

The now-unused `ToggleSpacesBar` action / `SpacesBarWrapper` widget / `is_spaces_bar_shown` path is left as dead code (builds clean, no warnings) and can be removed in a follow-up.
