### PR TITLE
fix(home): spaces vanishing on startup + room-list loading state

### DIFF
--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -2022,10 +2022,20 @@ impl Widget for RoomsList {
                         list.item(cx, portal_list_index, id!(empty)).draw_all(cx, &mut item_scope);
                     }
                 }
-                // Draw the status label as the bottom entry.
+                // Draw the status label as the bottom entry. While the room list is
+                // still empty (initial sync, before any rooms have arrived), show a
+                // loading spinner + message instead of a blank panel; once rooms
+                // appear this becomes the normal bottom status line.
                 else if portal_list_index == status_label_id {
                     let item = list.item(cx, portal_list_index, id!(status_label));
-                    item.label(cx, ids!(label)).set_text(cx, &self.status);
+                    let is_empty = status_label_id == 0;
+                    item.view(cx, ids!(loading_spinner)).set_visible(cx, is_empty);
+                    let status_text = if is_empty && self.status.is_empty() {
+                        "Loading rooms…".to_string()
+                    } else {
+                        self.status.clone()
+                    };
+                    item.label(cx, ids!(label)).set_text(cx, &status_text);
                     item.draw_all(cx, &mut item_scope);
                 }
                 // Draw a filler entry to take up space at the bottom of the portal list.

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{RoomDisplayName, RoomState};
 use ruma::{OwnedRoomAliasId, OwnedRoomId, room::JoinRuleSummary};
 
 use crate::{
-    app::AppState, home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, design_tokens::{RBX_FG_SECONDARY, RBX_NAV_FG}, room_filter_input_bar::MainFilterAction}, sliding_sync::AccountSwitchAction, utils::{self, RoomNameId}
+    app::AppState, home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, i18n::{AppLanguage, tr_fmt, tr_key}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, design_tokens::{RBX_FG_SECONDARY, RBX_NAV_FG}, room_filter_input_bar::MainFilterAction}, sliding_sync::AccountSwitchAction, utils::{self, RoomNameId}
 };
 
 script_mod! {
@@ -705,14 +705,12 @@ impl Widget for SpacesBar {
                     continue;
                 }
 
-                // Handle login success - clear and redraw spaces
-                if let Some(LoginAction::LoginSuccess) = action.downcast_ref() {
-                    self.all_joined_spaces.clear();
-                    self.displayed_spaces.clear();
-                    self.selected_space = None;
-                    self.redraw(cx);
-                    continue;
-                }
+                // NOTE: LoginSuccess intentionally does NOT clear the spaces here.
+                // On a restored session the space service has usually already loaded
+                // the spaces (via the diff stream) by the time the LoginSuccess action
+                // is delivered to the UI, so clearing wiped freshly-loaded spaces with
+                // no reload — the "spaces appear then vanish / show none" bug. Logout
+                // is handled by ClearAppState above; account switch is handled below.
 
                 // Handle account switch - clear and redraw spaces
                 if let Some(AccountSwitchAction::Switched(_)) = action.downcast_ref() {


### PR DESCRIPTION
## What & why

Two related home-screen fixes.

### 1. Spaces intermittently showing "no joined spaces"

The desktop left rail (and the mobile Workspace tab) sometimes showed **"Found no joined spaces"** even though the user had joined spaces — intermittently, across restarts.

**Root cause (verified by logging):** the space service DID load the spaces (`displayed_spaces` reached 3), but `SpacesBar`'s `LoginAction::LoginSuccess` handler then ran `all_joined_spaces.clear()` / `displayed_spaces.clear()`. On a restored session that action is delivered to the UI *after* the space service has already populated the list (spaces are drained via the `draw_walk` re-arm signal), so it **wiped freshly-loaded spaces with no reload**. Timeline from logging:

```
AddJoinedSpace ×3 -> displayed=3      (spaces shown)
LoginAction::LoginSuccess received
drained -> all_joined=0 displayed=0   (spaces wiped)
```

**Fix:** removed the `LoginSuccess` clear in `spaces_bar.rs`. Logout is already handled by `LogoutAction::ClearAppState` (which also drains the pending queue), and account switch by `AccountSwitchAction::Switched` — which fires *before* the new account's space service loads, so it doesn't race the same way (kept). Verified: the displayed-spaces count now stays put instead of dropping to 0 after login.

### 2. Blank room list during initial sync

On startup the room list was a blank white panel until rooms arrived (the status label's text was empty and its spinner hidden).

**Fix:** in `rooms_list.rs`, while the list is still empty, the status label now shows the loading spinner + **"Loading rooms…"**; once rooms appear it reverts to the normal bottom status line. (`all_rooms_loaded()` is an unimplemented `false` placeholder, so "empty list" = `status_label_id == 0` is used as the loading heuristic.)

## Testing

- `cargo build` clean; smoke runs show no DSL/runtime errors.
- Spaces fix verified with `--features log_space_service_diffs` + temporary UI-side logging: `displayed_spaces` stays at its loaded count across all frames (no post-login clear). Reverted an earlier mis-diagnosed `space_service_sync.rs` change (non-blocking avatar / backfill) — this PR is the minimal, correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)