### PR TITLE
fix(modals): unify modal shells, fix logout/leave bugs, globalize leave & report

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use crate::{
     avatar_cache::{self, clear_avatar_cache}, room_preview_cache::clear_room_preview_cache, home::{
         add_room::{CreateRoomModalAction, CreateRoomModalWidgetRefExt, StartChatModalAction, StartChatModalWidgetRefExt},
         bot_binding_modal::{BotBindingModalAction, BotBindingModalWidgetRefExt},
-        event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt, mark_invite_modal_closed}, invite_screen::{InviteScreenWidgetRefExt, LeaveRoomResultAction}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::{RoomContextMenuAction, RoomContextMenuWidgetRefExt}, room_screen::{InviteAction, MessageAction, RoomScreenWidgetRefExt, TimelineUpdate, clear_timeline_states}, room_settings_modal::{RoomSettingsAction, RoomSettingsModalWidgetRefExt}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, space_lobby::SpaceLobbyScreenWidgetRefExt, spaces_bar::SpacesBarRef
+        event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt, mark_invite_modal_closed}, invite_screen::{InviteScreenWidgetRefExt, LeaveRoomResultAction}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::{RoomContextMenuAction, RoomContextMenuWidgetRefExt}, room_screen::{InviteAction, MessageAction, ReportRoomModalAction, ReportRoomModalWidgetRefExt, ReportRoomResultAction, RoomScreenWidgetRefExt, TimelineUpdate, clear_timeline_states, set_room_info_action_modal_open}, room_settings_modal::{RoomSettingsAction, RoomSettingsModalWidgetRefExt}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, space_lobby::SpaceLobbyScreenWidgetRefExt, spaces_bar::SpacesBarRef
     }, i18n::{AppLanguage, tr_fmt, tr_key}, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
     }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, register::RegisterAction, room::BasicRoomDetails, shared::{confirmation_modal::{ConfirmationModalAction, ConfirmationModalContent, ConfirmationModalWidgetRefExt}, file_upload_modal::{FilePreviewerAction, FileUploadModalWidgetRefExt}, forward_modal::{ForwardMessageModalAction, ForwardMessageModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, room_filter_input_bar::FilterAction}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, RemoteDirectorySearchKind, RemoteDirectorySearchResult, RoomSettingsFetchedAction, RoomAvatarUploadedAction, TimelineKind, AccountSwitchAction, current_user_id, get_client, submit_async_request, get_timeline_update_sender}, updater::{UpdateCheckOutcome, check_for_updates, load_skipped_update_version, save_skipped_update_version, update_release_page_url}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
@@ -85,6 +85,8 @@ script_mod! {
                         }
                         join_leave_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill,
+                                align: Align{x: 0.5, y: 0.5},
                                 join_leave_modal_inner := JoinLeaveRoomModal {}
                             }
                         }
@@ -143,6 +145,8 @@ script_mod! {
                         // A modal to invite a user to a room.
                         invite_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill,
+                                align: Align{x: 0.5, y: 0.5},
                                 invite_modal_inner := InviteModal {}
                             }
                         }
@@ -283,12 +287,16 @@ script_mod! {
 
                         create_room_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill,
+                                align: Align{x: 0.5, y: 0.5},
                                 create_room_modal_inner := CreateRoomModal {}
                             }
                         }
 
                         start_chat_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill,
+                                align: Align{x: 0.5, y: 0.5},
                                 start_chat_modal_inner := StartChatModal {}
                             }
                         }
@@ -296,6 +304,8 @@ script_mod! {
                         // Show the logout confirmation modal.
                         logout_confirm_modal := Modal {
                             content +: {
+                                width: Fill, height: Fill,
+                                align: Align{x: 0.5, y: 0.5},
                                 logout_confirm_modal_inner := LogoutConfirmModal {}
                             }
                         }
@@ -347,6 +357,15 @@ script_mod! {
                             content +: {
                                 width: Fill, height: Fill, align: Align{x: 0.5, y: 0.5},
                                 delete_confirmation_modal_inner := NegativeConfirmationModal { }
+                            }
+                        }
+
+                        // Report-a-room modal. Hosted globally (not per-RoomScreen)
+                        // so it survives mobile<->desktop AdaptiveView rebuilds.
+                        report_room_modal := Modal {
+                            content +: {
+                                width: Fill, height: Fill, align: Align{x: 0.5, y: 0.5},
+                                report_room_modal_inner := mod.widgets.ReportRoomModal {}
                             }
                         }
 
@@ -477,6 +496,9 @@ pub struct App {
     /// handler can confirm the load event matches the room we're
     /// waiting on before firing the scroll.
     #[rust] pending_jump_to_event: Option<(OwnedRoomId, OwnedEventId)>,
+    /// The room a globally-hosted report modal is currently collecting a reason
+    /// for, so `ReportRoomModalAction::Submit` can target the right room.
+    #[rust] pending_report_room_id: Option<OwnedRoomId>,
     /// A stack of previously-selected rooms for mobile navigation.
     /// When a view is popped off the stack, the previous `selected_room` is restored from here.
     #[rust] mobile_room_nav_stack: Vec<SelectedRoom>,
@@ -1807,6 +1829,59 @@ impl MatchEvent for App {
                 _ => {}
             }
 
+            // Handle the GLOBAL report-room modal (moved out of RoomScreen so it
+            // survives mobile<->desktop AdaptiveView rebuilds). RoomScreen emits
+            // Open{room_id,...}; the modal widget emits Close/Submit.
+            match action.downcast_ref::<ReportRoomModalAction>() {
+                Some(ReportRoomModalAction::Open { room_id, room_name_id }) => {
+                    self.pending_report_room_id = Some(room_id.clone());
+                    self.ui.report_room_modal(cx, ids!(report_room_modal_inner))
+                        .show(cx, room_name_id);
+                    self.ui.modal(cx, ids!(report_room_modal)).open(cx);
+                    continue;
+                }
+                Some(ReportRoomModalAction::Close) => {
+                    self.pending_report_room_id = None;
+                    self.ui.modal(cx, ids!(report_room_modal)).close(cx);
+                    continue;
+                }
+                Some(ReportRoomModalAction::Submit(reason)) => {
+                    if let Some(room_id) = self.pending_report_room_id.take() {
+                        submit_async_request(MatrixRequest::ReportRoom {
+                            room_id,
+                            reason: reason.clone(),
+                        });
+                    }
+                    self.ui.modal(cx, ids!(report_room_modal)).close(cx);
+                    continue;
+                }
+                None => {}
+            }
+            if let Some(ReportRoomResultAction::Sent { .. }) = action.downcast_ref() {
+                enqueue_popup_notification(
+                    "Room reported successfully.",
+                    PopupKind::Success,
+                    Some(4.0),
+                );
+                continue;
+            }
+            if let Some(ReportRoomResultAction::Failed { error, .. }) = action.downcast_ref() {
+                let error_display = error.to_string();
+                enqueue_notification(NotificationItem {
+                    kind: PopupKind::Error,
+                    title: Some("Report failed".into()),
+                    message: format!("Failed to report room.\n\nError: {error}").into(),
+                    actions: vec![
+                        NotificationAction::new("Copy details", NotifActionStyle::Neutral, move |cx| {
+                            cx.copy_to_clipboard(&error_display);
+                        }),
+                    ],
+                    auto_dismissal_duration: Some(5.0),
+                    ..Default::default()
+                });
+                continue;
+            }
+
             // Handle RoomSettingsAction.
             match action.downcast_ref::<RoomSettingsAction>() {
                 Some(RoomSettingsAction::Open { room_id }) => {
@@ -2169,6 +2244,16 @@ impl AppMain for App {
 
         // Forward events to the MatchEvent trait implementation.
         self.match_event(cx, event);
+        // Keep the room-info-action-modal flag in sync from the GLOBAL modals
+        // (report / leave-confirm) so the room info pane doesn't self-close on
+        // Escape / tap-outside while one is open over it. Only on Actions events
+        // (when open/close happens) to avoid per-frame widget lookups.
+        if matches!(event, Event::Actions(_)) {
+            set_room_info_action_modal_open(
+                self.ui.modal(cx, ids!(report_room_modal)).is_open()
+                    || self.ui.modal(cx, ids!(delete_confirmation_modal)).is_open()
+            );
+        }
         let scope = &mut Scope::with_data(&mut self.app_state);
         self.ui.handle_event(cx, event, scope);
         self.handle_lifecycle_event(cx, event);

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -569,11 +569,12 @@ script_mod! {
     }
 
     mod.widgets.CreateRoomModal = #(CreateRoomModal::register_widget(vm)) {
-        width: Fit
+        width: Fill { max: 400 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
-        RoundedView {
-            width: 400
+        RoundedShadowView {
+            width: Fill
             height: Fit
             align: Align{x: 0.5}
             flow: Down
@@ -581,8 +582,13 @@ script_mod! {
 
             show_bg: true
             draw_bg +: {
-                color: #fff
-                border_radius: 4.0
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
             }
 
             title_view := View {
@@ -598,7 +604,7 @@ script_mod! {
                     flow: Flow.Right{wrap: true}
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 15}
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                     text: "Create New Room"
                 }
@@ -648,11 +654,12 @@ script_mod! {
     }
 
     mod.widgets.StartChatModal = #(StartChatModal::register_widget(vm)) {
-        width: Fit
+        width: Fill { max: 400 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
-        RoundedView {
-            width: 400
+        RoundedShadowView {
+            width: Fill
             height: Fit
             align: Align{x: 0.5}
             flow: Down
@@ -660,8 +667,13 @@ script_mod! {
 
             show_bg: true
             draw_bg +: {
-                color: #fff
-                border_radius: 4.0
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
             }
 
             title_view := View {
@@ -677,7 +689,7 @@ script_mod! {
                     flow: Flow.Right{wrap: true}
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 15}
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                     text: "Direct Messages"
                 }

--- a/src/home/invite_modal.rs
+++ b/src/home/invite_modal.rs
@@ -95,11 +95,12 @@ script_mod! {
 
 
     mod.widgets.InviteModal = #(InviteModal::register_widget(vm)) {
-        width: Fit
+        width: Fill { max: 400 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
-        RoundedView {
-            width: 400
+        RoundedShadowView {
+            width: Fill
             height: Fit
             align: Align{x: 0.5}
             flow: Down
@@ -107,8 +108,13 @@ script_mod! {
 
             show_bg: true
             draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 4.0
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
             }
 
             title_view := View {
@@ -124,7 +130,7 @@ script_mod! {
                     flow: Flow.Right{wrap: true},
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                     text: ""
                 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     room::{BasicRoomDetails, room_input_bar::{RoomInputBarState, RoomInputBarWidgetRefExt}, translation, typing_notice::TypingNoticeWidgetExt},
     shared::{
-        attachment_download::{DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, mark_pending_download_finished, media_source_mxc, reset_pending_download, start_attachment_download}, avatar::{AvatarRef, AvatarState, AvatarWidgetExt, AvatarWidgetRefExt}, confirmation_modal::{ConfirmationModalAction, ConfirmationModalContent, ConfirmationModalWidgetExt}, forward_modal::{ForwardMessageContent, ForwardMessageModalAction}, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetExt, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, restore_status_view::RestoreStatusViewWidgetExt, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
+        attachment_download::{DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, mark_pending_download_finished, media_source_mxc, reset_pending_download, start_attachment_download}, avatar::{AvatarRef, AvatarState, AvatarWidgetExt, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, forward_modal::{ForwardMessageContent, ForwardMessageModalAction}, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetExt, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, restore_status_view::RestoreStatusViewWidgetExt, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
     },
     sliding_sync::{BackwardsPaginateUntilEventRequest, FetchedRoomThread, MatrixRequest, PaginationDirection, RoomThreadsAction, SearchMessagesResultAction, SearchedMessage, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, current_user_id, get_client, submit_async_request, take_timeline_endpoints}, utils::{self, ImageFormat, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
 };
@@ -1030,7 +1030,10 @@ thread_local! {
     static ROOM_INFO_ACTION_MODAL_OPEN: Cell<bool> = const { Cell::new(false) };
 }
 
-fn set_room_info_action_modal_open(open: bool) {
+/// Set by app.rs each frame from the GLOBAL room-info-action modals
+/// (report / leave-confirm), so the room info sliding pane knows not to
+/// self-close on Escape / tap-outside while one of them is open over it.
+pub fn set_room_info_action_modal_open(open: bool) {
     ROOM_INFO_ACTION_MODAL_OPEN.with(|state| state.set(open));
 }
 
@@ -4035,11 +4038,12 @@ script_mod! {
     }
 
     mod.widgets.ReportRoomModal = #(ReportRoomModal::register_widget(vm)) {
-        width: Fit
+        width: Fill { max: 430 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
-        RoundedView {
-            width: 430
+        RoundedShadowView {
+            width: Fill
             height: Fit
             align: Align{x: 0.5}
             flow: Down
@@ -4048,8 +4052,13 @@ script_mod! {
 
             show_bg: true
             draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 6.0
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
             }
 
             title := Label {
@@ -4057,7 +4066,7 @@ script_mod! {
                 height: Fit
                 draw_text +: {
                     text_style: TITLE_TEXT { font_size: 13 }
-                    color: #000
+                    color: (RBX_FG_PRIMARY)
                 }
                 text: "Report Room"
             }
@@ -4568,19 +4577,6 @@ script_mod! {
                     delete_bot_modal_inner := mod.widgets.DeleteBotModal {}
                 }
             }
-
-            report_room_modal := Modal {
-                content +: {
-                    report_room_modal_inner := mod.widgets.ReportRoomModal {}
-                }
-            }
-
-            leave_room_confirm_modal := Modal {
-                content +: {
-                    leave_room_confirm_modal_inner := mod.widgets.NegativeConfirmationModal {}
-                }
-            }
-
 
             /*
              * TODO: add the action bar back in as a series of floating buttons.
@@ -5652,6 +5648,12 @@ impl RoomInfoSlidingPaneRef {
 
 #[derive(Clone, Debug)]
 pub enum ReportRoomModalAction {
+    /// Emitted by RoomScreen to open the (now global, app-root) report modal
+    /// for a specific room. Carries the room so app.rs can route the result.
+    Open {
+        room_id: OwnedRoomId,
+        room_name_id: RoomNameId,
+    },
     Close,
     Submit(String),
 }
@@ -5875,10 +5877,6 @@ impl Widget for RoomScreen {
         // uid, so route them the same as the overlay pane's.
         let info_content_widget_uid = self.room_info_sliding_pane(cx, ids!(info_content)).widget_uid();
         let loading_pane = self.loading_pane(cx, ids!(loading_pane));
-        set_room_info_action_modal_open(
-            self.view.modal(cx, ids!(report_room_modal)).is_open()
-                || self.view.modal(cx, ids!(leave_room_confirm_modal)).is_open()
-        );
 
         // Streaming animation frame handler
         if let Some(_ne) = self.streaming_next_frame.is_event(event) {
@@ -6145,22 +6143,6 @@ impl Widget for RoomScreen {
                     RoomTopBarAction::None => {}
                 }
 
-                if let Some(RoomsListAction::Selected(selected_room)) = action.downcast_ref() {
-                    if self.timeline_kind.as_ref() != selected_room.timeline_kind().as_ref() {
-                        self.close_report_room_modal(cx);
-                        self.close_leave_room_confirm_modal(cx);
-                    }
-                }
-                if let Some(AppStateAction::RoomFocused(selected_room)) = action.downcast_ref() {
-                    if self.timeline_kind.as_ref() != selected_room.timeline_kind().as_ref() {
-                        self.close_report_room_modal(cx);
-                        self.close_leave_room_confirm_modal(cx);
-                    }
-                }
-                if let Some(AppStateAction::FocusNone) = action.downcast_ref() {
-                    self.close_report_room_modal(cx);
-                    self.close_leave_room_confirm_modal(cx);
-                }
                 if let Some(AppStateAction::AgentRegistryUpdated) = action.downcast_ref() {
                     if room_info_sliding_pane.is_currently_shown(cx) {
                         self.refresh_room_info_pane(cx, scope.data.get::<AppState>());
@@ -6243,32 +6225,6 @@ impl Widget for RoomScreen {
                                 }),
                             ],
                             auto_dismissal_duration: None,
-                            ..Default::default()
-                        });
-                    }
-                }
-                if let Some(ReportRoomResultAction::Sent { room_id }) = action.downcast_ref() {
-                    if self.room_name_id.as_ref().is_some_and(|rn| rn.room_id() == room_id) {
-                        enqueue_popup_notification(
-                            "Room reported successfully.",
-                            PopupKind::Success,
-                            Some(4.0),
-                        );
-                    }
-                }
-                if let Some(ReportRoomResultAction::Failed { room_id, error }) = action.downcast_ref() {
-                    if self.room_name_id.as_ref().is_some_and(|rn| rn.room_id() == room_id) {
-                        let error_display = error.to_string();
-                        enqueue_notification(NotificationItem {
-                            kind: PopupKind::Error,
-                            title: Some("Report failed".into()),
-                            message: format!("Failed to report room.\n\nError: {error}").into(),
-                            actions: vec![
-                                NotificationAction::new("Copy details", NotifActionStyle::Neutral, move |cx| {
-                                    cx.copy_to_clipboard(&error_display);
-                                }),
-                            ],
-                            auto_dismissal_duration: Some(5.0),
                             ..Default::default()
                         });
                     }
@@ -6379,10 +6335,37 @@ impl Widget for RoomScreen {
                         );
                     }
                     RoomInfoPaneAction::ReportRoom => {
-                        self.open_report_room_modal(cx);
+                        // Open the GLOBAL report modal (app root) so it survives
+                        // mobile<->desktop AdaptiveView rebuilds. Carry the room.
+                        if let Some(room_name_id) = self.room_name_id.clone() {
+                            cx.action(ReportRoomModalAction::Open {
+                                room_id: room_name_id.room_id().clone(),
+                                room_name_id,
+                            });
+                        }
                     }
                     RoomInfoPaneAction::LeaveRoom => {
-                        self.open_leave_room_confirm_modal(cx);
+                        // Route to the GLOBAL delete-confirmation modal (app root)
+                        // so it survives mobile<->desktop AdaptiveView rebuilds.
+                        // The room_id is captured in the accept callback.
+                        if let Some(room_id) = self.room_id().cloned() {
+                            let room_name = self
+                                .room_name_id
+                                .as_ref()
+                                .map(|r| r.to_string())
+                                .unwrap_or_default();
+                            let content = ConfirmationModalContent {
+                                title_text: String::from("Leave Room").into(),
+                                body_text: format!("Are you sure you want to leave {room_name}?").into(),
+                                accept_button_text: Some(String::from("Leave").into()),
+                                cancel_button_text: Some(String::from("Cancel").into()),
+                                on_accept_clicked: Some(Box::new(move |_cx| {
+                                    submit_async_request(MatrixRequest::LeaveRoom { room_id });
+                                })),
+                                ..Default::default()
+                            };
+                            cx.action(ConfirmDeleteAction::Show(RefCell::new(Some(content))));
+                        }
                     }
                     // Bubbled by the pane itself into `OpenPeopleProfile`
                     // (handled above); nothing to do here.
@@ -6534,9 +6517,9 @@ impl Widget for RoomScreen {
         // We check which overlay views are visible in the order of those views' z-ordering,
         // such that the top-most views get a chance to handle the event first.
         //
-        let room_info_action_modal_open =
-            self.view.modal(cx, ids!(report_room_modal)).is_open()
-            || self.view.modal(cx, ids!(leave_room_confirm_modal)).is_open();
+        // Report / leave-confirm are now GLOBAL modals (app root); the flag is
+        // maintained by app.rs. Read it so the pane still yields correctly.
+        let room_info_action_modal_open = is_room_info_action_modal_open();
         let is_interactive_hit = utils::is_interactive_hit_event(event);
         let is_pane_shown: bool;
         if room_info_action_modal_open {
@@ -6588,9 +6571,6 @@ impl Widget for RoomScreen {
             } else {
                 Scope::with_props(&room_props)
             };
-            let leave_room_confirm_modal_uid = self
-                .confirmation_modal(cx, ids!(leave_room_confirm_modal_inner))
-                .widget_uid();
 
 
             // Forward the event to the inner timeline view, but capture any actions it produces
@@ -6791,42 +6771,6 @@ impl Widget for RoomScreen {
                         return false;
                     }
                     None => {}
-                }
-
-                match action.downcast_ref::<ReportRoomModalAction>() {
-                    Some(ReportRoomModalAction::Close) => {
-                        self.close_report_room_modal(cx);
-                        return false;
-                    }
-                    Some(ReportRoomModalAction::Submit(reason)) => {
-                        let Some(room_id) = self.room_id().cloned() else {
-                            self.close_report_room_modal(cx);
-                            return false;
-                        };
-                        submit_async_request(MatrixRequest::ReportRoom {
-                            room_id,
-                            reason: reason.clone(),
-                        });
-                        self.close_report_room_modal(cx);
-                        return false;
-                    }
-                    None => {}
-                }
-
-                if let ConfirmationModalAction::Close(accepted) = action
-                    .as_widget_action()
-                    .widget_uid_eq(leave_room_confirm_modal_uid)
-                    .cast()
-                {
-                    self.close_leave_room_confirm_modal(cx);
-                    if accepted {
-                        if let Some(room_id) = self.room_id().cloned() {
-                            submit_async_request(MatrixRequest::LeaveRoom {
-                                room_id,
-                            });
-                        }
-                    }
-                    return false;
                 }
 
                 if let MessageAction::ToggleAppServiceActions = action
@@ -7657,14 +7601,6 @@ impl RoomScreen {
         self.view.modal(cx, ids!(delete_bot_modal)).close(cx);
     }
 
-    fn close_report_room_modal(&self, cx: &mut Cx) {
-        self.view.modal(cx, ids!(report_room_modal)).close(cx);
-    }
-
-    fn close_leave_room_confirm_modal(&self, cx: &mut Cx) {
-        self.view.modal(cx, ids!(leave_room_confirm_modal)).close(cx);
-    }
-
     fn open_create_bot_modal(&mut self, cx: &mut Cx) {
         let Some(room_name_id) = self.room_name_id.clone() else {
             return;
@@ -7687,38 +7623,10 @@ impl RoomScreen {
         self.view.modal(cx, ids!(delete_bot_modal)).open(cx);
     }
 
-    fn open_report_room_modal(&mut self, cx: &mut Cx) {
-        let Some(room_name_id) = self.room_name_id.as_ref() else {
-            return;
-        };
-        self.view
-            .report_room_modal(cx, ids!(report_room_modal_inner))
-            .show(cx, room_name_id);
-        self.view.modal(cx, ids!(report_room_modal)).open(cx);
-    }
-
-    fn open_leave_room_confirm_modal(&mut self, cx: &mut Cx) {
-        let Some(room_name_id) = self.room_name_id.as_ref() else {
-            return;
-        };
-        self.view
-            .confirmation_modal(cx, ids!(leave_room_confirm_modal_inner))
-            .show(cx, ConfirmationModalContent {
-                title_text: String::from("Leave Room").into(),
-                body_text: format!("Are you sure you want to leave {}?", room_name_id).into(),
-                accept_button_text: Some(String::from("Leave").into()),
-                cancel_button_text: Some(String::from("Cancel").into()),
-                ..Default::default()
-            });
-        self.view.modal(cx, ids!(leave_room_confirm_modal)).open(cx);
-    }
-
     fn reset_app_service_ui(&mut self, cx: &mut Cx) {
         self.set_app_service_actions_visible(cx, false);
         self.close_create_bot_modal(cx);
         self.close_delete_bot_modal(cx);
-        self.close_report_room_modal(cx);
-        self.close_leave_room_confirm_modal(cx);
     }
 
     fn resolved_app_service_bot_user_id(

--- a/src/home/room_settings_modal.rs
+++ b/src/home/room_settings_modal.rs
@@ -13,18 +13,24 @@ script_mod! {
     use mod.widgets.*
 
     mod.widgets.RoomSettingsModal = #(RoomSettingsModal::register_widget(vm)) {
-        width: Fit
+        width: Fill { max: 680 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
-        RoundedView {
-            width: 680
+        RoundedShadowView {
+            width: Fill
             height: Fit
             flow: Down
             padding: Inset{top: 0, right: 0, bottom: 0, left: 0}
             show_bg: true
             draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 6.0
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
             }
 
             // ── Title bar ────────────────────────────────────────────────
@@ -41,7 +47,7 @@ script_mod! {
                     height: Fit
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 13}
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                     text: "Room Settings"
                 }

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -16,18 +16,26 @@ script_mod! {
 
 
     mod.widgets.JoinLeaveRoomModal = #(JoinLeaveRoomModal::register_widget(vm)) {
-        width: Fit
+        width: Fill { max: 400 }
         height: Fit
+        margin: Inset{left: 12, right: 12}
 
-        RoundedView {
+        RoundedShadowView {
             flow: Down
-            width: 400
+            width: Fill
             height: Fit
             padding: Inset{top: 30, right: 40, bottom: 20, left: 40}
 
             show_bg: true
-            draw_bg.color: (COLOR_PRIMARY)
-            draw_bg.border_radius: 4.0
+            draw_bg +: {
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
+            }
 
             title_view := View {
                 width: Fill,
@@ -39,7 +47,7 @@ script_mod! {
                     flow: Flow.Right{wrap: true},
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                 }
             }

--- a/src/logout/logout_confirm_modal.rs
+++ b/src/logout/logout_confirm_modal.rs
@@ -10,22 +10,35 @@ script_mod! {
     use mod.widgets.*
 
 
-    // A modal dialog that displays logout confirmation
+    // A modal dialog that displays logout confirmation.
+    // Responsive width via `Fill { max: 400 }` (caps at 400 on desktop, shrinks
+    // on narrow screens) — NOT a manual width sync, which previously caused a
+    // big→small shrink loop. Card uses the shared unified modal recipe
+    // (RoundedShadowView + RBX tokens), matching ConfirmationModal.
     mod.widgets.LogoutConfirmModal = #(LogoutConfirmModal::register_widget(vm)) {
-        width: Fit,
+        width: Fill { max: 400 },
         height: Fit,
+        margin: Inset{left: 12, right: 12}
 
-        modal_card := RoundedView {
-            width: 400,
+        modal_card := RoundedShadowView {
+            width: Fill,
             height: Fit,
             flow: Down,
             align: Align{x: 0.5},
-            padding: 25,
+            padding: 24,
             margin: 0
             spacing: 10,
 
             show_bg: true,
-            draw_bg.color: (COLOR_PRIMARY)
+            draw_bg +: {
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
+            }
 
             View {
                 width: Fill,
@@ -38,7 +51,7 @@ script_mod! {
                     text: "Confirm Logout",
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 18},
-                        color: #000000
+                        color: (RBX_FG_PRIMARY)
                     }
                 }
             }
@@ -51,7 +64,7 @@ script_mod! {
                     text_style: REGULAR_TEXT {
                         font_size: 14,
                     },
-                    color: #000000,
+                    color: (RBX_FG_PRIMARY),
                 },
                 text: "Are you sure you want to logout?"
             }
@@ -86,7 +99,6 @@ script_mod! {
 #[derive(Script, ScriptHook, Widget)]
 pub struct LogoutConfirmModal {
     #[deref] view: View,
-    #[rust] modal_width: f64,
     /// Whether the modal is in a final state, meaning the user can only click "Okay" to close it.
     ///
     /// * Set to `Some(true)` after a successful logout Action
@@ -169,7 +181,6 @@ pub enum ClearedComponentType {
 
 impl Widget for LogoutConfirmModal {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.sync_modal_layout(cx);
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
     }
@@ -295,23 +306,6 @@ impl WidgetMatchEvent for LogoutConfirmModal {
 }
 
 impl LogoutConfirmModal {
-    fn sync_modal_layout(&mut self, cx: &mut Cx) {
-        let rect = self.view.area().rect(cx);
-        if rect.size.x <= 1.0 {
-            return;
-        }
-        let available_width = (rect.size.x - 28.0).max(280.0);
-        let modal_width = available_width.min(400.0);
-        if (self.modal_width - modal_width).abs() <= 0.5 {
-            return;
-        }
-        self.modal_width = modal_width;
-        let mut modal_card = self.view.view(cx, ids!(modal_card));
-        script_apply_eval!(cx, modal_card, {
-            width: #(modal_width)
-        });
-    }
-
     /// Sets the message text displayed in the body of the modal.
     pub fn set_message(&mut self, cx: &mut Cx, message: &str) {
         self.label(cx, ids!(message)).set_text(cx, message);

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -19,30 +19,39 @@ script_mod! {
         height: Fit
         margin: Inset{left: 12, right: 12}
 
-        wrapper := RoundedView {
+        // Unified modal card: white RBX surface, soft border, and a drop shadow
+        // so the dialog reads as an elevated sheet above the scrim. This one
+        // recipe (RoundedShadowView + RBX tokens) is the shared visual all
+        // confirm-style modals inherit (Positive/Negative variants below).
+        wrapper := RoundedShadowView {
             width: Fill
             height: Fit
             align: Align{x: 0.5}
             flow: Down
-            padding: Inset{top: 28, right: 28, bottom: 18, left: 28}
+            padding: Inset{top: 24, right: 24, bottom: 16, left: 24}
 
             show_bg: true
             draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 4.0
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+                shadow_color: (RBX_SHADOW_STRONG)
+                shadow_radius: 10.0
+                shadow_offset: vec2(0.0, 3.0)
             }
 
             title_view := View {
                 width: Fill,
                 height: Fit,
-                padding: Inset{top: 0, bottom: 25}
+                padding: Inset{top: 0, bottom: 20}
                 align: Align{x: 0.5, y: 0.0}
 
                 title := Label {
                     flow: Flow.Right{wrap: true},
                     draw_text +: {
                         text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                 }
             }
@@ -56,7 +65,7 @@ script_mod! {
                     flow: Flow.Right{wrap: true},
                     draw_text +: {
                         text_style: REGULAR_TEXT {font_size: 11.5},
-                        color: #000
+                        color: (RBX_FG_PRIMARY)
                     }
                 }
             }


### PR DESCRIPTION
## What

Unifies the modal look across the app and fixes several modal bugs surfaced during testing.

### Visual unification
- **Shared `ConfirmationModal`** restyled to one card recipe (`RoundedShadowView` + RBX tokens: `RBX_BG_SURFACE` / `RBX_RADIUS_SM` / soft stroke / subtle shadow). Upgrades **invite / positive / delete / leave** confirm dialogs at once.
- **Room modals** (`room_settings`, `invite`, `join_leave`, `create_room`, `start_chat`, `report`) reskinned to the same recipe; titles moved off bare `#000` to `RBX_FG_PRIMARY`. Radius matches the app's cards (`RBX_RADIUS_SM` = 6, not the too-round 12/16).

### Bug fixes
- **Logout "big→small" glitch**: `logout_confirm_modal` had a `sync_modal_layout` that read its own `Fit` width and fed it back into its card width, shrinking it 400→372→…→280 over several frames. Removed the loop; uses `width: Fill { max: 400 }`.
- **Leave-room confirm not showing**: `NegativeConfirmationModal` (`width: Fill { max }`) inside a default `Fit` Modal content collapsed to 0 width. Fixed.
- **Mobile overflow**: fixed-width room modals (400/430/680) overflowed on mobile. Now `Fill { max: N }` + side margin + `Fill`/center content — capped on desktop, fits on mobile.

### Mobile↔desktop freeze (issue 2)
Per-`RoomScreen` modals are destroyed when the `AdaptiveView` rebuilds `MainDesktopUI` / mobile room views on a breakpoint cross (those aren't `CachedWidget`-wrapped), freezing any open modal. The two most common room-info-pane modals are moved to **app-root single instances**:
- **Leave** → routes to the global `delete_confirmation_modal` via `ConfirmDeleteAction::Show` with a `room_id` accept callback.
- **Report** → global `report_room_modal`; `App` tracks `pending_report_room_id` and handles `ReportRoomResultAction`.
- The room-info-pane close gate (`ROOM_INFO_ACTION_MODAL_OPEN`) is now maintained by `app.rs` from the global modals' open state, so the pane still won't self-close on Esc/tap-outside while a confirm is open over it.

### Intentionally left as-is
`create/delete-bot` and `translation-lang` modals stay per-`RoomScreen` — their submit/positioning logic is tightly coupled to room state, and their only failure mode is the rare case of being open exactly when the window crosses the mobile/desktop breakpoint.

## Testing
- `cargo build` clean against latest `main`.
- Manually verified: logout no longer shrinks; leave/report dialogs show, submit/cancel work, and survive a mobile↔desktop resize; room modals fit on mobile; confirm/logout radius+shadow match other cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)