### PR TITLE
fix(room-screen): stop bot cards rendering at wrong z-layer on first paint

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1736,7 +1736,6 @@ script_mod! {
             height: Fit
             flow: Overlay
             padding: 0.0
-            new_batch: true
             show_bg: true
             draw_bg +: {
                 color: (mod.widgets.COLOR_BOT_CODE_BG)
@@ -2043,7 +2042,6 @@ script_mod! {
                         width: Fit
                         height: #(BOT_BADGE_HEIGHT)
                         align: Align{x: 0.5, y: 0.5}
-                        new_batch: true
                         padding: Inset{left: #(BOT_BADGE_HORIZONTAL_PADDING), right: #(BOT_BADGE_HORIZONTAL_PADDING)}
                         show_bg: true
                         draw_bg +: {
@@ -2078,7 +2076,6 @@ script_mod! {
                         visible: false
                         width: Fit
                         height: Fit
-                        new_batch: true
                         padding: Inset{ left: 10.0, right: 10.0, top: 5.0, bottom: 5.0 }
                         show_bg: true
                         draw_bg +: {
@@ -2101,7 +2098,6 @@ script_mod! {
                         width: Fill
                         height: Fit
                         flow: Down
-                        new_batch: true
                         padding: Inset{ left: 14.0, right: 14.0, top: 12.0, bottom: 12.0 }
                         show_bg: true
                         draw_bg +: {
@@ -2166,7 +2162,6 @@ script_mod! {
                         width: Fill
                         height: Fit
                         flow: Down
-                        new_batch: true
                         spacing: 4.0
                         padding: Inset{ left: 12.0, right: 12.0, top: 10.0, bottom: 10.0 }
                         show_bg: true
@@ -2270,7 +2265,6 @@ script_mod! {
                         visible: false
                         width: Fit
                         height: Fit
-                        new_batch: true
                         padding: Inset{ left: 10.0, right: 10.0, top: 5.0, bottom: 5.0 }
                         show_bg: true
                         draw_bg +: {
@@ -2293,7 +2287,6 @@ script_mod! {
                         width: Fill
                         height: Fit
                         flow: Down
-                        new_batch: true
                         padding: Inset{ left: 14.0, right: 14.0, top: 12.0, bottom: 12.0 }
                         show_bg: true
                         draw_bg +: {
@@ -2357,7 +2350,6 @@ script_mod! {
                         width: Fill
                         height: Fit
                         flow: Down
-                        new_batch: true
                         spacing: 4.0
                         padding: Inset{ left: 12.0, right: 12.0, top: 10.0, bottom: 10.0 }
                         show_bg: true


### PR DESCRIPTION
## Problem

On the room screen, bot message cards composited at the **wrong z-layer on first render** — a card would paint over the composer / input bar (see screenshot in the linked report). Scrolling up/down or the arrival of a new event made it snap back to correct, then the glitch would recur on the next fresh render.

## Root cause

Each bot-card `RoundedView` carried `new_batch: true`, which routes it through `ViewOptimize::DrawList` (`makepad widgets/src/view.rs:242`): the card's paint lands in its **own cached child `DrawList2d`**, positioned by its own `view_transform`.

`PortalList` lays items out in two phases:
1. **Phase 1** — draw each item at an *estimated* absolute position.
2. **Phase 2** (`PortalList::end` → `shift_align_range` → `move_align_list`) — reposition items to the settled scroll position.

But `move_align_list` (makepad `draw/src/turtle.rs`) only shifts `Area::Instance` / `Area::Rect` / `BeginClip` entries — it has **no case for a sub-list / view_transform**. So a `new_batch` card is left stuck at its phase-1 estimate (the delta is largest on first populate: unknown heights + first_scroll + auto_tail all in one frame) and paints at the wrong depth. Scroll / a new event changes the turtle rect, flips the cached list's `will_redraw()` true, and the card re-walks at the correct position — which is exactly why it "self-heals".

The composer already carried a defensive `new_batch` as a per-victim band-aid for this same z-fight (`src/room/room_input_bar.rs:870-876`), but the bot cards' own stale first-render sub-list was the untreated root cause.

## Fix

`new_batch` was never functionally required on these cards:
- Rounded corners / borders come from the `RoundedView` `draw_bg` Sdf2d shader, **independent** of the optimize mode.
- The cards set no `clip_x` / `clip_y`.
- `RoundedView` has no shadow.

Removing it makes the cards ordinary content that PortalList's phase-2 pass **can** reposition, fixing first render at the root.

Deletes the **8** `new_batch: true` lines on the timeline bot-card templates: `code_block`, `bot_badge`, `bot_status_strip` (×2), `bot_body_card` (×2), `approval_request_view` (×2).

**Left untouched:** `translation_lang_popup`'s `new_batch` — it lives in a `Modal`, not a `PortalList` item, and has a real drop shadow.

Pure DSL deletion (8 lines), no logic or redraw hooks changed. `cargo build` passes.

```
 src/home/room_screen.rs | 8 --------
 1 file changed, 8 deletions(-)
```

## Testing

Static analysis can't run the GUI, so please verify visually:
- [ ] First render of a room whose latest visible messages are **bot cards** (ideally including a code block, an approval request, and a status strip) — cards no longer paint over the input bar; first frame is correct without scrolling.
- [ ] Rounded corners / borders still render crisply.
- [ ] Streaming bot replies (card height growing) render correctly.

## Follow-up (out of scope)

Now that the root cause is gone, the composer's and the mention/slash popup's defensive `new_batch` are likely redundant and could be cleaned up separately, along with the now-partially-stale explanatory comments that reference "the timeline's `new_batch` cards".

🤖 Generated with [Claude Code](https://claude.com/claude-code)