### PR TITLE
fix(room-screen): stop app freeze when clicking a member in the desktop room Info pane

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -4615,6 +4615,15 @@ impl ActionDefaultRef for InfoButtonAction {
 pub enum RoomInfoPaneAction {
     InviteUser,
     ShowPeoplePage,
+    /// Emitted ONLY by a `RoomInfoPeopleEntry` row when its person is tapped.
+    /// The owning `RoomInfoSlidingPane` instance re-bubbles this as
+    /// `OpenPeopleProfile` (tagged with the pane's own widget uid) so the
+    /// `RoomScreen` handler can pick it up. Kept distinct from
+    /// `OpenPeopleProfile` so that pane instances never react to each other's
+    /// re-emitted action — otherwise the desktop overlay pane and the inline
+    /// (mobile) pane, which both receive every broadcast `Event::Actions`,
+    /// would ping-pong the action between themselves forever and freeze the app.
+    PersonClicked(OwnedUserId),
     OpenPeopleProfile(OwnedUserId),
     ReportRoom,
     LeaveRoom,
@@ -4788,7 +4797,7 @@ impl Widget for RoomInfoPeopleEntry {
             Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
                 cx.widget_action(
                     self.widget_uid(),
-                    RoomInfoPaneAction::OpenPeopleProfile(user_id),
+                    RoomInfoPaneAction::PersonClicked(user_id),
                 );
             }
             _ => {}
@@ -5233,15 +5242,25 @@ impl Widget for RoomInfoSlidingPane {
         }
 
         if let Event::Actions(actions) = event {
-            for action in actions {
-                if action.as_widget_action().widget_uid_eq(self.widget_uid()).is_none()
-                    && let RoomInfoPaneAction::OpenPeopleProfile(user_id) = action.as_widget_action().cast()
-                {
-                    cx.widget_action(
-                        self.widget_uid(),
-                        RoomInfoPaneAction::OpenPeopleProfile(user_id.clone()),
-                    );
-                    break;
+            // Re-bubble a person tap from one of OUR people rows as
+            // `OpenPeopleProfile` tagged with this pane's own widget uid, so the
+            // `RoomScreen` handler (which filters by pane uid) can pick it up.
+            //
+            // Gate on `show_people_page` so ONLY the instance currently showing
+            // its People page bubbles. Both the desktop overlay pane and the
+            // inline (mobile) pane receive every broadcast `Event::Actions`, and
+            // `PersonClicked` is deliberately a distinct variant that no pane
+            // ever emits — together this guarantees the two instances can never
+            // ping-pong the action between themselves (which froze the app).
+            if self.show_people_page {
+                for action in actions {
+                    if let RoomInfoPaneAction::PersonClicked(user_id) = action.as_widget_action().cast() {
+                        cx.widget_action(
+                            self.widget_uid(),
+                            RoomInfoPaneAction::OpenPeopleProfile(user_id.clone()),
+                        );
+                        break;
+                    }
                 }
             }
 
@@ -6246,6 +6265,9 @@ impl Widget for RoomScreen {
                     RoomInfoPaneAction::LeaveRoom => {
                         self.open_leave_room_confirm_modal(cx);
                     }
+                    // Bubbled by the pane itself into `OpenPeopleProfile`
+                    // (handled above); nothing to do here.
+                    RoomInfoPaneAction::PersonClicked(_) => {}
                     RoomInfoPaneAction::None => {}
                 }
 


### PR DESCRIPTION
## Summary

On **desktop**, opening the room **Info** pane → **Members** → clicking a person froze the entire app (100% hang). This PR fixes that infinite-loop freeze.

## Root cause

Two live `RoomInfoSlidingPane` instances exist at once:
- the desktop overlay `room_info_sliding_pane` (visible when shown), and
- the inline `info_content`, which is permanently `visible: true` (only its parent wrapper `info_tab_body` is toggled hidden on desktop, not the pane itself).

`Event::Actions` is a **global broadcast** in Makepad — `Event::requires_visibility()` returns false for it, and `View::handle_event` only early-returns on `!visible && requires_visibility()`. So **both** pane instances receive every action.

The old re-bubble logic re-emitted `OpenPeopleProfile` whenever the action's `widget_uid != self.widget_uid()`. With two instances A and B, A reacted to B's re-emission and B reacted to A's — re-emitting forever → infinite `Event::Actions` dispatch → hard freeze. Mobile was unaffected because the overlay isn't shown there (`if !self.visible { return; }` bails first), leaving a single instance.

## Fix

- Add a distinct `RoomInfoPaneAction::PersonClicked(OwnedUserId)` variant, emitted **only** by `RoomInfoPeopleEntry` rows on tap (never by a pane).
- The pane reacts **only** to `PersonClicked`, gated behind `self.show_people_page` so only the instance currently showing its People page fires, and re-bubbles it as `OpenPeopleProfile` tagged with the pane's own uid.
- Because no pane ever emits `PersonClicked`, the two instances can never ping-pong an action between themselves — the loop is structurally impossible.
- `RoomScreen` still handles `OpenPeopleProfile` (uid-filtered to the two panes) and ignores `PersonClicked`.

## Testing

- `cargo build` passes (no new warnings).
- Verified on desktop: Info → Members → click a user now opens the user profile pane instead of freezing; mobile path still opens it exactly once.
- Diagnosis + fix independently cross-checked from three adversarial angles (root cause, fix completeness, sibling-loop scan) — no remaining holes; all other pane actions trigger on spatial hits / per-instance button clicks and are inherently loop-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)