### PR TITLE
Improve Octos agent access setup UX

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -965,6 +965,29 @@ impl MatchEvent for App {
                 self.ui.modal(cx, ids!(add_agent_modal)).open(cx);
                 continue;
             }
+            if let Some(AgentSettingsAction::OpenOctosSetup) = action.downcast_ref() {
+                let app_language = self.app_state.app_language;
+                let octos_service_url = self.app_state.bot_settings.resolved_octos_service_url().to_string();
+                let existing_octos_agent = self.app_state
+                    .agent_registry
+                    .agent_user_ids()
+                    .into_iter()
+                    .find(|user_id| {
+                        self.app_state
+                            .agent_registry
+                            .get(user_id.as_ref())
+                            .is_some_and(|entry| entry.framework == AgentFramework::Octos)
+                    });
+                let existing_octos_agent_user_id = existing_octos_agent.as_ref().map(|user_id| user_id.as_str());
+                self.ui.add_agent_modal(cx, ids!(add_agent_modal_inner)).show_octos(
+                    cx,
+                    app_language,
+                    &octos_service_url,
+                    existing_octos_agent_user_id,
+                );
+                self.ui.modal(cx, ids!(add_agent_modal)).open(cx);
+                continue;
+            }
             match action.downcast_ref::<AddAgentModalAction>() {
                 Some(AddAgentModalAction::Close) => {
                     self.ui.modal(cx, ids!(add_agent_modal)).close(cx);
@@ -1880,7 +1903,7 @@ impl MatchEvent for App {
                         .show(
                             cx,
                             room_name_id.clone(),
-                            &self.app_state.bot_settings,
+                            &self.app_state,
                             self.app_state.app_language,
                         );
                     self.ui.modal(cx, ids!(bot_binding_modal)).open(cx);

--- a/src/home/bot_binding_modal.rs
+++ b/src/home/bot_binding_modal.rs
@@ -4,13 +4,58 @@ use makepad_widgets::*;
 use ruma::{OwnedUserId, UserId};
 
 use crate::{
-    app::{AppState, BotSettingsState, RoomBotBindingState},
+    app::{AgentFramework, AppState, RoomBotBindingState},
     i18n::{AppLanguage, tr_fmt, tr_key},
     persistence,
     shared::popup_list::{PopupKind, enqueue_popup_notification},
     sliding_sync::{MatrixRequest, current_user_id, submit_async_request},
     utils::RoomNameId,
 };
+
+fn push_unique_bot_user_id(bot_user_ids: &mut Vec<OwnedUserId>, bot_user_id: OwnedUserId) {
+    if !bot_user_ids
+        .iter()
+        .any(|known_bot_user_id| known_bot_user_id.as_str() == bot_user_id.as_str())
+    {
+        bot_user_ids.push(bot_user_id);
+    }
+}
+
+fn bot_binding_known_bot_user_ids(app_state: &AppState) -> Vec<OwnedUserId> {
+    let mut known_bot_user_ids = app_state.bot_settings.known_bot_user_ids();
+    for bound_bot_user_id in app_state.bot_settings.all_bound_bot_user_ids() {
+        push_unique_bot_user_id(&mut known_bot_user_ids, bound_bot_user_id);
+    }
+    for agent_user_id in app_state.agent_registry.agent_user_ids() {
+        if app_state
+            .agent_registry
+            .get(agent_user_id.as_ref())
+            .is_some_and(|entry| entry.framework == AgentFramework::Octos)
+        {
+            push_unique_bot_user_id(&mut known_bot_user_ids, agent_user_id);
+        }
+    }
+    known_bot_user_ids.sort_by(|lhs, rhs| lhs.as_str().cmp(rhs.as_str()));
+    known_bot_user_ids.dedup_by(|lhs, rhs| lhs.as_str() == rhs.as_str());
+    known_bot_user_ids
+}
+
+fn default_known_bot_selection(
+    room_bound_bots: &[RoomBotBindingState],
+    known_bot_user_ids: &[OwnedUserId],
+) -> usize {
+    room_bound_bots
+        .first()
+        .and_then(|binding|
+            known_bot_user_ids
+                .iter()
+                .position(|known_bot_user_id| known_bot_user_id.as_str() == binding.bot_user_id.as_str())
+        )
+        .map_or_else(
+            || if known_bot_user_ids.is_empty() { 0 } else { 1 },
+            |index| index + 1,
+        )
+}
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -623,25 +668,12 @@ impl BotBindingModal {
         &mut self,
         cx: &mut Cx,
         room_name_id: RoomNameId,
-        bot_settings: &BotSettingsState,
+        app_state: &AppState,
         app_language: AppLanguage,
     ) {
         self.app_language = app_language;
-        self.room_bound_bots = bot_settings.room_bindings_for(room_name_id.room_id());
-        self.known_bot_user_ids = bot_settings.known_bot_user_ids();
-        for bound_bot_user_id in bot_settings.all_bound_bot_user_ids() {
-            if !self
-                .known_bot_user_ids
-                .iter()
-                .any(|known_bot_user_id| known_bot_user_id.as_str() == bound_bot_user_id.as_str())
-            {
-                self.known_bot_user_ids.push(bound_bot_user_id);
-            }
-        }
-        self.known_bot_user_ids
-            .sort_by(|lhs, rhs| lhs.as_str().cmp(rhs.as_str()));
-        self.known_bot_user_ids
-            .dedup_by(|lhs, rhs| lhs.as_str() == rhs.as_str());
+        self.room_bound_bots = app_state.bot_settings.room_bindings_for(room_name_id.room_id());
+        self.known_bot_user_ids = bot_binding_known_bot_user_ids(app_state);
         self.room_name_id = Some(room_name_id.clone());
 
         self.set_title_and_body(cx, &room_name_id);
@@ -652,15 +684,7 @@ impl BotBindingModal {
         let known_bots_dropdown = self.view.drop_down(cx, ids!(form.known_bots_dropdown));
         let user_id_input = self.view.text_input(cx, ids!(form.user_id_input));
         let remark_input = self.view.text_input(cx, ids!(form.remark_input));
-        let selected_item = self
-            .room_bound_bots
-            .first()
-            .and_then(|binding|
-                self.known_bot_user_ids
-                    .iter()
-                    .position(|known_bot_user_id| known_bot_user_id.as_str() == binding.bot_user_id.as_str())
-            )
-            .map_or(0, |index| index + 1);
+        let selected_item = default_known_bot_selection(&self.room_bound_bots, &self.known_bot_user_ids);
         current_room_bots_dropdown.set_selected_item(
             cx,
             if self.room_bound_bots.is_empty() { 0 } else { 1 },
@@ -669,6 +693,12 @@ impl BotBindingModal {
         if let Some(bound_bot) = self.room_bound_bots.first() {
             user_id_input.set_text(cx, bound_bot.bot_user_id.as_str());
             remark_input.set_text(cx, &bound_bot.remark);
+        } else if let Some(bot_user_id) = selected_item
+            .checked_sub(1)
+            .and_then(|index| self.known_bot_user_ids.get(index))
+        {
+            user_id_input.set_text(cx, bot_user_id.as_str());
+            remark_input.set_text(cx, "");
         } else {
             user_id_input.set_text(cx, "");
             remark_input.set_text(cx, "");
@@ -693,11 +723,11 @@ impl BotBindingModalRef {
         &self,
         cx: &mut Cx,
         room_name_id: RoomNameId,
-        bot_settings: &BotSettingsState,
+        app_state: &AppState,
         app_language: AppLanguage,
     ) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.show(cx, room_name_id, bot_settings, app_language);
+        inner.show(cx, room_name_id, app_state, app_language);
     }
 }
 
@@ -706,5 +736,45 @@ fn persist_bot_settings(app_state: &AppState) {
         if let Err(e) = persistence::save_app_state(app_state.clone(), user_id) {
             error!("Failed to persist bot settings. Error: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bot_binding_known_bot_user_ids, default_known_bot_selection};
+    use crate::app::{AgentEntry, AgentFramework, AppState};
+    use matrix_sdk::ruma::OwnedUserId;
+
+    #[test]
+    fn room_bot_picker_includes_registered_octos_agents() {
+        let mut app_state = AppState::default();
+        let octos_id: OwnedUserId = "@octos_mac:matrix.palpo.im".try_into().unwrap();
+
+        app_state.agent_registry.register(
+            octos_id.clone(),
+            AgentEntry {
+                framework: AgentFramework::Octos,
+                ..Default::default()
+            },
+        );
+
+        let known_bots = bot_binding_known_bot_user_ids(&app_state);
+
+        assert!(
+            known_bots.iter().any(|user_id| user_id.as_str() == octos_id.as_str()),
+            "room bot picker should offer globally registered Octos agents without requiring manual re-entry",
+        );
+    }
+
+    #[test]
+    fn room_bot_picker_defaults_to_first_registered_bot() {
+        let octos_id: OwnedUserId = "@octos_mac:matrix.palpo.im".try_into().unwrap();
+        let known_bots = vec![octos_id];
+
+        assert_eq!(
+            default_known_bot_selection(&[], &known_bots),
+            1,
+            "when a room has no bot binding but registered bots exist, Manage Bot should preselect a bot instead of Custom bot user ID",
+        );
     }
 }

--- a/src/home/room_settings_modal.rs
+++ b/src/home/room_settings_modal.rs
@@ -244,6 +244,45 @@ script_mod! {
                         draw_bg +: { color: (COLOR_SECONDARY) }
                     }
 
+                    // ── Advanced ────────────────────────────────────
+                    advanced_heading := Label {
+                        width: Fill
+                        height: Fit
+                        margin: Inset{bottom: 10}
+                        draw_text +: {
+                            text_style: RBX_TEXT_SECTION_TITLE {}
+                            color: (RBX_FG_PRIMARY)
+                        }
+                        text: "Advanced"
+                    }
+
+                    room_id_label := Label {
+                        width: Fill
+                        height: Fit
+                        margin: Inset{bottom: 4}
+                        draw_text +: {
+                            text_style: RBX_TEXT_BODY {}
+                            color: (RBX_FG_SECONDARY)
+                        }
+                        text: "Room ID"
+                    }
+
+                    room_id_input := RobrixTextInput {
+                        width: Fill
+                        height: 36
+                        is_read_only: true
+                        empty_text: "!room:server"
+                    }
+
+                    // ── Section separator ────────────────────────────
+                    View {
+                        width: Fill
+                        height: 1
+                        margin: Inset{top: 20, bottom: 16}
+                        show_bg: true
+                        draw_bg +: { color: (COLOR_SECONDARY) }
+                    }
+
                     // ── Room Addresses ───────────────────────────────
                     addresses_heading := Label {
                         width: Fill
@@ -680,6 +719,7 @@ impl RoomSettingsModal {
         room_topic: &str,
         canonical_alias: Option<&str>,
     ) {
+        let room_id_text = room_id.as_str().to_string();
         self.room_id = Some(room_id);
         self.original_name = room_name.to_string();
         self.original_topic = room_topic.to_string();
@@ -694,6 +734,10 @@ impl RoomSettingsModal {
             .set_text(cx, room_name);
         self.view.text_input(cx, ids!(room_topic_input))
             .set_text(cx, room_topic);
+        self.view.text_input(cx, ids!(room_id_input))
+            .set_text(cx, &room_id_text);
+        self.view.text_input(cx, ids!(room_id_input))
+            .set_is_read_only(cx, true);
 
         // Canonical alias
         let alias_text = canonical_alias
@@ -763,5 +807,29 @@ impl RoomSettingsModalRef {
     pub fn apply_avatar(&self, cx: &mut Cx, image_data: &[u8]) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.apply_avatar(cx, image_data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const SOURCE: &str = include_str!("room_settings_modal.rs");
+
+    #[test]
+    fn advanced_section_declares_read_only_room_id_input() {
+        assert!(SOURCE.contains(concat!("advanced_", "heading := Label")));
+        assert!(SOURCE.contains(concat!("text: \"", "Advanced", "\"")));
+        assert!(SOURCE.contains(concat!("room_id_", "label := Label")));
+        assert!(SOURCE.contains(concat!("text: \"", "Room ID", "\"")));
+        assert!(SOURCE.contains(concat!("room_id_", "input := RobrixTextInput")));
+        assert!(SOURCE.contains(concat!("is_read_", "only: true")));
+        assert!(SOURCE.contains(concat!("empty_text: \"", "!room:server", "\"")));
+    }
+
+    #[test]
+    fn show_populates_room_id_input_from_room_id() {
+        assert!(SOURCE.contains(concat!("let room_id_", "text = room_id.as_str().to_string();")));
+        assert!(SOURCE.contains(concat!("self.room_id = Some(room_id", ");")));
+        assert!(SOURCE.contains(concat!("ids!(room_id_", "input))")));
+        assert!(SOURCE.contains(concat!(".set_text(cx, &room_id_", "text);")));
     }
 }

--- a/src/settings/agent_add_modal.rs
+++ b/src/settings/agent_add_modal.rs
@@ -273,77 +273,6 @@ script_mod! {
         }
     }
 
-    let MatrixIdField = View {
-        width: Fill
-        height: Fit
-        flow: Down
-        spacing: 5
-        field_label := Label {
-            width: Fill
-            height: Fit
-            draw_text +: {
-                color: (RBX_FG_SECONDARY)
-                text_style: RBX_TEXT_META {}
-            }
-            text: "Agent Matrix ID"
-        }
-        field_control := RoundedView {
-            width: Fill
-            height: Fit
-            flow: Right
-            align: Align{y: 0.5}
-            spacing: 0
-            padding: Inset{left: 11, right: 4, top: 2, bottom: 2}
-            new_batch: true
-            show_bg: true
-            draw_bg +: {
-                color: (RBX_BG_SURFACE_SUBTLE)
-                border_radius: (RBX_RADIUS_XXS)
-                border_size: 1.0
-                border_color: (RBX_STROKE_SOFT)
-            }
-            at_prefix := Label {
-                width: Fit
-                height: Fit
-                margin: Inset{right: 2}
-                draw_text +: {
-                    color: (RBX_FG_TERTIARY)
-                    text_style: RBX_TEXT_BODY_STRONG {}
-                }
-                text: "@"
-            }
-            field_input := RobrixTextInput {
-                width: Fill
-                height: Fit
-                padding: Inset{left: 2, right: 8, top: 8, bottom: 8}
-                empty_text: "agent:server"
-                draw_bg +: {
-                    color: (RBX_TRANSPARENT)
-                    color_hover: (RBX_TRANSPARENT)
-                    color_focus: (RBX_TRANSPARENT)
-                    color_down: (RBX_TRANSPARENT)
-                    color_empty: (RBX_TRANSPARENT)
-                    color_disabled: (RBX_TRANSPARENT)
-                    border_size: 0.0
-                    border_color: (RBX_TRANSPARENT)
-                    border_color_hover: (RBX_TRANSPARENT)
-                    border_color_focus: (RBX_TRANSPARENT)
-                    border_color_down: (RBX_TRANSPARENT)
-                    border_color_empty: (RBX_TRANSPARENT)
-                    border_color_disabled: (RBX_TRANSPARENT)
-                }
-                // Dark real input vs light-grey placeholder, so the hint reads
-                // as a hint rather than an entered ID.
-                draw_text +: {
-                    color: (RBX_FG_PRIMARY)
-                    color_empty: (RBX_FG_TERTIARY)
-                    color_empty_hover: (RBX_FG_TERTIARY)
-                    color_empty_focus: (RBX_FG_TERTIARY)
-                }
-            }
-        }
-    }
-
     mod.widgets.AddAgentModal = #(AddAgentModal::register_widget(vm)) {
         // Fill/Fit root: the hosting Modal content provides a real width and
         // bottom alignment. The sheet is capped below, so narrow phones get
@@ -370,6 +299,9 @@ script_mod! {
             // Without this, those taps fall through the sheet to the buttons
             // behind the modal. (A View only hit-tests when it has a cursor or an
             // animator — see widgets/src/view.rs.)
+            // View handles child events first, then its own hit-test. Keep the
+            // sheet from taking keyboard focus back after a TextInput receives it.
+            grab_key_focus: false
             capture_overload: true
             cursor: MouseCursor.Default
             padding: Inset{left: 16, right: 16, top: 10, bottom: 16}
@@ -644,7 +576,10 @@ script_mod! {
                         }
                     }
 
-                    id_field := MatrixIdField {}
+                    id_field := AgentField {
+                        field_label.text: "Agent Matrix ID"
+                        field_input.empty_text: "@agent:server or agent:server"
+                    }
 
                     add_friend_button := RobrixIconButton {
                         width: Fill
@@ -908,7 +843,7 @@ impl WidgetMatchEvent for AddAgentModal {
         }
 
         if self.step == 2 {
-            let id_changed = self.view.text_input(cx, ids!(id_field.field_control.field_input)).changed(actions).is_some();
+            let id_changed = self.view.text_input(cx, ids!(id_field.field_input)).changed(actions).is_some();
             let octos_url_changed = self.is_octos()
                 && self.view.text_input(cx, ids!(octos_section.octos_url_field.field_input)).changed(actions).is_some();
             if octos_url_changed {
@@ -1018,7 +953,7 @@ impl AddAgentModal {
     }
 
     fn add_friend(&mut self, cx: &mut Cx) {
-        let raw = self.view.text_input(cx, ids!(id_field.field_control.field_input)).text();
+        let raw = self.view.text_input(cx, ids!(id_field.field_input)).text();
         match parse_agent_user_id(&raw) {
             Ok(user_id) => {
                 self.target_user_id = Some(user_id.clone());
@@ -1110,6 +1045,12 @@ impl AddAgentModal {
         err.set_visible(cx, false);
         self.view.button(cx, ids!(octos_section.save_appservice_button))
             .set_text(cx, "Saved");
+        if self.friend_state == FriendState::Idle {
+            let id_input = self.view.text_input(cx, ids!(id_field.field_input));
+            id_input.set_is_read_only(cx, false);
+            id_input.set_key_focus(cx);
+        }
+        self.sync_bind_button(cx);
         self.view.redraw(cx);
     }
 
@@ -1118,7 +1059,7 @@ impl AddAgentModal {
     }
 
     fn sync_bind_button(&mut self, cx: &mut Cx) {
-        let agent_id_raw = self.view.text_input(cx, ids!(id_field.field_control.field_input)).text();
+        let agent_id_raw = self.view.text_input(cx, ids!(id_field.field_input)).text();
         let (text, enabled) = bind_button_state(
             self.friend_state,
             self.is_octos(),
@@ -1285,7 +1226,7 @@ impl AddAgentModal {
         self.view.view(cx, ids!(friend_added_strip)).set_visible(cx, added);
         self.view.view(cx, ids!(octos_section)).set_visible(cx, self.is_octos());
         // The Matrix ID field locks once a friend request is in flight / done.
-        self.view.text_input(cx, ids!(id_field.field_control.field_input)).set_is_read_only(cx, self.friend_state != FriendState::Idle);
+        self.view.text_input(cx, ids!(id_field.field_input)).set_is_read_only(cx, self.friend_state != FriendState::Idle);
 
         if self.is_octos() {
             self.view.text_input(cx, ids!(octos_section.octos_url_field.field_input)).set_is_read_only(cx, false);
@@ -1381,14 +1322,50 @@ impl AddAgentModal {
         self.octos_health = OctosHealthState::default();
         self.octos_probe_base_url = None;
 
-        self.view.text_input(cx, ids!(id_field.field_control.field_input)).set_text(cx, "");
-        self.view.text_input(cx, ids!(id_field.field_control.field_input)).set_is_read_only(cx, false);
+        self.view.text_input(cx, ids!(id_field.field_input)).set_text(cx, "");
+        self.view.text_input(cx, ids!(id_field.field_input)).set_is_read_only(cx, false);
         self.view.text_input(cx, ids!(octos_section.octos_url_field.field_input)).set_text(cx, BotSettingsState::DEFAULT_OCTOS_SERVICE_URL);
         self.view.button(cx, ids!(octos_section.save_appservice_button)).set_text(cx, "Save AppService");
         self.set_add_friend_label(cx, "Add friend & bind");
         self.populate_framework_cards(cx);
         self.update_framework_cards(cx);
         self.sync_steps(cx);
+        self.view.redraw(cx);
+    }
+
+    pub fn show_octos(
+        &mut self,
+        cx: &mut Cx,
+        app_language: AppLanguage,
+        octos_service_url: &str,
+        existing_octos_agent_user_id: Option<&str>,
+    ) {
+        self.show(cx, app_language);
+        let trimmed = octos_service_url.trim();
+        let url = if trimmed.is_empty() {
+            BotSettingsState::DEFAULT_OCTOS_SERVICE_URL.to_string()
+        } else {
+            trimmed.to_string()
+        };
+
+        self.selected_framework = Some(AgentFramework::Octos);
+        self.step = 2;
+        self.view.text_input(cx, ids!(octos_section.octos_url_field.field_input))
+            .set_text(cx, &url);
+        self.view.button(cx, ids!(octos_section.save_appservice_button))
+            .set_text(cx, "Save AppService");
+        self.update_framework_cards(cx);
+        self.sync_steps(cx);
+        let id_input = self.view.text_input(cx, ids!(id_field.field_input));
+        if let Some(existing_octos_agent_user_id) = existing_octos_agent_user_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            id_input.set_text(cx, existing_octos_agent_user_id);
+        }
+        id_input.set_is_read_only(cx, false);
+        id_input.set_key_focus(cx);
+        self.sync_bind_button(cx);
         self.view.redraw(cx);
     }
 
@@ -1406,6 +1383,17 @@ impl AddAgentModalRef {
     pub fn show(&self, cx: &mut Cx, app_language: AppLanguage) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.show(cx, app_language);
+    }
+
+    pub fn show_octos(
+        &self,
+        cx: &mut Cx,
+        app_language: AppLanguage,
+        octos_service_url: &str,
+        existing_octos_agent_user_id: Option<&str>,
+    ) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.show_octos(cx, app_language, octos_service_url, existing_octos_agent_user_id);
     }
 
     pub fn clear_waiting_state(&self) {
@@ -1491,7 +1479,7 @@ mod tests {
             .find("octos_section := RoundedView")
             .expect("Octos step should expose an AppService section");
         let matrix_pos = src
-            .find("id_field := MatrixIdField")
+            .find("id_field := AgentField")
             .expect("Octos step should still include Matrix ID binding");
 
         assert!(octos_pos < matrix_pos, "Octos AppService URL should be configured before Matrix ID binding");
@@ -1506,6 +1494,105 @@ mod tests {
         assert!(!src.contains("let appservice_unlocked = self.friend_state == FriendState::Added;"));
         assert!(!src.contains("if self.friend_state != FriendState::Added {\n                return;\n            }"));
         assert!(src.contains("fn save_octos_appservice_settings"));
+    }
+
+    #[test]
+    fn test_saving_octos_appservice_focuses_matrix_id_binding_field() {
+        let src = production_src(include_str!("agent_add_modal.rs"));
+        let save_fn_pos = src
+            .find("fn save_octos_appservice_settings")
+            .expect("Octos AppService save handler should exist");
+        let save_fn = &src[save_fn_pos..];
+
+        assert!(
+            save_fn.contains("let id_input = self.view.text_input(cx, ids!(id_field.field_input));"),
+            "after saving the AppService URL, the handler should select the Matrix ID field",
+        );
+        assert!(
+            save_fn.contains("id_input.set_key_focus(cx);"),
+            "after saving the AppService URL, focus should move to the Matrix ID field for the bind step",
+        );
+    }
+
+    #[test]
+    fn test_saving_octos_appservice_does_not_steal_matrix_id_focus_while_friend_request_in_flight() {
+        let src = production_src(include_str!("agent_add_modal.rs"));
+        let save_fn_pos = src
+            .find("fn save_octos_appservice_settings")
+            .expect("Octos AppService save handler should exist");
+        let save_fn = &src[save_fn_pos..];
+
+        assert!(
+            save_fn.contains("if self.friend_state == FriendState::Idle {"),
+            "saving the AppService URL must not unlock or steal focus into the Matrix ID field while a friend/bind request is in flight or already done, since sync_step2 locks that field on FriendState::Pending/Added",
+        );
+    }
+
+    #[test]
+    fn test_add_modal_can_open_directly_to_octos_setup_with_saved_url() {
+        let src = production_src(include_str!("agent_add_modal.rs"));
+        let show_fn_pos = src
+            .find("pub fn show_octos")
+            .expect("AddAgentModal should expose a direct Octos setup entry point");
+        let show_fn = &src[show_fn_pos..];
+
+        assert!(show_fn.contains("self.selected_framework = Some(AgentFramework::Octos);"));
+        assert!(show_fn.contains("self.step = 2;"));
+        assert!(
+            show_fn.contains("octos_service_url")
+                && show_fn.contains("octos_section.octos_url_field.field_input")
+                && show_fn.contains("set_text(cx, &url);"),
+            "direct Octos setup should prefill the saved AppService URL instead of resetting to localhost",
+        );
+    }
+
+    #[test]
+    fn test_direct_octos_setup_focuses_matrix_id_input() {
+        let src = production_src(include_str!("agent_add_modal.rs"));
+        let show_fn_pos = src
+            .find("pub fn show_octos")
+            .expect("AddAgentModal should expose a direct Octos setup entry point");
+        let show_fn = &src[show_fn_pos..];
+
+        assert!(
+            show_fn.contains("let id_input = self.view.text_input(cx, ids!(id_field.field_input));")
+                && show_fn.contains("id_input.set_is_read_only(cx, false);")
+                && show_fn.contains("id_input.set_key_focus(cx);"),
+            "opening the saved Octos setup directly should focus the Matrix ID field so the user can start typing the bot id",
+        );
+    }
+
+    #[test]
+    fn test_direct_octos_setup_prefills_existing_octos_agent_id() {
+        let src = production_src(include_str!("agent_add_modal.rs"));
+        let show_fn_pos = src
+            .find("pub fn show_octos")
+            .expect("AddAgentModal should expose a direct Octos setup entry point");
+        let show_fn = &src[show_fn_pos..];
+
+        assert!(show_fn.contains("existing_octos_agent_user_id"));
+        assert!(
+            show_fn.contains("if let Some(existing_octos_agent_user_id) = existing_octos_agent_user_id")
+                && show_fn.contains("id_input.set_text(cx, existing_octos_agent_user_id);"),
+            "opening Change Octos Bot should show the currently registered Octos bot instead of an empty Matrix ID field",
+        );
+        assert!(
+            show_fn.contains("self.sync_bind_button(cx);"),
+            "programmatic Matrix ID prefill should refresh the bind button state",
+        );
+    }
+
+    #[test]
+    fn test_app_routes_octos_setup_action_with_saved_appservice_url() {
+        let app_src = include_str!("../app.rs");
+
+        assert!(app_src.contains("AgentSettingsAction::OpenOctosSetup"));
+        assert!(app_src.contains("resolved_octos_service_url().to_string()"));
+        assert!(app_src.contains("find(|user_id|"));
+        assert!(app_src.contains("entry.framework == AgentFramework::Octos"));
+        assert!(app_src.contains(".show_octos("));
+        assert!(app_src.contains("&octos_service_url"));
+        assert!(app_src.contains("existing_octos_agent_user_id"));
     }
 
     #[test]
@@ -1616,6 +1703,21 @@ mod tests {
     }
 
     #[test]
+    fn test_add_modal_sheet_does_not_steal_text_input_focus() {
+        let src = production_src(include_str!("agent_add_modal.rs"));
+        let sheet_pos = src.find("sheet := RoundedView").expect("modal should have a sheet");
+        let body_pos = src.find("body_scroll := ScrollYView").expect("modal should have a body");
+        let sheet_block = &src[sheet_pos..body_pos];
+
+        assert!(sheet_block.contains("cursor: MouseCursor.Default"));
+        assert!(sheet_block.contains("capture_overload: true"));
+        assert!(
+            sheet_block.contains("grab_key_focus: false"),
+            "sheet absorbs pointer hits but must not take keyboard focus back from TextInput children",
+        );
+    }
+
+    #[test]
     fn test_framework_picker_matches_handoff_order_and_tile_size() {
         let src = production_src(include_str!("agent_add_modal.rs"));
         let hermes_pos = src.find("hermes_card := FrameworkCard").expect("Hermes card should exist");
@@ -1640,14 +1742,16 @@ mod tests {
 
 
     #[test]
-    fn test_matrix_id_field_matches_handoff_at_adornment() {
+    fn test_matrix_id_field_uses_plain_text_input_without_at_adornment() {
         let src = production_src(include_str!("agent_add_modal.rs"));
 
-        assert!(src.contains("let MatrixIdField = View"));
-        assert!(src.contains("at_prefix := Label"));
-        assert!(src.contains("text: \"@\""));
-        assert!(src.contains("empty_text: \"agent:server\""));
-        assert!(!src.contains("field_input.empty_text: \"@agent:server\""));
+        assert!(
+            src.contains("id_field := AgentField"),
+            "Matrix ID should use the same plain RobrixTextInput field pattern as working user/bot id inputs",
+        );
+        assert!(!src.contains("let MatrixIdField = View"));
+        assert!(!src.contains("at_prefix := Label"));
+        assert!(src.contains("field_input.empty_text: \"@agent:server or agent:server\""));
     }
 
     #[test]

--- a/src/settings/agent_settings.rs
+++ b/src/settings/agent_settings.rs
@@ -537,6 +537,48 @@ script_mod! {
                     text: "Endpoint not configured"
                 }
             }
+
+            appservice_actions_row := View {
+                width: Fill
+                height: Fit
+                flow: Right
+                align: Align{y: 0.5}
+                spacing: 8
+                margin: Inset{top: 6}
+
+                appservice_bind_button := RobrixIconButton {
+                    width: Fill
+                    height: (RBX_CONTROL_H_MD)
+                    padding: Inset{top: 8, bottom: 8, left: 12, right: 12}
+                    icon_walk: Walk{width: 0, height: 0}
+                    spacing: 0
+                    text: "Bind Octos Bot"
+                    draw_bg +: {
+                        color: (RBX_ACCENT)
+                        color_hover: (RBX_ACCENT_HOVER)
+                        color_down: (RBX_ACCENT_PRESSED)
+                        border_radius: (RBX_RADIUS_XXS)
+                    }
+                    draw_text +: { color: (RBX_FG_ON_ACCENT), color_hover: (RBX_FG_ON_ACCENT), color_down: (RBX_FG_ON_ACCENT) }
+                }
+                appservice_edit_button := RobrixIconButton {
+                    width: Fill
+                    height: (RBX_CONTROL_H_MD)
+                    padding: Inset{top: 8, bottom: 8, left: 12, right: 12}
+                    icon_walk: Walk{width: 0, height: 0}
+                    spacing: 0
+                    text: "Edit AppService"
+                    draw_bg +: {
+                        color: (RBX_BG_SURFACE)
+                        color_hover: (RBX_BG_HOVER)
+                        color_down: (RBX_BG_PRESSED)
+                        border_radius: (RBX_RADIUS_XXS)
+                        border_size: 1.0
+                        border_color: (RBX_INFO_FG)
+                    }
+                    draw_text +: { color: (RBX_INFO_FG), color_hover: (RBX_INFO_FG), color_down: (RBX_INFO_FG) }
+                }
+            }
         }
 
         registry_card := RoundedView {
@@ -634,6 +676,8 @@ script_mod! {
 pub enum AgentSettingsAction {
     /// The user tapped "Add an agent" — the host should open the add-agent modal.
     OpenAddAgent,
+    /// The user wants to configure or bind Octos from the AppService summary.
+    OpenOctosSetup,
 }
 
 /// Emitted by an [`AgentRegistryRow`] when one of its row buttons is clicked.
@@ -797,6 +841,10 @@ pub struct AgentSettings {
     #[rust]
     last_synced_agent_ids: Vec<OwnedUserId>,
     #[rust]
+    last_synced_appservice_enabled: bool,
+    #[rust]
+    last_synced_octos_service_url: String,
+    #[rust]
     has_synced_agents: bool,
     #[rust]
     octos_health: OctosHealthState,
@@ -887,6 +935,12 @@ impl WidgetMatchEvent for AgentSettings {
             cx.action(AgentSettingsAction::OpenAddAgent);
             return;
         }
+        if self.view.button(cx, ids!(appservice_summary_card.appservice_actions_row.appservice_bind_button)).clicked(actions)
+            || self.view.button(cx, ids!(appservice_summary_card.appservice_actions_row.appservice_edit_button)).clicked(actions)
+        {
+            cx.action(AgentSettingsAction::OpenOctosSetup);
+            return;
+        }
 
         // Row actions arrive as `AgentRowAction`s emitted by each
         // `AgentRegistryRow`, carrying the row's own MXID (mirrors how
@@ -975,11 +1029,19 @@ impl AgentSettings {
     }
 
     fn sync_agents_from_scope_if_needed(&mut self, cx: &mut Cx, scope: &mut Scope) {
-        let current_ids = match scope.data.get::<AppState>() {
-            Some(app_state) => app_state.agent_registry.agent_user_ids(),
+        let (current_ids, appservice_enabled, octos_service_url) = match scope.data.get::<AppState>() {
+            Some(app_state) => (
+                app_state.agent_registry.agent_user_ids(),
+                app_state.bot_settings.enabled,
+                app_state.bot_settings.resolved_octos_service_url().to_string(),
+            ),
             None => return,
         };
-        if self.has_synced_agents && self.last_synced_agent_ids == current_ids {
+        if self.has_synced_agents
+            && self.last_synced_agent_ids == current_ids
+            && self.last_synced_appservice_enabled == appservice_enabled
+            && self.last_synced_octos_service_url == octos_service_url
+        {
             return;
         }
         if let Some(app_state) = scope.data.get::<AppState>() {
@@ -995,6 +1057,8 @@ impl AgentSettings {
         let agent_ids = app_state.agent_registry.agent_user_ids();
         self.has_synced_agents = true;
         self.last_synced_agent_ids = agent_ids.clone();
+        self.last_synced_appservice_enabled = app_state.bot_settings.enabled;
+        self.last_synced_octos_service_url = app_state.bot_settings.resolved_octos_service_url().to_string();
 
         let any = !agent_ids.is_empty();
         self.view.view(cx, ids!(registry_card.agents_list)).set_visible(cx, any);
@@ -1033,16 +1097,35 @@ impl AgentSettings {
                 format!("{octos_count}/{octos_count} online")
             }
             OctosHealthStatus::Unreachable if octos_count > 0 => format!("0/{octos_count} online"),
+            _ if app_state.bot_settings.enabled && octos_count == 0 => "No Octos bound".to_string(),
             _ => format!("{octos_count} Octos"),
         };
         self.view.label(cx, ids!(appservice_summary_card.appservice_summary_header.appservice_online_pill.appservice_online_label))
             .set_text(cx, &label);
+        let body = if app_state.bot_settings.enabled && octos_count == 0 {
+            "AppService URL is saved. Bind an Octos Matrix ID to make it usable in Agent Access."
+        } else {
+            "Robrix stays a normal Matrix client. It binds local Octos services and runs the matching slash commands."
+        };
+        self.view.label(cx, ids!(appservice_summary_card.appservice_summary_body))
+            .set_text(cx, body);
         self.view.label(cx, ids!(appservice_summary_card.appservice_config_row.appservice_endpoint_value))
             .set_text(cx, app_state.bot_settings.resolved_octos_service_url());
 
         let config_label = if app_state.bot_settings.enabled { "Enabled" } else { "Disabled" };
         self.view.label(cx, ids!(appservice_summary_card.appservice_config_row.appservice_config_state_pill.appservice_config_state_label))
             .set_text(cx, config_label);
+        let bind_label = if !app_state.bot_settings.enabled {
+            "Configure Octos"
+        } else if octos_count == 0 {
+            "Bind Octos Bot"
+        } else {
+            "Change Octos Bot"
+        };
+        self.view.button(cx, ids!(appservice_summary_card.appservice_actions_row.appservice_bind_button))
+            .set_text(cx, bind_label);
+        self.view.button(cx, ids!(appservice_summary_card.appservice_actions_row.appservice_edit_button))
+            .set_visible(cx, app_state.bot_settings.enabled);
 
         let mut dot = self.view.view(cx, ids!(appservice_summary_card.appservice_summary_header.appservice_online_pill.appservice_online_dot));
         let mut config_pill = self.view.view(cx, ids!(appservice_summary_card.appservice_config_row.appservice_config_state_pill));
@@ -1301,6 +1384,52 @@ mod tests {
         assert!(src.contains("octos_agents_stat"));
         assert!(src.contains("appservice_endpoint_value"));
         assert!(src.contains("appservice_config_state_label"));
+    }
+
+    #[test]
+    fn test_appservice_summary_explains_saved_url_still_needs_bound_octos_agent() {
+        let src = production_src(include_str!("agent_settings.rs"));
+
+        assert!(
+            src.contains("AppService URL is saved. Bind an Octos Matrix ID to make it usable in Agent Access."),
+            "Agent Access should not imply that saving the AppService URL alone creates a usable Octos agent",
+        );
+    }
+
+    #[test]
+    fn test_agent_access_summary_refreshes_when_only_appservice_config_changes() {
+        let src = production_src(include_str!("agent_settings.rs"));
+
+        assert!(src.contains("last_synced_appservice_enabled"));
+        assert!(src.contains("last_synced_octos_service_url"));
+        assert!(
+            src.contains("&& self.last_synced_appservice_enabled == appservice_enabled")
+                && src.contains("&& self.last_synced_octos_service_url == octos_service_url"),
+            "Agent Access summary refresh must include AppService config changes, not only AgentRegistry IDs",
+        );
+    }
+
+    #[test]
+    fn test_appservice_summary_has_direct_octos_setup_actions() {
+        let src = production_src(include_str!("agent_settings.rs"));
+
+        assert!(src.contains("appservice_bind_button"));
+        assert!(src.contains("appservice_edit_button"));
+        assert!(src.contains("Bind Octos Bot"));
+        assert!(src.contains("Edit AppService"));
+        assert!(src.contains("OpenOctosSetup"));
+    }
+
+    #[test]
+    fn test_appservice_summary_buttons_open_octos_setup() {
+        let src = production_src(include_str!("agent_settings.rs"));
+
+        assert!(
+            src.contains("self.view.button(cx, ids!(appservice_summary_card.appservice_actions_row.appservice_bind_button)).clicked(actions)")
+                && src.contains("self.view.button(cx, ids!(appservice_summary_card.appservice_actions_row.appservice_edit_button)).clicked(actions)")
+                && src.contains("cx.action(AgentSettingsAction::OpenOctosSetup);"),
+            "Octos summary actions should open the Octos setup flow directly instead of the generic framework picker",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Clarify the Agent Access AppService card so a saved AppService URL is not confused with a usable bound Octos bot.
- Add direct Configure/Bind/Change Octos actions from Agent Access and open the Octos setup flow with the saved AppService URL and existing Octos bot ID prefilled.
- Make room Manage Bot use registered Octos agents as selectable known bots, defaulting to the first registered bot when the room has no binding.
- Show the Matrix room ID in Room Settings > Advanced as a read-only, copyable field.

## Why

The previous flow made users re-enter bot IDs in multiple places and did not make the distinction between global Agent Access binding and per-room bot binding clear. It also required users to find the Matrix room ID somewhere else before they could use it in setup flows.

## Testing

- `cargo test agent_add_modal --quiet`
- `cargo test agent_settings --quiet`
- `cargo test bot_binding_modal --quiet`
- `cargo test room_settings_modal --quiet`
- `cargo test --lib --quiet`
- `cargo build --quiet`
- `git diff --check`
