### PR TITLE
chore(release): finalize v1.0.0 — sync Cargo.lock + clippy fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "robrix"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -2049,7 +2049,7 @@ impl Widget for RoomsList {
                     // the spinner and show the empty message instead. For the all-rooms
                     // view we can't yet reliably detect completion, so keep the prior
                     // "spinner until the first room arrives" behavior.
-                    let still_loading = self.selected_space.as_ref().map_or(true, |space| {
+                    let still_loading = self.selected_space.as_ref().is_none_or(|space| {
                         !self.space_map.get(space.room_id())
                             .is_some_and(|smv| smv.is_fully_paginated)
                     });


### PR DESCRIPTION
## Summary

Follow-up to #237 to make `main` releasable as **v1.0.0**. #237 was squash-merged with only the `Cargo.toml` change; this PR lands the two remaining pieces so tagging `v1.0.0` won't break the release build.

### 1. Sync `Cargo.lock` (release-blocking) 🔴

#237 bumped `Cargo.toml` to `1.0.0` but left `Cargo.lock`'s `robrix` entry at `1.0.0-alpha.2`, so `main` is currently inconsistent.

`release.yml`'s `check_tag_version` job runs:
```
cargo metadata --no-deps --format-version 1 --frozen
```
`--frozen` **fails** when the lockfile is out of sync with the manifest. So pushing the `v1.0.0` tag on the current `main` would fail at the version-consistency gate before any build starts. This resyncs `Cargo.lock` (`robrix 1.0.0-alpha.2` → `1.0.0`).

### 2. Fix clippy warning

`src/home/rooms_list.rs:2052` triggered `clippy::unnecessary_map_or` (`map_or(true, ..)` → `is_none_or(..)`). This was pushed to #237's branch but not captured by the squash merge. Semantically identical.

## Verification

- `cargo clippy --workspace --all-features` → clean (exit 0), verified locally.
- Diff is minimal: 1 line in `Cargo.lock`, 1 line in `src/home/rooms_list.rs`.

## Next step

Once merged, tag the resulting `main` commit `v1.0.0` and push it to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)