### PR TITLE
feat(agent): show bot identity pills in rooms list, room info & member list (P0-B items 2 & 5)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2867,6 +2867,33 @@ impl AppState {
             }
         }
     }
+
+    /// Removes an AgentLab registration and the bot identity state that was
+    /// derived from that registration.
+    ///
+    /// Octos registration writes the same MXID into several legacy app-service
+    /// fields so slash commands and room binding keep working. Unbind must clear
+    /// those fields too, otherwise list/member bot markers keep rendering from
+    /// stale `known_bot_user_ids`, room bindings, or the configured BotFather ID.
+    pub fn unregister_agent_and_clear_bot_identity(
+        &mut self,
+        user_id: &UserId,
+        current_user_id: Option<&UserId>,
+    ) -> bool {
+        let removed_agent = self.agent_registry.unregister(user_id);
+        let removed_known_bot = self.bot_settings.remove_known_bot_user_id(user_id);
+        let removed_room_bindings = self
+            .bot_settings
+            .remove_room_bindings_where(|_, bot_user_id| bot_user_id == user_id);
+        let cleared_configured_bot = self
+            .bot_settings
+            .clear_configured_bot_if_matches(user_id, current_user_id);
+
+        removed_agent
+            || removed_known_bot
+            || removed_room_bindings > 0
+            || cleared_configured_bot
+    }
 }
 
 /// Local bot integration settings persisted per Matrix account.
@@ -3057,6 +3084,33 @@ impl BotSettingsState {
             self.known_bot_user_ids
                 .dedup_by(|lhs, rhs| lhs.as_str() == rhs.as_str());
         }
+        changed
+    }
+
+    pub fn remove_known_bot_user_id(&mut self, bot_user_id: &UserId) -> bool {
+        let original_len = self.known_bot_user_ids.len();
+        self.known_bot_user_ids
+            .retain(|known_bot_user_id| known_bot_user_id.as_str() != bot_user_id.as_str());
+        original_len != self.known_bot_user_ids.len()
+    }
+
+    pub fn clear_configured_bot_if_matches(
+        &mut self,
+        bot_user_id: &UserId,
+        current_user_id: Option<&UserId>,
+    ) -> bool {
+        let matches_configured_bot = self
+            .resolved_bot_user_id(current_user_id)
+            .ok()
+            .is_some_and(|resolved_bot_user_id| resolved_bot_user_id.as_str() == bot_user_id.as_str());
+        if !matches_configured_bot {
+            return false;
+        }
+
+        let changed = self.enabled
+            || self.botfather_user_id.trim() != Self::DEFAULT_BOTFATHER_LOCALPART;
+        self.enabled = false;
+        self.botfather_user_id = Self::DEFAULT_BOTFATHER_LOCALPART.to_string();
         changed
     }
 
@@ -3490,6 +3544,73 @@ mod tests {
         let known = app_state.bot_settings.known_bot_user_ids();
         assert!(known.iter().any(|id| id.as_str() == "@botA:example.org"));
         assert!(!known.is_empty());
+    }
+
+    #[test]
+    fn unregister_agent_clears_agentlab_bot_identity_surfaces() {
+        let current_user_id = UserId::parse("@alice:example.org").unwrap();
+        let agent_id: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let other_bot_id: OwnedUserId = "@other_bot:example.org".try_into().unwrap();
+        let agent_room_id: OwnedRoomId = "!agent-room:example.org".try_into().unwrap();
+        let other_room_id: OwnedRoomId = "!other-room:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent_id.clone(), AgentEntry {
+            framework: AgentFramework::Octos,
+            ..Default::default()
+        });
+        app_state.bot_settings.enabled = true;
+        app_state.bot_settings.botfather_user_id = agent_id.to_string();
+        app_state.bot_settings.record_known_bot_user_ids([
+            agent_id.clone(),
+            other_bot_id.clone(),
+        ]);
+        app_state.bot_settings.room_bindings.push(RoomBotBindingState {
+            room_id: agent_room_id.clone(),
+            bot_user_id: agent_id.clone(),
+            remark: String::new(),
+        });
+        app_state.bot_settings.room_bindings.push(RoomBotBindingState {
+            room_id: other_room_id.clone(),
+            bot_user_id: other_bot_id.clone(),
+            remark: String::new(),
+        });
+
+        assert!(app_state.unregister_agent_and_clear_bot_identity(
+            agent_id.as_ref(),
+            Some(current_user_id.as_ref()),
+        ));
+
+        assert!(!app_state.agent_registry.contains(agent_id.as_ref()));
+        assert!(
+            !app_state
+                .bot_settings
+                .known_bot_user_ids()
+                .iter()
+                .any(|known_bot_user_id| known_bot_user_id.as_str() == agent_id.as_str())
+        );
+        assert!(
+            app_state
+                .bot_settings
+                .known_bot_user_ids()
+                .iter()
+                .any(|known_bot_user_id| known_bot_user_id.as_str() == other_bot_id.as_str())
+        );
+        assert!(!app_state.bot_settings.enabled);
+        assert_eq!(
+            app_state.bot_settings.botfather_user_id,
+            BotSettingsState::DEFAULT_BOTFATHER_LOCALPART,
+        );
+        assert!(
+            app_state
+                .bot_settings
+                .bound_bot_user_ids(agent_room_id.as_ref())
+                .is_empty()
+        );
+        assert_eq!(
+            app_state.bot_settings.bound_bot_user_ids(other_room_id.as_ref()),
+            vec![other_bot_id]
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1623,6 +1623,10 @@ impl MatchEvent for App {
                     }
                     continue;
                 }
+                Some(AppStateAction::AgentRegistryUpdated) => {
+                    self.ui.redraw(cx);
+                    continue;
+                }
                 Some(AppStateAction::NavigateToRoom { room_to_close, destination_room }) => {
                     self.navigate_to_room(cx, room_to_close.as_ref(), destination_room);
                     continue;
@@ -3820,6 +3824,10 @@ pub enum AppStateAction {
     KnownBotUserIdsDiscovered {
         bot_user_ids: Vec<OwnedUserId>,
     },
+    /// The global AgentRegistry changed outside the top-level App handler.
+    /// Widgets that derive bot pills from registered-agent identity should
+    /// refresh from the already-mutated AppState.
+    AgentRegistryUpdated,
     /// The given room was successfully loaded from the homeserver
     /// and is now known to our client.
     ///

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -6158,6 +6158,15 @@ impl Widget for RoomScreen {
                     self.close_report_room_modal(cx);
                     self.close_leave_room_confirm_modal(cx);
                 }
+                if let Some(AppStateAction::AgentRegistryUpdated) = action.downcast_ref() {
+                    if room_info_sliding_pane.is_currently_shown(cx) {
+                        self.refresh_room_info_pane(cx, scope.data.get::<AppState>());
+                    }
+                    if matches!(self.active_room_tab, RoomTab::Info) {
+                        self.refresh_inline_room_info(cx, scope.data.get::<AppState>());
+                    }
+                    self.redraw(cx);
+                }
 
                 // Handle actions related to restoring the previously-saved state of rooms.
                 if let Some(AppStateAction::RoomLoadedSuccessfully { room_name_id, ..}) = action.downcast_ref() {

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3080,12 +3080,16 @@ script_mod! {
                 height: Fit
                 flow: Flow.Right{wrap: true}
                 align: Align{y: 0.5}
-                spacing: 6
 
                 display_name := Label {
                     width: Fit
                     height: Fit
                     flow: Flow.Right{wrap: true}
+                    // Gap to the badge lives here (not as container `spacing`)
+                    // so a wrapped bot_badge starts flush at the row's left
+                    // edge instead of inheriting an extra leading offset from
+                    // the wrap-flow container's spacing bookkeeping.
+                    margin: Inset{right: 6}
                     draw_text +: {
                         text_style: RBX_TEXT_BODY_STRONG {}
                         color: (RBX_FG_PRIMARY)
@@ -3280,15 +3284,57 @@ script_mod! {
                                     align: Align{y: 0.5}
                                     spacing: 6
 
-                                    room_name_value := Label {
+                                    // Room name + bot pill live together in a Fill
+                                    // sub-row so the pill trails the (capped,
+                                    // ellipsized) name text directly, the same way
+                                    // the rooms list packs its bot pill snug against
+                                    // the name instead of at the row's far edge.
+                                    // This sub-row keeps the same Fill role that
+                                    // room_name_value used to play here, so
+                                    // favorite_button's pinned-right position is
+                                    // unaffected.
+                                    title_wrap := View {
                                         width: Fill
                                         height: Fit
-                                        flow: Flow.Right{wrap: true}
-                                        draw_text +: {
-                                            text_style: RBX_TEXT_SECTION_TITLE {}
-                                            color: (RBX_FG_PRIMARY)
+                                        flow: Right
+                                        align: Align{y: 0.5}
+                                        spacing: 6
+
+                                        room_name_value := Label {
+                                            width: Fit{max: FitBound.Abs(150.0)}
+                                            height: Fit
+                                            flow: Flow.Right{wrap: false}
+                                            max_lines: 1
+                                            text_overflow: Ellipsis
+                                            draw_text +: {
+                                                text_style: RBX_TEXT_SECTION_TITLE {}
+                                                color: (RBX_FG_PRIMARY)
+                                            }
+                                            text: ""
                                         }
-                                        text: ""
+
+                                        // Bot indicator pill, styled to match the
+                                        // rooms-list / timeline bot pill exactly.
+                                        title_bot_pill := RoundedView {
+                                            visible: false
+                                            width: Fit
+                                            height: 16.0
+                                            align: Align{x: 0.5, y: 0.5}
+                                            padding: Inset{left: 6.0, right: 6.0}
+                                            show_bg: true
+                                            draw_bg +: {
+                                                color: (COLOR_ACTIVE_PRIMARY)
+                                                border_radius: 3.0
+                                            }
+                                            Label {
+                                                width: Fit, height: Fit, padding: 0
+                                                draw_text +: {
+                                                    text_style: REGULAR_TEXT { font_size: 8.5, top_drop: -0.08 }
+                                                    color: #fff
+                                                }
+                                                text: "bot"
+                                            }
+                                        }
                                     }
 
                                     favorite_button := View {
@@ -5345,7 +5391,10 @@ impl Widget for RoomInfoSlidingPane {
         self.view(cx, ids!(people_view)).set_visible(cx, self.show_people_page);
 
         // ----- Hero: name, room id, favourite star -----
-        self.label(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.room_name_value)).set_text(cx, &info.room_name);
+        self.label(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.title_wrap.room_name_value)).set_text(cx, &info.room_name);
+        // Bot pill trailing the room name, mirroring the rooms-list bot pill;
+        // driven by the same is_agent_enabled flag as the Agent-enabled badge below.
+        self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.title_wrap.title_bot_pill)).set_visible(cx, info.is_agent_enabled);
         self.label(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.room_id_row.room_id_value)).set_text(cx, &info.room_id);
         self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.favorite_button.star_outline)).set_visible(cx, !info.is_favorite);
         self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.favorite_button.star_filled)).set_visible(cx, info.is_favorite);
@@ -5993,7 +6042,7 @@ impl Widget for RoomScreen {
                 }
             }
 
-            self.handle_message_actions(cx, actions, &portal_list, &loading_pane);
+            self.handle_message_actions(cx, actions, &portal_list, &loading_pane, scope);
 
             for action in actions {
                 // Mobile RoomTopBar (header + Chat/Info tabs) actions.
@@ -6020,7 +6069,7 @@ impl Widget for RoomScreen {
                                     });
                                 }
                             }
-                            self.refresh_inline_room_info(cx);
+                            self.refresh_inline_room_info(cx, scope.data.get::<AppState>());
                         }
                         self.redraw(cx);
                     }
@@ -6324,7 +6373,7 @@ impl Widget for RoomScreen {
             // (desktop only — the button is hidden on mobile).
             for action in actions {
                 if let InfoButtonAction::OpenRequested = action.as_widget_action().cast_ref() {
-                    self.show_room_info_pane(cx);
+                    self.show_room_info_pane(cx, scope.data.get::<AppState>());
                     break;
                 }
             }
@@ -6385,12 +6434,12 @@ impl Widget for RoomScreen {
                 self.refresh_threads_pane(cx);
             }
             if room_info_sliding_pane.is_currently_shown(cx) {
-                self.refresh_room_info_pane(cx);
+                self.refresh_room_info_pane(cx, scope.data.get::<AppState>());
             }
             // Keep the inline "Info" tab body current as room data (members,
             // topic, etc.) arrives, mirroring the overlay pane above.
             if matches!(self.active_room_tab, RoomTab::Info) {
-                self.refresh_inline_room_info(cx);
+                self.refresh_inline_room_info(cx, scope.data.get::<AppState>());
             }
 
             // Ideally we would do this elsewhere on the main thread, because it's not room-specific,
@@ -8700,6 +8749,7 @@ impl RoomScreen {
         actions: &ActionsBuf,
         portal_list: &PortalListRef,
         loading_pane: &LoadingPaneRef,
+        scope: &mut Scope,
     ) {
         if let Some(clicked_context) = self.octos_action_button_contexts
             .iter()
@@ -9036,7 +9086,7 @@ impl RoomScreen {
                     self.show_threads_pane(cx);
                 }
                 MessageAction::ShowRoomInfoPane => {
-                    self.show_room_info_pane(cx);
+                    self.show_room_info_pane(cx, scope.data.get::<AppState>());
                 }
                 MessageAction::ToggleTranslationLangPopup { button_rect } => {
                     self.toggle_translation_lang_popup(cx, *button_rect);
@@ -9547,7 +9597,12 @@ impl RoomScreen {
     /// Build the room-info payload from current state, or `None` if no room is
     /// displayed. Shared by both the sliding info pane and the inline "Info"
     /// tab body so the two presentations stay in sync.
-    fn build_room_info_pane_info(&mut self) -> Option<RoomInfoPaneInfo> {
+    ///
+    /// `app_state`, when available, makes the member list's "Bot" marker
+    /// registry-aware (AgentRegistry ∪ app-service known bots), mirroring the
+    /// timeline. Callers without a reachable `AppState` (no `Scope` in hand)
+    /// pass `None`, which falls back to the name-only heuristic.
+    fn build_room_info_pane_info(&mut self, app_state: Option<&AppState>) -> Option<RoomInfoPaneInfo> {
         let room_id = self.room_id().cloned()?;
         let room_name = self.room_name_id.as_ref()
             .map(ToString::to_string)
@@ -9620,6 +9675,23 @@ impl RoomScreen {
                             _ => 3,
                         }
                     };
+
+                    // Registry-aware bot detection, mirroring the timeline's
+                    // `is_timeline_sender_bot`: the union of the AgentRegistry
+                    // and (app-service-gated) known-bot list, plus the
+                    // resolved parent BotFather MXID. Computed once here
+                    // (not per member) since it's the same for every entry.
+                    let known_bot_user_ids = app_state
+                        .map(timeline_known_bot_user_ids)
+                        .unwrap_or_default();
+                    let resolved_parent_bot_user_id = app_state.and_then(|s| {
+                        if s.bot_settings.enabled {
+                            s.bot_settings.resolved_bot_user_id(my_user_id.as_deref()).ok()
+                        } else {
+                            None
+                        }
+                    });
+
                     // Build with a precomputed (role-weight, lowercased-name) sort
                     // key so sorting doesn't allocate a String per comparison.
                     let mut keyed: Vec<(u8, String, RoomInfoPeopleEntryInfo)> = members.iter()
@@ -9627,7 +9699,11 @@ impl RoomScreen {
                             let display_name = member.display_name()
                                 .map(ToOwned::to_owned)
                                 .unwrap_or_else(|| member.user_id().to_string());
-                            let is_bot = is_likely_bot_member(member, None);
+                            let is_bot = is_known_or_likely_bot(
+                                    member.user_id(),
+                                    resolved_parent_bot_user_id.as_deref(),
+                                    &known_bot_user_ids,
+                                ) || is_likely_bot_member(member, resolved_parent_bot_user_id.as_deref());
                             let level = match member.suggested_role_for_power_level() {
                                 RoomMemberRole::Creator => String::from("Creator"),
                                 RoomMemberRole::Administrator => String::from("Admin"),
@@ -9711,23 +9787,23 @@ impl RoomScreen {
         })
     }
 
-    fn refresh_room_info_pane(&mut self, cx: &mut Cx) {
-        if let Some(info) = self.build_room_info_pane_info() {
+    fn refresh_room_info_pane(&mut self, cx: &mut Cx, app_state: Option<&AppState>) {
+        if let Some(info) = self.build_room_info_pane_info(app_state) {
             self.room_info_sliding_pane(cx, ids!(room_info_sliding_pane)).set_info(cx, info);
         }
     }
 
     /// Populate the inline "Info" tab body (a second `RoomInfoSlidingPane`
     /// instance mounted inline inside `keyboard_view`).
-    fn refresh_inline_room_info(&mut self, cx: &mut Cx) {
-        if let Some(info) = self.build_room_info_pane_info() {
+    fn refresh_inline_room_info(&mut self, cx: &mut Cx, app_state: Option<&AppState>) {
+        if let Some(info) = self.build_room_info_pane_info(app_state) {
             self.room_info_sliding_pane(cx, ids!(info_content)).set_info(cx, info);
         }
     }
 
-    fn show_room_info_pane(&mut self, cx: &mut Cx) {
+    fn show_room_info_pane(&mut self, cx: &mut Cx, app_state: Option<&AppState>) {
         self.hide_threads_pane(cx);
-        self.refresh_room_info_pane(cx);
+        self.refresh_room_info_pane(cx, app_state);
         self.room_info_sliding_pane(cx, ids!(room_info_sliding_pane)).show(cx);
         self.redraw(cx);
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -8393,6 +8393,18 @@ impl RoomScreen {
                     });
                 }
                 TimelineUpdate::RoomMembersListFetched { members } => {
+                    if let TimelineKind::MainRoom { room_id } = &tl.kind {
+                        let member_user_ids = members
+                            .iter()
+                            .map(|member| member.user_id().to_owned())
+                            .collect();
+                        crate::home::rooms_list::enqueue_rooms_list_update(
+                            crate::home::rooms_list::RoomsListUpdate::UpdateRoomMemberUserIds {
+                                room_id: room_id.clone(),
+                                member_user_ids,
+                            }
+                        );
+                    }
                     let members = Arc::new(members);
                     if tl.awaiting_post_sync_member_refresh {
                         tl.room_members_sync_pending = false;
@@ -14310,6 +14322,15 @@ mod tests {
             after.resolved_parent_bot_user_id.as_deref(),
             &after.known_bot_user_ids,
         ));
+    }
+
+    #[test]
+    fn test_room_members_fetch_updates_rooms_list_member_ids() {
+        let src = include_str!("room_screen.rs");
+
+        assert!(src.contains("TimelineUpdate::RoomMembersListFetched"));
+        assert!(src.contains("RoomsListUpdate::UpdateRoomMemberUserIds"));
+        assert!(src.contains("member.user_id().to_owned()"));
     }
 
     #[test]

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3301,7 +3301,7 @@ script_mod! {
                                         spacing: 6
 
                                         room_name_value := Label {
-                                            width: Fit{max: FitBound.Abs(150.0)}
+                                            width: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.82}}
                                             height: Fit
                                             flow: Flow.Right{wrap: false}
                                             max_lines: 1
@@ -3322,6 +3322,7 @@ script_mod! {
                                             align: Align{x: 0.5, y: 0.5}
                                             padding: Inset{left: 6.0, right: 6.0}
                                             show_bg: true
+                                            new_batch: true
                                             draw_bg +: {
                                                 color: (COLOR_ACTIVE_PRIMARY)
                                                 border_radius: 3.0
@@ -3330,7 +3331,7 @@ script_mod! {
                                                 width: Fit, height: Fit, padding: 0
                                                 draw_text +: {
                                                     text_style: REGULAR_TEXT { font_size: 8.5, top_drop: -0.08 }
-                                                    color: #fff
+                                                    color: (RBX_FG_ON_ACCENT)
                                                 }
                                                 text: "bot"
                                             }
@@ -4727,17 +4728,51 @@ struct RoomInfoPaneInfo {
     show_people_loading: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RoomInfoBotIdentityFingerprint {
+    resolved_parent_bot_user_id: Option<OwnedUserId>,
+    known_bot_user_ids: Vec<OwnedUserId>,
+}
+
+fn room_info_bot_identity_fingerprint(
+    app_state: Option<&AppState>,
+    my_user_id: Option<&UserId>,
+) -> RoomInfoBotIdentityFingerprint {
+    app_state
+        .map(|app_state| {
+            let resolved_parent_bot_user_id = if app_state.bot_settings.enabled {
+                app_state
+                    .bot_settings
+                    .resolved_bot_user_id(my_user_id)
+                    .ok()
+            } else {
+                None
+            };
+            RoomInfoBotIdentityFingerprint {
+                resolved_parent_bot_user_id,
+                known_bot_user_ids: timeline_known_bot_user_ids(app_state),
+            }
+        })
+        .unwrap_or(RoomInfoBotIdentityFingerprint {
+            resolved_parent_bot_user_id: None,
+            known_bot_user_ids: Vec::new(),
+        })
+}
+
 /// Cache for the expensive member-row build. Keyed by the room and the identity
 /// (`Arc` pointer) of `TimelineUiState::room_members`, which is replaced wholesale
 /// whenever the member list changes — so a pointer match means "members unchanged,
 /// reuse the prebuilt rows" and we skip rebuilding + re-sorting all members on
-/// every sync Signal (critical for very large rooms).
+/// every sync Signal (critical for very large rooms). Bot identity context is part
+/// of the key because registry / app-service updates can change row bot markers
+/// without changing the room member list.
 struct RoomInfoMembersCache {
     room_id: OwnedRoomId,
     /// The exact `room_members` `Arc` the cached rows were built from. Held so the
     /// allocation can't be freed and its address reused (an ABA false-hit), and so
     /// validity is a cheap `Arc::ptr_eq` against the current `room_members`.
     members: Arc<Vec<RoomMember>>,
+    bot_identity: RoomInfoBotIdentityFingerprint,
     entries: Arc<Vec<RoomInfoPeopleEntryInfo>>,
     is_agent_enabled: bool,
     my_role: String,
@@ -9645,6 +9680,7 @@ impl RoomScreen {
             ));
 
         let my_user_id = current_user_id();
+        let bot_identity = room_info_bot_identity_fingerprint(app_state, my_user_id.as_deref());
         // Clone the members `Arc` out first (cheap) so the `tl_state` borrow is
         // released before we (mutably) touch the cache below.
         let members_arc = self.tl_state.as_ref().and_then(|tl| tl.room_members.clone());
@@ -9652,7 +9688,9 @@ impl RoomScreen {
         let (people_entries, show_people_loading, member_count, is_agent_enabled, my_role) =
             if let Some(members) = members_arc {
                 let cache_valid = self.room_info_members_cache.as_ref().is_some_and(|c|
-                    c.room_id == room_id && Arc::ptr_eq(&c.members, &members)
+                    c.room_id == room_id
+                        && Arc::ptr_eq(&c.members, &members)
+                        && c.bot_identity == bot_identity
                 );
                 if !cache_valid {
                     // Expensive path — only when the member list actually changed.
@@ -9681,16 +9719,9 @@ impl RoomScreen {
                     // and (app-service-gated) known-bot list, plus the
                     // resolved parent BotFather MXID. Computed once here
                     // (not per member) since it's the same for every entry.
-                    let known_bot_user_ids = app_state
-                        .map(timeline_known_bot_user_ids)
-                        .unwrap_or_default();
-                    let resolved_parent_bot_user_id = app_state.and_then(|s| {
-                        if s.bot_settings.enabled {
-                            s.bot_settings.resolved_bot_user_id(my_user_id.as_deref()).ok()
-                        } else {
-                            None
-                        }
-                    });
+                    let known_bot_user_ids = &bot_identity.known_bot_user_ids;
+                    let resolved_parent_bot_user_id =
+                        bot_identity.resolved_parent_bot_user_id.as_deref();
 
                     // Build with a precomputed (role-weight, lowercased-name) sort
                     // key so sorting doesn't allocate a String per comparison.
@@ -9701,9 +9732,9 @@ impl RoomScreen {
                                 .unwrap_or_else(|| member.user_id().to_string());
                             let is_bot = is_known_or_likely_bot(
                                     member.user_id(),
-                                    resolved_parent_bot_user_id.as_deref(),
-                                    &known_bot_user_ids,
-                                ) || is_likely_bot_member(member, resolved_parent_bot_user_id.as_deref());
+                                    resolved_parent_bot_user_id,
+                                    known_bot_user_ids,
+                                ) || is_likely_bot_member(member, resolved_parent_bot_user_id);
                             let level = match member.suggested_role_for_power_level() {
                                 RoomMemberRole::Creator => String::from("Creator"),
                                 RoomMemberRole::Administrator => String::from("Admin"),
@@ -9736,6 +9767,7 @@ impl RoomScreen {
                     self.room_info_members_cache = Some(RoomInfoMembersCache {
                         room_id: room_id.clone(),
                         members: Arc::clone(&members),
+                        bot_identity: bot_identity.clone(),
                         entries,
                         is_agent_enabled,
                         my_role,
@@ -14124,6 +14156,46 @@ mod tests {
         let known_bot_user_ids = room_props_known_bot_user_ids(&app_state);
 
         assert!(known_bot_user_ids.iter().any(|id| id == &agent_id));
+    }
+
+    #[test]
+    fn test_room_info_bot_identity_fingerprint_tracks_registry_agents() {
+        let agent_id: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        let before = room_info_bot_identity_fingerprint(Some(&app_state), None);
+
+        app_state
+            .agent_registry
+            .register(agent_id.clone(), crate::app::AgentEntry::default());
+        let after = room_info_bot_identity_fingerprint(Some(&app_state), None);
+
+        assert_ne!(before, after);
+        assert!(after.known_bot_user_ids.iter().any(|id| id == &agent_id));
+    }
+
+    #[test]
+    fn test_room_info_bot_identity_fingerprint_tracks_appservice_known_bots() {
+        let current_user_id: OwnedUserId = "@alice:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state.bot_settings.enabled = true;
+        let bot_id = app_state
+            .bot_settings
+            .resolved_bot_user_id(Some(current_user_id.as_ref()))
+            .unwrap();
+        let before = room_info_bot_identity_fingerprint(
+            Some(&app_state),
+            Some(current_user_id.as_ref()),
+        );
+
+        app_state.bot_settings.record_known_bot_user_ids([bot_id.clone()]);
+        let after = room_info_bot_identity_fingerprint(
+            Some(&app_state),
+            Some(current_user_id.as_ref()),
+        );
+
+        assert_ne!(before, after);
+        assert_eq!(after.resolved_parent_bot_user_id.as_ref(), Some(&bot_id));
+        assert!(after.known_bot_user_ids.iter().any(|id| id == &bot_id));
     }
 
     #[test]

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -14271,6 +14271,48 @@ mod tests {
     }
 
     #[test]
+    fn test_room_info_bot_marker_hidden_after_agentlab_unbind() {
+        let current_user_id: OwnedUserId = "@alice:example.org".try_into().unwrap();
+        let agent_id: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent_id.clone(), crate::app::AgentEntry {
+            framework: crate::app::AgentFramework::Octos,
+            ..Default::default()
+        });
+        app_state.bot_settings.enabled = true;
+        app_state.bot_settings.botfather_user_id = agent_id.to_string();
+        app_state.bot_settings.record_known_bot_user_ids([agent_id.clone()]);
+
+        let before = room_info_bot_identity_fingerprint(
+            Some(&app_state),
+            Some(current_user_id.as_ref()),
+        );
+        assert!(is_known_or_likely_bot(
+            agent_id.as_ref(),
+            before.resolved_parent_bot_user_id.as_deref(),
+            &before.known_bot_user_ids,
+        ));
+
+        app_state.unregister_agent_and_clear_bot_identity(
+            agent_id.as_ref(),
+            Some(current_user_id.as_ref()),
+        );
+        let after = room_info_bot_identity_fingerprint(
+            Some(&app_state),
+            Some(current_user_id.as_ref()),
+        );
+
+        assert!(after.resolved_parent_bot_user_id.is_none());
+        assert!(after.known_bot_user_ids.is_empty());
+        assert!(!is_known_or_likely_bot(
+            agent_id.as_ref(),
+            after.resolved_parent_bot_user_id.as_deref(),
+            &after.known_bot_user_ids,
+        ));
+    }
+
+    #[test]
     fn test_room_info_title_bot_pill_hidden_after_room_unbound() {
         let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
         let bot_id: OwnedUserId = "@bot:example.org".try_into().unwrap();
@@ -14308,6 +14350,33 @@ mod tests {
             room_id.as_ref(),
             Some(agent_id.as_ref()),
         ));
+    }
+
+    #[test]
+    fn test_room_info_title_bot_pill_hidden_after_agentlab_unbind_clears_binding() {
+        let current_user_id: OwnedUserId = "@alice:example.org".try_into().unwrap();
+        let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
+        let agent_id: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent_id.clone(), crate::app::AgentEntry {
+            framework: crate::app::AgentFramework::Octos,
+            ..Default::default()
+        });
+        app_state.bot_settings.enabled = true;
+        app_state.bot_settings.botfather_user_id = agent_id.to_string();
+        app_state.bot_settings.record_known_bot_user_ids([agent_id.clone()]);
+        app_state
+            .bot_settings
+            .set_room_bound(room_id.clone(), Some(agent_id.clone()), true);
+        assert!(room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+
+        app_state.unregister_agent_and_clear_bot_identity(
+            agent_id.as_ref(),
+            Some(current_user_id.as_ref()),
+        );
+
+        assert!(!room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
     }
 
     #[test]

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 use crate::home::event_reaction_list::ReactionListWidgetRefExt;
 use crate::home::room_read_receipt::AvatarRowWidgetRefExt;
+use crate::home::rooms_list_entry::room_shows_agent_badge;
 use crate::home::search_messages::{
     MessageSearchHit, SearchMessagesAction, SearchMessagesButtonWidgetExt,
     SearchMessagesSlidingPaneRef, SearchMessagesSlidingPaneWidgetExt,
@@ -4763,14 +4764,16 @@ fn room_info_bot_identity_fingerprint(
         })
 }
 
-fn room_info_title_shows_agent_badge(
+/// Delegates to the rooms-list predicate (`room_shows_agent_badge`) so the
+/// Info-pane title pill and the rooms-list row pill always agree.
+fn room_info_title_shows_agent_badge<'a>(
     app_state: Option<&AppState>,
     room_id: &RoomId,
     dm_target: Option<&UserId>,
+    member_user_ids: impl IntoIterator<Item = &'a UserId>,
 ) -> bool {
     app_state.is_some_and(|app_state|
-        app_state.bot_settings.is_room_bound(room_id)
-            || dm_target.is_some_and(|user_id| app_state.agent_registry.contains(user_id))
+        room_shows_agent_badge(app_state, room_id, dm_target, member_user_ids)
     )
 }
 
@@ -9754,6 +9757,9 @@ impl RoomScreen {
             app_state,
             room_id.as_ref(),
             room_info_dm_target.as_deref(),
+            members_arc.iter()
+                .flat_map(|members| members.iter())
+                .map(|member| member.user_id()),
         );
 
         let (people_entries, show_people_loading, member_count, is_agent_enabled, my_role) =
@@ -14342,12 +14348,35 @@ mod tests {
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(bot_id.clone()), true);
-        assert!(room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+        assert!(room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, std::iter::empty(),
+        ));
 
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(bot_id), false);
-        assert!(!room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+        assert!(!room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, std::iter::empty(),
+        ));
+    }
+
+    #[test]
+    fn test_room_info_title_bot_pill_shown_when_member_is_registered_agent() {
+        let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
+        let agent_id: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state
+            .agent_registry
+            .register(agent_id.clone(), crate::app::AgentEntry::default());
+        assert!(room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, [agent_id.as_ref()],
+        ));
+
+        app_state.agent_registry.unregister(agent_id.as_ref());
+        assert!(!room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, [agent_id.as_ref()],
+        ));
     }
 
     #[test]
@@ -14363,6 +14392,7 @@ mod tests {
             Some(&app_state),
             room_id.as_ref(),
             Some(agent_id.as_ref()),
+            std::iter::empty(),
         ));
 
         app_state.agent_registry.unregister(agent_id.as_ref());
@@ -14370,6 +14400,7 @@ mod tests {
             Some(&app_state),
             room_id.as_ref(),
             Some(agent_id.as_ref()),
+            std::iter::empty(),
         ));
     }
 
@@ -14390,14 +14421,18 @@ mod tests {
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(agent_id.clone()), true);
-        assert!(room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+        assert!(room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, std::iter::empty(),
+        ));
 
         app_state.unregister_agent_and_clear_bot_identity(
             agent_id.as_ref(),
             Some(current_user_id.as_ref()),
         );
 
-        assert!(!room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+        assert!(!room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, std::iter::empty(),
+        ));
     }
 
     #[test]
@@ -14405,9 +14440,13 @@ mod tests {
         let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
         let bot_id: OwnedUserId = "@bot:example.org".try_into().unwrap();
         let mut app_state = AppState::default();
-        app_state.bot_settings.record_known_bot_user_ids([bot_id]);
+        app_state.bot_settings.record_known_bot_user_ids([bot_id.clone()]);
 
-        assert!(!room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+        // A known bot that is neither bound, a DM target, nor a registered-agent
+        // member must not trigger the pill — even when it is a room member.
+        assert!(!room_info_title_shows_agent_badge(
+            Some(&app_state), room_id.as_ref(), None, [bot_id.as_ref()],
+        ));
     }
 
     #[test]

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -9,7 +9,7 @@ use imbl::Vector;
 use makepad_widgets::{image_cache::ImageBuffer, *};
 use matrix_sdk::{
     OwnedServerName, media::{MediaFormat, MediaRequestParameters}, room::{RoomMember, RoomMemberRole}, ruma::{
-        EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, UserId, events::{
+        EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, RoomId, UserId, events::{
             receipt::Receipt,
             room::{
                 ImageInfo, MediaSource, message::{
@@ -4714,6 +4714,10 @@ struct RoomInfoPaneInfo {
     /// Whether this room has a bot/agent participating (any member detected as a
     /// bot via `is_likely_bot_member`).
     is_agent_enabled: bool,
+    /// Whether the compact "bot" pill should trail the room title. This follows
+    /// the same user-facing badge semantics as the rooms list: room binding or a
+    /// registered-agent DM, not merely a bot-looking member in an unbound room.
+    show_title_bot_pill: bool,
     member_count: usize,
     /// The current user's role in this room: "Owner" / "Admin" / "Moderator" /
     /// "Member", or empty if members haven't loaded yet.
@@ -4757,6 +4761,34 @@ fn room_info_bot_identity_fingerprint(
             resolved_parent_bot_user_id: None,
             known_bot_user_ids: Vec::new(),
         })
+}
+
+fn room_info_title_shows_agent_badge(
+    app_state: Option<&AppState>,
+    room_id: &RoomId,
+    dm_target: Option<&UserId>,
+) -> bool {
+    app_state.is_some_and(|app_state|
+        app_state.bot_settings.is_room_bound(room_id)
+            || dm_target.is_some_and(|user_id| app_state.agent_registry.contains(user_id))
+    )
+}
+
+fn room_info_dm_target_from_user_ids<'a>(
+    user_ids: impl IntoIterator<Item = &'a UserId>,
+    my_user_id: Option<&UserId>,
+) -> Option<OwnedUserId> {
+    let mut dm_target = None;
+    for user_id in user_ids {
+        if my_user_id.is_some_and(|my_user_id| my_user_id == user_id) {
+            continue;
+        }
+        if dm_target.is_some() {
+            return None;
+        }
+        dm_target = Some(user_id.to_owned());
+    }
+    dm_target
 }
 
 /// Cache for the expensive member-row build. Keyed by the room and the identity
@@ -5427,9 +5459,8 @@ impl Widget for RoomInfoSlidingPane {
 
         // ----- Hero: name, room id, favourite star -----
         self.label(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.title_wrap.room_name_value)).set_text(cx, &info.room_name);
-        // Bot pill trailing the room name, mirroring the rooms-list bot pill;
-        // driven by the same is_agent_enabled flag as the Agent-enabled badge below.
-        self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.title_wrap.title_bot_pill)).set_visible(cx, info.is_agent_enabled);
+        // Bot pill trailing the room name, mirroring the rooms-list bot pill.
+        self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.title_wrap.title_bot_pill)).set_visible(cx, info.show_title_bot_pill);
         self.label(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.room_id_row.room_id_value)).set_text(cx, &info.room_id);
         self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.favorite_button.star_outline)).set_visible(cx, !info.is_favorite);
         self.view(cx, ids!(content_scroll.info_view.summary_card.hero_row.room_meta.name_row.favorite_button.star_filled)).set_visible(cx, info.is_favorite);
@@ -9637,7 +9668,11 @@ impl RoomScreen {
     /// registry-aware (AgentRegistry ∪ app-service known bots), mirroring the
     /// timeline. Callers without a reachable `AppState` (no `Scope` in hand)
     /// pass `None`, which falls back to the name-only heuristic.
-    fn build_room_info_pane_info(&mut self, app_state: Option<&AppState>) -> Option<RoomInfoPaneInfo> {
+    fn build_room_info_pane_info(
+        &mut self,
+        app_state: Option<&AppState>,
+        is_direct_room: bool,
+    ) -> Option<RoomInfoPaneInfo> {
         let room_id = self.room_id().cloned()?;
         let room_name = self.room_name_id.as_ref()
             .map(ToString::to_string)
@@ -9684,6 +9719,21 @@ impl RoomScreen {
         // Clone the members `Arc` out first (cheap) so the `tl_state` borrow is
         // released before we (mutably) touch the cache below.
         let members_arc = self.tl_state.as_ref().and_then(|tl| tl.room_members.clone());
+        let room_info_dm_target = if is_direct_room {
+            members_arc.as_ref().and_then(|members|
+                room_info_dm_target_from_user_ids(
+                    members.iter().map(|member| member.user_id()),
+                    my_user_id.as_deref(),
+                )
+            )
+        } else {
+            None
+        };
+        let show_title_bot_pill = room_info_title_shows_agent_badge(
+            app_state,
+            room_id.as_ref(),
+            room_info_dm_target.as_deref(),
+        );
 
         let (people_entries, show_people_loading, member_count, is_agent_enabled, my_role) =
             if let Some(members) = members_arc {
@@ -9809,6 +9859,7 @@ impl RoomScreen {
             is_encrypted,
             is_favorite,
             is_agent_enabled,
+            show_title_bot_pill,
             member_count,
             my_role,
             room_avatar_uri,
@@ -9820,7 +9871,8 @@ impl RoomScreen {
     }
 
     fn refresh_room_info_pane(&mut self, cx: &mut Cx, app_state: Option<&AppState>) {
-        if let Some(info) = self.build_room_info_pane_info(app_state) {
+        let is_direct_room = self.current_room_is_direct(cx);
+        if let Some(info) = self.build_room_info_pane_info(app_state, is_direct_room) {
             self.room_info_sliding_pane(cx, ids!(room_info_sliding_pane)).set_info(cx, info);
         }
     }
@@ -9828,9 +9880,20 @@ impl RoomScreen {
     /// Populate the inline "Info" tab body (a second `RoomInfoSlidingPane`
     /// instance mounted inline inside `keyboard_view`).
     fn refresh_inline_room_info(&mut self, cx: &mut Cx, app_state: Option<&AppState>) {
-        if let Some(info) = self.build_room_info_pane_info(app_state) {
+        let is_direct_room = self.current_room_is_direct(cx);
+        if let Some(info) = self.build_room_info_pane_info(app_state, is_direct_room) {
             self.room_info_sliding_pane(cx, ids!(info_content)).set_info(cx, info);
         }
+    }
+
+    fn current_room_is_direct(&self, cx: &mut Cx) -> bool {
+        let Some(room_id) = self.room_id() else { return false };
+        if !cx.has_global::<RoomsListRef>() {
+            return false;
+        }
+        cx.get_global::<RoomsListRef>()
+            .is_direct_room(room_id)
+            .unwrap_or(false)
     }
 
     fn show_room_info_pane(&mut self, cx: &mut Cx, app_state: Option<&AppState>) {
@@ -14196,6 +14259,78 @@ mod tests {
         assert_ne!(before, after);
         assert_eq!(after.resolved_parent_bot_user_id.as_ref(), Some(&bot_id));
         assert!(after.known_bot_user_ids.iter().any(|id| id == &bot_id));
+    }
+
+    #[test]
+    fn test_room_info_title_bot_pill_hidden_after_room_unbound() {
+        let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
+        let bot_id: OwnedUserId = "@bot:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state
+            .bot_settings
+            .set_room_bound(room_id.clone(), Some(bot_id.clone()), true);
+        assert!(room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+
+        app_state
+            .bot_settings
+            .set_room_bound(room_id.clone(), Some(bot_id), false);
+        assert!(!room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+    }
+
+    #[test]
+    fn test_room_info_title_bot_pill_hidden_after_agent_registry_unbind() {
+        let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
+        let agent_id: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state
+            .agent_registry
+            .register(agent_id.clone(), crate::app::AgentEntry::default());
+        assert!(room_info_title_shows_agent_badge(
+            Some(&app_state),
+            room_id.as_ref(),
+            Some(agent_id.as_ref()),
+        ));
+
+        app_state.agent_registry.unregister(agent_id.as_ref());
+        assert!(!room_info_title_shows_agent_badge(
+            Some(&app_state),
+            room_id.as_ref(),
+            Some(agent_id.as_ref()),
+        ));
+    }
+
+    #[test]
+    fn test_room_info_title_bot_pill_ignores_known_bot_without_binding_or_agent_dm() {
+        let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
+        let bot_id: OwnedUserId = "@bot:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state.bot_settings.record_known_bot_user_ids([bot_id]);
+
+        assert!(!room_info_title_shows_agent_badge(Some(&app_state), room_id.as_ref(), None));
+    }
+
+    #[test]
+    fn test_room_info_dm_target_requires_single_non_self_member() {
+        let me: OwnedUserId = "@me:example.org".try_into().unwrap();
+        let agent_id: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let human_id: OwnedUserId = "@human:example.org".try_into().unwrap();
+
+        assert_eq!(
+            room_info_dm_target_from_user_ids(
+                [me.as_ref(), agent_id.as_ref()],
+                Some(me.as_ref()),
+            ),
+            Some(agent_id.clone()),
+        );
+        assert_eq!(
+            room_info_dm_target_from_user_ids(
+                [me.as_ref(), agent_id.as_ref(), human_id.as_ref()],
+                Some(me.as_ref()),
+            ),
+            None,
+        );
     }
 
     #[test]

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -320,6 +320,9 @@ pub struct JoinedRoomInfo {
     pub is_selected: bool,
     /// Whether this a direct room.
     pub is_direct: bool,
+    /// The DM counterparty's MXID when this is a 1:1 direct room, else `None`.
+    /// Used to decide whether to show an agent badge (see `room_shows_agent_badge`).
+    pub dm_target: Option<OwnedUserId>,
     /// Whether this room is end-to-end encrypted.
     ///
     /// `None` means the encryption state is not known yet or failed to load.
@@ -652,6 +655,7 @@ impl RoomsList {
                     has_been_paginated: false,
                     is_selected: false,
                     is_direct: false,
+                    dm_target: None,
                     is_encrypted: None,
                     is_tombstoned: false,
                 });
@@ -876,6 +880,9 @@ impl RoomsList {
 
                         // Update the room. If it should be displayed, add it to the proper list.
                         room.is_direct = is_direct;
+                        if !is_direct {
+                            room.dm_target = None;
+                        }
                         let has_favorite_tag = room.tags.contains_key(&TagName::Favorite);
                         let has_low_priority_tag = room.tags.contains_key(&TagName::LowPriority);
                         if should_display_room!(self, &room_id, room) {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -190,6 +190,11 @@ pub enum RoomsListUpdate {
         room_id: OwnedRoomId,
         is_direct: bool,
     },
+    /// Update the active member MXIDs known for the given room.
+    UpdateRoomMemberUserIds {
+        room_id: OwnedRoomId,
+        member_user_ids: Vec<OwnedUserId>,
+    },
     /// Update whether the given room is end-to-end encrypted.
     UpdateIsEncrypted {
         room_id: OwnedRoomId,
@@ -323,6 +328,9 @@ pub struct JoinedRoomInfo {
     /// The DM counterparty's MXID when this is a 1:1 direct room, else `None`.
     /// Used to decide whether to show an agent badge (see `room_shows_agent_badge`).
     pub dm_target: Option<OwnedUserId>,
+    /// Active room members known from RoomScreen member fetches.
+    /// Used for non-DM room agent badges.
+    pub member_user_ids: Vec<OwnedUserId>,
     /// Whether this room is end-to-end encrypted.
     ///
     /// `None` means the encryption state is not known yet or failed to load.
@@ -656,6 +664,7 @@ impl RoomsList {
                     is_selected: false,
                     is_direct: false,
                     dm_target: None,
+                    member_user_ids: Vec::new(),
                     is_encrypted: None,
                     is_tombstoned: false,
                 });
@@ -898,6 +907,14 @@ impl RoomsList {
                         }
                     } else {
                         error!("Error: couldn't find room {room_id} to update is_direct");
+                    }
+                }
+                RoomsListUpdate::UpdateRoomMemberUserIds { room_id, member_user_ids } => {
+                    if let Some(room) = self.all_joined_rooms.get_mut(&room_id) {
+                        room.member_user_ids = member_user_ids;
+                        self.redraw(cx);
+                    } else {
+                        warning!("Warning: couldn't find room {room_id} to update room member user IDs");
                     }
                 }
                 RoomsListUpdate::UpdateIsEncrypted { room_id, is_encrypted } => {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1656,6 +1656,11 @@ impl Widget for RoomsList {
                     continue;
                 }
 
+                if let Some(AppStateAction::AgentRegistryUpdated) = action.downcast_ref() {
+                    self.redraw(cx);
+                    continue;
+                }
+
                 // Clear widget state upon logout.
                 if let Some(LogoutAction::ClearAppState { .. }) = action.downcast_ref() {
                     while PENDING_ROOM_UPDATES.pop().is_some() {}

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -573,32 +573,43 @@ impl RoomsListEntryContent {
         // Toggle the background color via the animator (handles selected/deselected bg).
         self.animator_toggle(cx, is_selected, Animate::No, ids!(selected.on), ids!(selected.off));
 
+        // NOTE: not every adaptive variant contains all of these widgets (e.g.
+        // `IconAndName` has no timestamp/message preview, `OnlyIcon` has no room
+        // name), and `script_apply_eval!` on an empty WidgetRef logs script-VM
+        // errors ("__script_source__ not found"), so guard each apply.
+
         // Update text colors for room name.
         let mut room_name_label = self.view.label(cx, ids!(room_name));
-        script_apply_eval!(cx, room_name_label, {
-            draw_text +: {
-                color: #(room_name_color)
-            }
-        });
+        if !room_name_label.is_empty() {
+            script_apply_eval!(cx, room_name_label, {
+                draw_text +: {
+                    color: #(room_name_color)
+                }
+            });
+        }
 
         // Update text colors for timestamp.
         let mut timestamp_label = self.view.label(cx, ids!(timestamp));
-        script_apply_eval!(cx, timestamp_label, {
-            draw_text +: {
-                color: #(timestamp_color)
-            }
-        });
+        if !timestamp_label.is_empty() {
+            script_apply_eval!(cx, timestamp_label, {
+                draw_text +: {
+                    color: #(timestamp_color)
+                }
+            });
+        }
 
         // Update text colors for the latest message preview (both HTML and plaintext variants).
         let mut html_widget = self.view.html(cx, ids!(latest_message.html_view.html));
-        script_apply_eval!(cx, html_widget, {
-            font_color: #(message_text_color),
-            draw_text +: { color: #(message_text_color) },
-            draw_block +: {
-                quote_bg_color: #(code_bg_color),
-                code_color: #(code_bg_color),
-            }
-        });
+        if !html_widget.is_empty() {
+            script_apply_eval!(cx, html_widget, {
+                font_color: #(message_text_color),
+                draw_text +: { color: #(message_text_color) },
+                draw_block +: {
+                    quote_bg_color: #(code_bg_color),
+                    code_color: #(code_bg_color),
+                }
+            });
+        }
 
         // Both states sit on a light surface (transparent / soft-teal wash), so
         // use the design-token link color in both cases for a consistent look.
@@ -607,11 +618,13 @@ impl RoomsListEntryContent {
             .set_link_color(cx, Some(crate::shared::design_tokens::RBX_LINK));
 
         let mut pt_label = self.view.label(cx, ids!(latest_message.plaintext_view.pt_label));
-        script_apply_eval!(cx, pt_label, {
-            draw_text +: {
-                color: #(message_text_color)
-            }
-        });
+        if !pt_label.is_empty() {
+            script_apply_eval!(cx, pt_label, {
+                draw_text +: {
+                    color: #(message_text_color)
+                }
+            });
+        }
     }
 }
 

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -1,5 +1,5 @@
 use makepad_widgets::*;
-use matrix_sdk::ruma::{OwnedRoomId, RoomId, UserId};
+use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId, RoomId, UserId};
 
 use crate::{
     app::AppState,
@@ -431,6 +431,7 @@ impl Widget for RoomsListEntryContent {
                     app_state,
                     joined_room_info.room_name_id.room_id(),
                     joined_room_info.dm_target.as_deref(),
+                    &joined_room_info.member_user_ids,
                 )
             });
             self.draw_joined_room(cx, joined_room_info, show_agent_badge);
@@ -647,9 +648,13 @@ pub fn room_shows_agent_badge(
     app_state: &AppState,
     room_id: &RoomId,
     dm_target: Option<&UserId>,
+    member_user_ids: &[OwnedUserId],
 ) -> bool {
     app_state.bot_settings.is_room_bound(room_id)
         || dm_target.is_some_and(|user_id| app_state.agent_registry.contains(user_id))
+        || member_user_ids
+            .iter()
+            .any(|user_id| app_state.agent_registry.contains(user_id.as_ref()))
 }
 
 #[cfg(test)]
@@ -691,7 +696,7 @@ mod tests {
             bot_user_id: "@bot:example.org".try_into().unwrap(),
             remark: String::new(),
         });
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
     }
 
     #[test]
@@ -700,7 +705,7 @@ mod tests {
         let agent: OwnedUserId = "@agent:example.org".try_into().unwrap();
         let mut app_state = AppState::default();
         app_state.agent_registry.register(agent.clone(), AgentEntry::default());
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
     }
 
     #[test]
@@ -708,21 +713,37 @@ mod tests {
         let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
         let human: OwnedUserId = "@human:example.org".try_into().unwrap();
         let app_state = AppState::default();
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(human.as_ref())));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(human.as_ref()), &[]));
     }
 
     #[test]
     fn test_agent_badge_hidden_for_unbound_group_room() {
         let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
         let app_state = AppState::default();
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+    }
+
+    #[test]
+    fn test_agent_badge_shown_when_room_member_is_registered_agent() {
+        let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
+        let agent: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent.clone(), AgentEntry::default());
+
+        assert!(room_shows_agent_badge(
+            &app_state,
+            room_id.as_ref(),
+            None,
+            &[agent],
+        ));
     }
 
     #[test]
     fn test_agent_badge_hidden_when_dm_target_none() {
         let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
         let app_state = AppState::default();
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
     }
 
     #[test]
@@ -736,7 +757,7 @@ mod tests {
             bot_user_id: agent.clone(),
             remark: String::new(),
         });
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
     }
 
     #[test]
@@ -748,12 +769,12 @@ mod tests {
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(bot.clone()), true);
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
 
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(bot), false);
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
     }
 
     #[test]
@@ -763,10 +784,10 @@ mod tests {
         let mut app_state = AppState::default();
 
         app_state.agent_registry.register(agent.clone(), AgentEntry::default());
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
 
         app_state.agent_registry.unregister(agent.as_ref());
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
     }
 
     #[test]
@@ -783,14 +804,32 @@ mod tests {
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(agent.clone()), true);
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
 
         app_state.unregister_agent_and_clear_bot_identity(
             agent.as_ref(),
             Some(current_user_id.as_ref()),
         );
 
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+    }
+
+    #[test]
+    fn test_agent_badge_hidden_after_agentlab_unbind_with_cached_member_id() {
+        let current_user_id: OwnedUserId = "@alice:example.org".try_into().unwrap();
+        let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
+        let agent: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent.clone(), AgentEntry::default());
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[agent.clone()]));
+
+        app_state.unregister_agent_and_clear_bot_identity(
+            agent.as_ref(),
+            Some(current_user_id.as_ref()),
+        );
+
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[agent]));
     }
 
     #[test]

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -221,6 +221,11 @@ script_mod! {
         // (and its layout) based on the available space in the sidebar.
         adaptive_preview := AdaptiveView {
             height: Fit
+            // The wider variants contain `RoomsListBotPill`, a `new_batch`
+            // view that owns a child DrawList. Retain variants across resize
+            // swaps so ultra-narrow transitions do not drop DrawLists that the
+            // previous frame may still reference.
+            retain_unused_variants: true
 
             OnlyIcon := mod.widgets.RoomsListEntryContent {
                 align: Align{x: 0.5, y: 0.5}
@@ -732,5 +737,49 @@ mod tests {
             remark: String::new(),
         });
         assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+    }
+
+    #[test]
+    fn test_agent_badge_hidden_after_room_unbound() {
+        let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
+        let bot: OwnedUserId = "@bot:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state
+            .bot_settings
+            .set_room_bound(room_id.clone(), Some(bot.clone()), true);
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+
+        app_state
+            .bot_settings
+            .set_room_bound(room_id.clone(), Some(bot), false);
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+    }
+
+    #[test]
+    fn test_agent_badge_hidden_after_agent_registry_unbind() {
+        let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
+        let agent: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent.clone(), AgentEntry::default());
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+
+        app_state.agent_registry.unregister(agent.as_ref());
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+    }
+
+    #[test]
+    fn test_rooms_list_entry_retains_adaptive_variants_for_batched_bot_pill() {
+        let source = include_str!("rooms_list_entry.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+
+        assert!(
+            production_source.contains("adaptive_preview := AdaptiveView {")
+                && production_source.contains("retain_unused_variants: true")
+                && production_source.contains("mod.widgets.RoomsListBotPill = RoundedView")
+                && production_source.contains("new_batch: true"),
+            "RoomsListEntry AdaptiveView must retain variants because bot pills own new_batch DrawLists",
+        );
     }
 }

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -60,6 +60,30 @@ script_mod! {
         text: "[Room name unknown]"
     }
 
+    // A small blue "bot" pill shown after the room name for agent-bound rooms.
+    // Reproduces the timeline's bot badge look (room_screen.rs) locally so this
+    // file doesn't depend on room_screen's private constants/widgets.
+    mod.widgets.RoomsListBotPill = RoundedView {
+        visible: false
+        width: Fit
+        height: 16.0
+        align: Align{x: 0.5, y: 0.5}
+        padding: Inset{left: 6.0, right: 6.0}
+        show_bg: true
+        draw_bg +: {
+            color: (COLOR_ACTIVE_PRIMARY)
+            border_radius: 3.0
+        }
+        Label {
+            width: Fit, height: Fit, padding: 0
+            draw_text +: {
+                text_style: REGULAR_TEXT { font_size: 8.5, top_drop: -0.08 }
+                color: #fff
+            }
+            text: "bot"
+        }
+    }
+
     mod.widgets.RoomsListEntryTimestamp = Label {
         padding: Inset{top: 1},
         width: Fit, height: Fit
@@ -214,7 +238,19 @@ script_mod! {
                 padding: 5.
                 align: Align{x: 0.5, y: 0.5}
                 avatar := Avatar {}
-                room_name := mod.widgets.RoomName {}
+                name_wrap := View {
+                    width: Fill, height: Fit
+                    flow: Right
+                    align: Align{y: 0.5}
+                    spacing: 6
+                    // Hug the name text so the bot pill packs snug right after it,
+                    // instead of Fill's turtle-advance pushing the pill to the row's
+                    // right edge. Capped so long names still ellipsize; IconAndName
+                    // is only shown at sidebar widths <= 200px, so a smaller cap
+                    // than FullPreview leaves room for the pill.
+                    room_name := mod.widgets.RoomName { width: Fit{max: FitBound.Abs(130.0)} }
+                    bot_pill := mod.widgets.RoomsListBotPill {}
+                }
                 unread_badge := UnreadBadge {}
                 encryption_icon := mod.widgets.EncryptionIcon {}
                 tombstone_icon := mod.widgets.TombstoneIcon {}
@@ -230,7 +266,16 @@ script_mod! {
                         width: Fill, height: Fit,
                         spacing: 3,
                         flow: Right,
-                        room_name := mod.widgets.RoomName {}
+                        name_wrap := View {
+                            width: Fill, height: Fit
+                            flow: Right
+                            align: Align{y: 0.5}
+                            spacing: 6
+                            // Same fix as IconAndName above, but with a larger cap since
+                            // FullPreview is shown on desktop/wider sidebars.
+                            room_name := mod.widgets.RoomName { width: Fit{max: FitBound.Abs(200.0)} }
+                            bot_pill := mod.widgets.RoomsListBotPill {}
+                        }
                         timestamp := mod.widgets.RoomsListEntryTimestamp { }
                     }
                     bottom := View {
@@ -370,11 +415,19 @@ impl Widget for RoomsListEntryContent {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        let app_language = scope.data.get::<AppState>()
+        let app_state = scope.data.get::<AppState>();
+        let app_language = app_state
             .map(|app_state| app_state.app_language)
             .unwrap_or_default();
         if let Some(joined_room_info) = scope.props.get::<JoinedRoomInfo>() {
-            self.draw_joined_room(cx, joined_room_info);
+            let show_agent_badge = app_state.is_some_and(|app_state| {
+                room_shows_agent_badge(
+                    app_state,
+                    joined_room_info.room_name_id.room_id(),
+                    joined_room_info.dm_target.as_deref(),
+                )
+            });
+            self.draw_joined_room(cx, joined_room_info, show_agent_badge);
         } else if let Some(invited_room_info) = scope.props.get::<InvitedRoomInfo>() {
             self.draw_invited_room(cx, invited_room_info, app_language);
         }
@@ -389,6 +442,7 @@ impl RoomsListEntryContent {
         &mut self,
         cx: &mut Cx,
         room_info: &JoinedRoomInfo,
+        show_agent_badge: bool,
     ) {
         self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.to_string());
         if let Some((ts, msg)) = room_info.latest.as_ref() {
@@ -412,6 +466,7 @@ impl RoomsListEntryContent {
             cx,
             should_show_encryption_icon(room_info.is_encrypted, room_info.is_tombstoned),
         );
+        self.view.view(cx, ids!(bot_pill)).set_visible(cx, show_agent_badge);
         self.view.view(cx, ids!(tombstone_icon)).set_visible(cx, room_info.is_tombstoned);
     }
 
@@ -465,6 +520,7 @@ impl RoomsListEntryContent {
             .update_counts(false, 1, 0);
 
         self.view.view(cx, ids!(encryption_icon)).set_visible(cx, false);
+        self.view.view(cx, ids!(bot_pill)).set_visible(cx, false);
         self.view.view(cx, ids!(tombstone_icon)).set_visible(cx, false);
         self.draw_common(cx, &room_info.room_avatar, room_info.is_selected);
     }

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -1,5 +1,5 @@
 use makepad_widgets::*;
-use matrix_sdk::ruma::OwnedRoomId;
+use matrix_sdk::ruma::{OwnedRoomId, RoomId, UserId};
 
 use crate::{
     app::AppState,
@@ -563,9 +563,25 @@ pub fn should_show_encryption_icon(is_encrypted: Option<bool>, is_tombstoned: bo
     matches!(is_encrypted, Some(true)) && !is_tombstoned
 }
 
+/// Whether the rooms-list row for `room_id` should display an agent badge.
+///
+/// True when the room is bound to a bot (app-service binding) OR it is a 1:1 DM
+/// whose counterparty is a registered agent. Derived live from `AppState`, so it
+/// updates as soon as an agent is registered or unregistered.
+pub fn room_shows_agent_badge(
+    app_state: &AppState,
+    room_id: &RoomId,
+    dm_target: Option<&UserId>,
+) -> bool {
+    app_state.bot_settings.is_room_bound(room_id)
+        || dm_target.is_some_and(|user_id| app_state.agent_registry.contains(user_id))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::{AgentEntry, AppState};
+    use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
 
     #[test]
     fn test_room_list_icon_visible_when_encrypted() {
@@ -585,5 +601,66 @@ mod tests {
     #[test]
     fn test_room_list_icon_yields_to_tombstone() {
         assert!(!should_show_encryption_icon(Some(true), true));
+    }
+
+    #[test]
+    fn test_agent_badge_shown_when_room_bound() {
+        let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state
+            .bot_settings
+            .record_known_bot_user_ids(["@bot:example.org".try_into().unwrap()]);
+        // Bind the bot to the room so is_room_bound() is true.
+        app_state.bot_settings.room_bindings.push(crate::app::RoomBotBindingState {
+            room_id: room_id.clone(),
+            bot_user_id: "@bot:example.org".try_into().unwrap(),
+            remark: String::new(),
+        });
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+    }
+
+    #[test]
+    fn test_agent_badge_shown_when_dm_target_is_registered_agent() {
+        let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
+        let agent: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state.agent_registry.register(agent.clone(), AgentEntry::default());
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
+    }
+
+    #[test]
+    fn test_agent_badge_hidden_for_human_dm() {
+        let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
+        let human: OwnedUserId = "@human:example.org".try_into().unwrap();
+        let app_state = AppState::default();
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(human.as_ref())));
+    }
+
+    #[test]
+    fn test_agent_badge_hidden_for_unbound_group_room() {
+        let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
+        let app_state = AppState::default();
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+    }
+
+    #[test]
+    fn test_agent_badge_hidden_when_dm_target_none() {
+        let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
+        let app_state = AppState::default();
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+    }
+
+    #[test]
+    fn test_agent_badge_idempotent_when_bound_and_agent_dm() {
+        let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
+        let agent: OwnedUserId = "@agent:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+        app_state.agent_registry.register(agent.clone(), AgentEntry::default());
+        app_state.bot_settings.room_bindings.push(crate::app::RoomBotBindingState {
+            room_id: room_id.clone(),
+            bot_user_id: agent.clone(),
+            remark: String::new(),
+        });
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref())));
     }
 }

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -770,6 +770,30 @@ mod tests {
     }
 
     #[test]
+    fn test_agent_badge_hidden_after_agentlab_unbind_clears_binding() {
+        let current_user_id: OwnedUserId = "@alice:example.org".try_into().unwrap();
+        let room_id: OwnedRoomId = "!room:example.org".try_into().unwrap();
+        let agent: OwnedUserId = "@octos_mac:example.org".try_into().unwrap();
+        let mut app_state = AppState::default();
+
+        app_state.agent_registry.register(agent.clone(), AgentEntry::default());
+        app_state.bot_settings.enabled = true;
+        app_state.bot_settings.botfather_user_id = agent.to_string();
+        app_state.bot_settings.record_known_bot_user_ids([agent.clone()]);
+        app_state
+            .bot_settings
+            .set_room_bound(room_id.clone(), Some(agent.clone()), true);
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+
+        app_state.unregister_agent_and_clear_bot_identity(
+            agent.as_ref(),
+            Some(current_user_id.as_ref()),
+        );
+
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None));
+    }
+
+    #[test]
     fn test_rooms_list_entry_retains_adaptive_variants_for_batched_bot_pill() {
         let source = include_str!("rooms_list_entry.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -70,6 +70,7 @@ script_mod! {
         align: Align{x: 0.5, y: 0.5}
         padding: Inset{left: 6.0, right: 6.0}
         show_bg: true
+        new_batch: true
         draw_bg +: {
             color: (COLOR_ACTIVE_PRIMARY)
             border_radius: 3.0
@@ -78,7 +79,7 @@ script_mod! {
             width: Fit, height: Fit, padding: 0
             draw_text +: {
                 text_style: REGULAR_TEXT { font_size: 8.5, top_drop: -0.08 }
-                color: #fff
+                color: (RBX_FG_ON_ACCENT)
             }
             text: "bot"
         }
@@ -248,7 +249,7 @@ script_mod! {
                     // right edge. Capped so long names still ellipsize; IconAndName
                     // is only shown at sidebar widths <= 200px, so a smaller cap
                     // than FullPreview leaves room for the pill.
-                    room_name := mod.widgets.RoomName { width: Fit{max: FitBound.Abs(130.0)} }
+                    room_name := mod.widgets.RoomName { width: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.70}} }
                     bot_pill := mod.widgets.RoomsListBotPill {}
                 }
                 unread_badge := UnreadBadge {}
@@ -273,7 +274,7 @@ script_mod! {
                             spacing: 6
                             // Same fix as IconAndName above, but with a larger cap since
                             // FullPreview is shown on desktop/wider sidebars.
-                            room_name := mod.widgets.RoomName { width: Fit{max: FitBound.Abs(200.0)} }
+                            room_name := mod.widgets.RoomName { width: Fit{max: FitBound.Rel{base: Base.Full, factor: 0.78}} }
                             bot_pill := mod.widgets.RoomsListBotPill {}
                         }
                         timestamp := mod.widgets.RoomsListEntryTimestamp { }

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -1,5 +1,5 @@
 use makepad_widgets::*;
-use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId, RoomId, UserId};
+use matrix_sdk::ruma::{OwnedRoomId, RoomId, UserId};
 
 use crate::{
     app::AppState,
@@ -431,7 +431,7 @@ impl Widget for RoomsListEntryContent {
                     app_state,
                     joined_room_info.room_name_id.room_id(),
                     joined_room_info.dm_target.as_deref(),
-                    &joined_room_info.member_user_ids,
+                    joined_room_info.member_user_ids.iter().map(|user_id| user_id.as_ref()),
                 )
             });
             self.draw_joined_room(cx, joined_room_info, show_agent_badge);
@@ -640,21 +640,24 @@ pub fn should_show_encryption_icon(is_encrypted: Option<bool>, is_tombstoned: bo
 }
 
 /// Whether the rooms-list row for `room_id` should display an agent badge.
+/// Also the single source of truth for the room-info title pill, so the
+/// rooms list and the Info pane can never disagree.
 ///
-/// True when the room is bound to a bot (app-service binding) OR it is a 1:1 DM
-/// whose counterparty is a registered agent. Derived live from `AppState`, so it
-/// updates as soon as an agent is registered or unregistered.
-pub fn room_shows_agent_badge(
+/// True when the room is bound to a bot (app-service binding), OR it is a 1:1 DM
+/// whose counterparty is a registered agent, OR any of its members is a
+/// registered agent. Derived live from `AppState`, so it updates as soon as an
+/// agent is registered or unregistered.
+pub fn room_shows_agent_badge<'a>(
     app_state: &AppState,
     room_id: &RoomId,
     dm_target: Option<&UserId>,
-    member_user_ids: &[OwnedUserId],
+    member_user_ids: impl IntoIterator<Item = &'a UserId>,
 ) -> bool {
     app_state.bot_settings.is_room_bound(room_id)
         || dm_target.is_some_and(|user_id| app_state.agent_registry.contains(user_id))
         || member_user_ids
-            .iter()
-            .any(|user_id| app_state.agent_registry.contains(user_id.as_ref()))
+            .into_iter()
+            .any(|user_id| app_state.agent_registry.contains(user_id))
 }
 
 #[cfg(test)]
@@ -696,7 +699,7 @@ mod tests {
             bot_user_id: "@bot:example.org".try_into().unwrap(),
             remark: String::new(),
         });
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
     }
 
     #[test]
@@ -705,7 +708,7 @@ mod tests {
         let agent: OwnedUserId = "@agent:example.org".try_into().unwrap();
         let mut app_state = AppState::default();
         app_state.agent_registry.register(agent.clone(), AgentEntry::default());
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), std::iter::empty()));
     }
 
     #[test]
@@ -713,14 +716,14 @@ mod tests {
         let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
         let human: OwnedUserId = "@human:example.org".try_into().unwrap();
         let app_state = AppState::default();
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(human.as_ref()), &[]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(human.as_ref()), std::iter::empty()));
     }
 
     #[test]
     fn test_agent_badge_hidden_for_unbound_group_room() {
         let room_id: OwnedRoomId = "!group:example.org".try_into().unwrap();
         let app_state = AppState::default();
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
     }
 
     #[test]
@@ -735,7 +738,7 @@ mod tests {
             &app_state,
             room_id.as_ref(),
             None,
-            &[agent],
+            [agent.as_ref()],
         ));
     }
 
@@ -743,7 +746,7 @@ mod tests {
     fn test_agent_badge_hidden_when_dm_target_none() {
         let room_id: OwnedRoomId = "!dm:example.org".try_into().unwrap();
         let app_state = AppState::default();
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
     }
 
     #[test]
@@ -757,7 +760,7 @@ mod tests {
             bot_user_id: agent.clone(),
             remark: String::new(),
         });
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), std::iter::empty()));
     }
 
     #[test]
@@ -769,12 +772,12 @@ mod tests {
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(bot.clone()), true);
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
 
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(bot), false);
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
     }
 
     #[test]
@@ -784,10 +787,10 @@ mod tests {
         let mut app_state = AppState::default();
 
         app_state.agent_registry.register(agent.clone(), AgentEntry::default());
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), std::iter::empty()));
 
         app_state.agent_registry.unregister(agent.as_ref());
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), &[]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), Some(agent.as_ref()), std::iter::empty()));
     }
 
     #[test]
@@ -804,14 +807,14 @@ mod tests {
         app_state
             .bot_settings
             .set_room_bound(room_id.clone(), Some(agent.clone()), true);
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
 
         app_state.unregister_agent_and_clear_bot_identity(
             agent.as_ref(),
             Some(current_user_id.as_ref()),
         );
 
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, std::iter::empty()));
     }
 
     #[test]
@@ -822,14 +825,14 @@ mod tests {
         let mut app_state = AppState::default();
 
         app_state.agent_registry.register(agent.clone(), AgentEntry::default());
-        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[agent.clone()]));
+        assert!(room_shows_agent_badge(&app_state, room_id.as_ref(), None, [agent.as_ref()]));
 
         app_state.unregister_agent_and_clear_bot_identity(
             agent.as_ref(),
             Some(current_user_id.as_ref()),
         );
 
-        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, &[agent]));
+        assert!(!room_shows_agent_badge(&app_state, room_id.as_ref(), None, [agent.as_ref()]));
     }
 
     #[test]

--- a/src/settings/agent_settings.rs
+++ b/src/settings/agent_settings.rs
@@ -17,7 +17,7 @@ use makepad_widgets::*;
 use ruma::OwnedUserId;
 
 use crate::{
-    app::{AgentEntry, AgentFramework, AppState, BotSettingsState},
+    app::{AgentEntry, AgentFramework, AppState, AppStateAction, BotSettingsState},
     i18n::{AppLanguage, tr_key},
     persistence,
     profile::user_profile::UserProfile,
@@ -975,7 +975,9 @@ impl WidgetMatchEvent for AgentSettings {
                 }
                 Some(AgentRowAction::Unbind(user_id)) => {
                     if let Some(app_state) = scope.data.get_mut::<AppState>() {
-                        app_state.agent_registry.unregister(user_id);
+                        if app_state.agent_registry.unregister(user_id) {
+                            cx.action(AppStateAction::AgentRegistryUpdated);
+                        }
                         if let Some(account_user_id) = current_user_id() {
                             if let Err(e) = persistence::save_app_state(app_state.clone(), account_user_id) {
                                 error!("Failed to persist agent registry. Error: {e}");
@@ -1515,6 +1517,15 @@ mod tests {
         assert!(src.contains("dot.set_visible(cx, framework == AgentFramework::Octos)"));
         assert!(src.contains("OctosHealthStatus::Reachable"));
         assert!(src.contains("mod.widgets.RBX_SUCCESS_FG"));
+    }
+
+    #[test]
+    fn test_agent_unbind_notifies_agent_badge_surfaces() {
+        let src = production_src(include_str!("agent_settings.rs"));
+
+        assert!(src.contains("AgentRowAction::Unbind"));
+        assert!(src.contains("agent_registry.unregister(user_id)"));
+        assert!(src.contains("AppStateAction::AgentRegistryUpdated"));
     }
 
     #[test]

--- a/src/settings/agent_settings.rs
+++ b/src/settings/agent_settings.rs
@@ -975,7 +975,10 @@ impl WidgetMatchEvent for AgentSettings {
                 }
                 Some(AgentRowAction::Unbind(user_id)) => {
                     if let Some(app_state) = scope.data.get_mut::<AppState>() {
-                        if app_state.agent_registry.unregister(user_id) {
+                        if app_state.unregister_agent_and_clear_bot_identity(
+                            user_id,
+                            current_user_id().as_deref(),
+                        ) {
                             cx.action(AppStateAction::AgentRegistryUpdated);
                         }
                         if let Some(account_user_id) = current_user_id() {
@@ -1524,7 +1527,7 @@ mod tests {
         let src = production_src(include_str!("agent_settings.rs"));
 
         assert!(src.contains("AgentRowAction::Unbind"));
-        assert!(src.contains("agent_registry.unregister(user_id)"));
+        assert!(src.contains("unregister_agent_and_clear_bot_identity"));
         assert!(src.contains("AppStateAction::AgentRegistryUpdated"));
     }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -7327,6 +7327,17 @@ async fn add_new_room(
     let room_name_id = RoomNameId::from((new_room.display_name.clone(), new_room.room_id.clone()));
     // Start with a basic text avatar; the avatar image will be fetched asynchronously below.
     let room_avatar = avatar_from_room_name(room_name_id.name_for_avatar());
+    // The DM counterparty MXID, only for 1:1 direct rooms (used for agent badges).
+    let dm_target = if new_room.is_direct {
+        let targets = new_room.room.direct_targets();
+        if targets.len() == 1 {
+            targets.into_iter().next().and_then(|id| id.into_user_id())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
     rooms_list::enqueue_rooms_list_update(RoomsListUpdate::AddJoinedRoom(JoinedRoomInfo {
         latest,
         tags: new_room.tags.clone().unwrap_or_default(),
@@ -7345,6 +7356,7 @@ async fn add_new_room(
         has_been_paginated: false,
         is_selected: false,
         is_direct: new_room.is_direct,
+        dm_target,
         is_encrypted,
         is_tombstoned: new_room.is_tombstoned,
     }));

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -7357,6 +7357,7 @@ async fn add_new_room(
         is_selected: false,
         is_direct: new_room.is_direct,
         dm_target,
+        member_user_ids: Vec::new(),
         is_encrypted,
         is_tombstoned: new_room.is_tombstoned,
     }));


### PR DESCRIPTION
## What

Makes agent/bot identity visible at a glance across three surfaces, driven by the global `AgentRegistry` instead of name heuristics alone:

1. **Rooms list** — a `bot` pill after the room name (matching the timeline pill style) for rows whose room is bot-bound **or** whose DM counterparty is a registered agent. Shown in the `IconAndName` / `FullPreview` adaptive variants; the name hugs its text (`Fit{max}`) so the pill sits snug and long names ellipsize without pushing it away.
2. **Room info header** — a `bot` pill next to the room name (driven by `is_agent_enabled`), alongside the existing *Agent-enabled* badge. Covers both the desktop sliding pane and the mobile inline Info tab (shared widget).
3. **Member list** — `is_bot` now uses the same union as the timeline (`AgentRegistry` ∪ app-service known bots ∪ name heuristic), so registered agents with non-bot-like names (e.g. `@octos_mac`) finally get their **Bot** pill. The pill also left-aligns with the name when it wraps under a long MXID.

## How

- New pure predicate `room_shows_agent_badge(app_state, room_id, dm_target)` (+6 unit tests), mirroring the `should_show_encryption_icon` pattern.
- `JoinedRoomInfo.dm_target: Option<OwnedUserId>` plumbed from `room.direct_targets()` in sliding_sync (1:1 rooms only; cleared when a room stops being direct).
- `build_room_info_pane_info` takes `Option<&AppState>`; `None` degrades to the previous heuristic-only behavior. Union computed once per member-cache rebuild.
- All pills are live-derived from `AppState` each draw — registering/unbinding an agent updates the UI without restart.

## Testing

- `cargo build` clean; `cargo test -p robrix --lib` 475/475.
- Manual visual verification on **macOS and Android** (rooms list variants, info pane + inline Info tab, member list, timeline regression, human-DM/group negative cases).

## Known follow-ups (out of scope, tracked)

- Info-header room name is capped at 150px with ellipsis (deliberate, to keep pill + favorite button visible); could become pane-width-relative later.
- Labs "Unbind" of an Octos agent is resurrected on restart by `seed_agent_registry_from_known_bots` (pre-existing three-source identity model); a registry-convergence task is planned.
- `UpdateIsDirect` doesn't backfill `dm_target` mid-session (accepted YAGNI; corrected on next full room load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)