### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 categories = ["gui"]
 repository = "https://github.com/Project-Robius-China/robrix2"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
@@ -308,7 +308,7 @@ minimum_system_version = "11.0"
 frameworks = []
 info_plist_path = "./packaging/Info.plist"
 entitlements = "./packaging/Entitlements.plist"
-signing_identity = "Developer ID Application: GOSIM FOUNDATION LTD. (HMX6XGJZ3R)"
+signing_identity = "-"
 
 
 ## Configuration for `cargo packager`'s generation of a macOS `.dmg`.


### PR DESCRIPTION
## Summary

Prepares the **v1.0.0** release.

- Bump package version `1.0.0-alpha.2` → `1.0.0` in `Cargo.toml`.
- Set macOS packager `signing_identity = "-"` (ad-hoc signing) because the Developer ID certificate has not been issued yet. Once the GOSIM Developer ID certificate arrives, this reverts to `Developer ID Application: GOSIM FOUNDATION LTD. (HMX6XGJZ3R)`.

## Notes

- `Cargo.lock` already lists `robrix 1.0.0`, so no lockfile change is needed.
- `packaging/Info.plist` is left untouched (as in the previous `alpha.1` / `alpha.2` bumps); cargo-packager derives the bundle version from the `Cargo.toml` version at package time.
- The release CI (`.github/workflows/release.yml`) triggers on pushing a `v*.*.*` tag. After this PR is merged, push the `v1.0.0` tag on the merged `main` commit to build & publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)