### PR TITLE
fix(home): mobile back nav out of a space + fix empty-space loading spinner

### DIFF
--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1428,13 +1428,16 @@ impl RoomsList {
                 let is_fully_paginated = matches!(state, SpaceRoomListPaginationState::Idle { end_reached: true });
                 // Only re-fetch the list of rooms in this space if it was not already fully paginated.
                 let should_fetch_rooms: bool;
+                let was_fully_paginated: bool;
                 match self.space_map.entry(space_id.clone()) {
                     Entry::Occupied(mut occ) => {
                         let value_mut = occ.get_mut();
+                        was_fully_paginated = value_mut.is_fully_paginated;
                         should_fetch_rooms = !value_mut.is_fully_paginated;
                         value_mut.is_fully_paginated = is_fully_paginated;
                     }
                     Entry::Vacant(vac) => {
+                        was_fully_paginated = false;
                         vac.insert_entry(SpaceMapValue {
                             is_fully_paginated,
                             parent_chain: parent_chain.clone(),
@@ -1442,6 +1445,16 @@ impl RoomsList {
                         });
                         should_fetch_rooms = true;
                     }
+                }
+                // If the currently-selected space just finished paginating, redraw so
+                // an empty space can drop the loading spinner in favor of the real
+                // "No joined or invited rooms found in this space." message.
+                if is_fully_paginated && !was_fully_paginated
+                    && self.selected_space.as_ref().is_some_and(|sel|
+                        sel.room_id() == space_id || parent_chain.contains(sel.room_id())
+                    )
+                {
+                    self.redraw(cx);
                 }
                 let Some(sender) = self.space_request_sender.as_ref() else {
                     error!("BUG: RoomsList: no space request sender was available after pagination state update.");
@@ -2029,8 +2042,24 @@ impl Widget for RoomsList {
                 else if portal_list_index == status_label_id {
                     let item = list.item(cx, portal_list_index, id!(status_label));
                     let is_empty = status_label_id == 0;
-                    item.view(cx, ids!(loading_spinner)).set_visible(cx, is_empty);
-                    let status_text = if is_empty && self.status.is_empty() {
+                    // Only show the loading spinner while rooms are genuinely still
+                    // loading. For a selected space, "loading" means its direct-child
+                    // list has not been fully paginated yet; once it has, an empty
+                    // result is a real "no rooms" state (not a loading one), so we drop
+                    // the spinner and show the empty message instead. For the all-rooms
+                    // view we can't yet reliably detect completion, so keep the prior
+                    // "spinner until the first room arrives" behavior.
+                    let still_loading = self.selected_space.as_ref().map_or(true, |space| {
+                        !self.space_map.get(space.room_id())
+                            .is_some_and(|smv| smv.is_fully_paginated)
+                    });
+                    let show_spinner = is_empty && still_loading;
+                    item.view(cx, ids!(loading_spinner)).set_visible(cx, show_spinner);
+                    let status_text = if show_spinner && self.selected_space.is_some() {
+                        // Still paginating this space: "Loading rooms…" is clearer than
+                        // the transient "no rooms found" computed from the partial list.
+                        "Loading rooms…".to_string()
+                    } else if is_empty && self.status.is_empty() {
                         "Loading rooms…".to_string()
                     } else {
                         self.status.clone()

--- a/src/home/rooms_list_header.rs
+++ b/src/home/rooms_list_header.rs
@@ -15,6 +15,7 @@ use crate::{
     i18n::{AppLanguage, tr_key},
     profile::user_profile_cache,
     room_preview_cache,
+    settings::app_preferences::effective_is_desktop,
     shared::{
         image_viewer::{ImageViewerAction, ImageViewerError, LoadState},
         popup_list::{PopupKind, enqueue_popup_notification},
@@ -33,6 +34,52 @@ script_mod! {
         flow: Right,
         align: Align{y: 0.5}
         spacing: 3,
+
+        // Back button — mobile only. Shown when a space is selected so the user
+        // can leave the space and return to the full "All Rooms" list (on desktop
+        // the spaces rail handles this, so it stays hidden there). Visibility is
+        // driven imperatively from `handle_event` on `TabSelected`.
+        back_button := View {
+            visible: false,
+            width: Fit,
+            height: Fit
+            margin: Inset{left: 2, right: 1}
+            flow: Overlay,
+
+            Icon {
+                draw_icon +: {
+                    svg: (ICON_ARROW_BACK)
+                    color: (RBX_FG_SECONDARY)
+                }
+                icon_walk: Walk{width: 18, height: Fit, margin: Inset{bottom: 2}}
+            }
+
+            back_click_area := Button {
+                width: Fill,
+                height: Fill
+                padding: Inset{top: 6, bottom: 6, left: 6, right: 6}
+                spacing: 0,
+                text: ""
+                draw_bg +: {
+                    color: #0000
+                    color_hover: #0000
+                    color_down: #0000
+                    border_color: #0000
+                    border_color_hover: #0000
+                    border_color_down: #0000
+                    border_color_focus: #0000
+                    border_size: 0.0
+                    border_radius: 0.0
+                }
+                draw_text +: {
+                    color: #0000
+                    color_hover: #0000
+                    color_down: #0000
+                    color_focus: #0000
+                }
+                icon_walk: Walk{width: 0, height: 0}
+            }
+        }
 
         header_title := Label {
             width: Fill,
@@ -193,6 +240,10 @@ impl Widget for RoomsListHeader {
             self.set_app_language(cx, app_language);
         }
         if let Event::Actions(actions) = event {
+            if self.view.button(cx, ids!(back_button.back_click_area)).clicked(actions) {
+                // Leave the currently-selected space and return to the full rooms list.
+                cx.action(NavigationBarAction::GoToHome);
+            }
             if self.view.button(cx, ids!(open_directory_button.directory_click_area)).clicked(actions) {
                 cx.action(NavigationBarAction::GoToDirectory);
             }
@@ -257,16 +308,22 @@ impl Widget for RoomsListHeader {
 
                 if let Some(NavigationBarAction::TabSelected(tab)) = action.downcast_ref() {
                     let header_title = self.view.label(cx, ids!(header_title));
-                    match tab {
+                    let show_back = match tab {
                         SelectedTab::Space { space_name_id } => {
                             header_title.set_text(cx, &space_name_id.to_string());
                             self.showing_space_title = true;
+                            // On mobile there's no spaces rail to step out of a space,
+                            // so surface a back button that returns to "All Rooms".
+                            !effective_is_desktop(cx)
                         }
                         _ => {
                             header_title.set_text(cx, tr_key(self.app_language, "rooms_list_header.title.all_rooms"));
                             self.showing_space_title = false;
+                            false
                         }
-                    }
+                    };
+                    self.view.view(cx, ids!(back_button)).set_visible(cx, show_back);
+                    self.redraw(cx);
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary

Two mobile-facing fixes for the Rooms / Workspace flow:

### 1. Can't leave a workspace on mobile (stuck in a space)
On mobile, opening a workspace from the **Workspace** tab auto-switches to the **Rooms** tab and filters the rooms list to that space (`selected_space` is set). There was no control to clear that filter, so the user got stuck and could never get back to the full room list.

**Fix:** Added a **back button** in the rooms-list header (`RoomsListHeader`), shown **only on mobile when a space is selected**. Tapping it emits `NavigationBarAction::GoToHome`, which clears `selected_space`, restores the "All Rooms" title, and re-shows the full rooms list. Desktop is unaffected — its spaces rail already handles this, and the button stays hidden there (gated by `effective_is_desktop`).

### 2. Empty workspace shows the loading spinner forever
The rooms-list status row showed the loading spinner whenever the list was empty (`status_label_id == 0`), with no way to tell "still loading" apart from "loaded but genuinely empty". A workspace with no rooms therefore span forever, which read as an ambiguous perpetual load.

**Fix:** The spinner now only shows while rooms are genuinely still loading:
- For a **selected space**, that means its direct-child list isn't fully paginated yet (`SpaceMapValue.is_fully_paginated`). Once pagination completes, an empty result is a real empty state → drop the spinner and show **"No joined or invited rooms found in this space."**; while loading, the text reads **"Loading rooms…"** to avoid the spinner-plus-"no rooms" contradiction.
- The **all-rooms** view keeps its prior behavior (we can't yet reliably detect full-load completion).
- Added a redraw when the selected space finishes paginating so the state flips promptly.

## Files
- `src/home/rooms_list_header.rs` — mobile back button (DSL + visibility/click logic)
- `src/home/rooms_list.rs` — spinner shown only while still loading; redraw on space pagination complete

## Test plan (mobile view)
1. Workspace tab → tap a workspace → a back arrow appears top-left → tapping it returns to the full "All Rooms" list.
2. Open a workspace with **no** rooms → shows "No joined or invited rooms found in this space." with **no** spinner; a workspace still loading shows the spinner + "Loading rooms…".
3. Desktop view is unchanged (no back button; all-rooms loading behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)