### PR TITLE
feat(demo): deterministic Palpo profile + workflow conventions (FSF0-A)

### DIFF
--- a/roadmap/agentchat-demo/.gitignore
+++ b/roadmap/agentchat-demo/.gitignore
@@ -1,0 +1,8 @@
+palpo/.env
+palpo/.runtime/
+palpo/*.token
+palpo/*.log
+palpo/*.db
+palpo/*.sqlite*
+palpo/**/data/
+

--- a/roadmap/agentchat-demo/README.md
+++ b/roadmap/agentchat-demo/README.md
@@ -83,6 +83,18 @@ The artifacts were adversarially audited against the agent-chat code; fixes appl
 
 ## Quick start
 
+The FSF-0 deterministic Palpo substrate is maintained separately under
+[`palpo/`](palpo/README.md). Its contract suite is the default infrastructure
+preflight and starts no container or agent:
+
+```bash
+node --test roadmap/agentchat-demo/palpo/tests/*.test.mjs
+```
+
+Render and start the real `palpo-local` profile only through the operator
+commands in `palpo/README.md`; both local and team-server settings use the same
+Compose file.
+
 ```bash
 cd roadmap/agentchat-demo
 # 1. Fill agent-chat/.env from agent-chat.env.demo

--- a/roadmap/agentchat-demo/issue-workflow/SKILL.md
+++ b/roadmap/agentchat-demo/issue-workflow/SKILL.md
@@ -314,3 +314,163 @@ PATH and the cowork CLI works runtime-agnostically.)
 - For demo visibility, prefer `post(group=GROUP, mentions=[...])` over private
   `send_message` so the human sees the coordinator↔implementer↔reviewer loop.
 - Persist `state.json` after every transition so `/status` and restarts are sane.
+
+---
+
+## GitHub integration convention (gh) — optional mirror, NEVER a blocker
+
+Mirrors each room issue to a GitHub issue and delivers completed work as a PR,
+using the `gh` CLI that every worker already has. The room + local files stay
+the source of truth; GitHub is a mirror. **No GitHub failure may ever block,
+fail, or delay the local workflow** — on any error, record it, post one room
+note, and continue exactly as before.
+
+### Activation check (coordinator runs once per issue, cache in state.json)
+GitHub steps activate only when ALL of these hold in the shared workspace:
+1. `gh repo view --json nameWithOwner -q .nameWithOwner` succeeds (a GitHub remote exists);
+2. `gh auth status` succeeds;
+3. `state.json` does not contain `"github": "off"` (operator kill-switch).
+
+If any check fails: write `- **GitHub:** none (<short reason>)` into the issue
+file, post ONE room note, and never retry within this issue. Attribution note:
+`gh` acts as the local operator's account (or a `GH_TOKEN` the operator set in
+the agent env). Never read, store, or echo tokens.
+
+### Coordinator hooks
+- **At `/create-issue` step 1**, right after writing `issues/NNN-<slug>.md`:
+  idempotency first — `gh issue list --search "\"[<TEAM>-NNN]\" in:title" --json number`
+  (safe on retries/429s); only if empty:
+  ```bash
+  gh issue create --title "[<TEAM>-NNN] <title>" --body-file issues/NNN-<slug>.md
+  ```
+  Then add `- **GitHub:** #<num>` as a metadata line directly under the
+  `- **Type:**` line, mirror `"github_issue": <num>` into this issue's
+  `state.json` object, and include `GH#<num>` in the step-5 approval `post`.
+- **At `/go` step 6 on final APPROVE** (after the Codex gate — never before):
+  delegate PR opening to the implementer (it owns the working tree):
+  ```
+  send_message(to="<TEAM>_implementer", type="request",
+    summary="Open PR for issue NNN",
+    full="Final gate approved. Push branch and open the PR per the gh convention; reply with PR number + URL.")
+  ```
+  On the implementer's PR reply: `gh issue comment <num> --body "Delivered in PR #<pr>"`,
+  add `- **PR:** #<pr>` to the issue file, and make the completion post
+  `"Issue NNN complete ✅ → PR #<pr> <url>"`.
+- **On escalation** (3 failed rounds → human): if a GH issue exists, mirror the
+  escalation note with `gh issue comment`.
+
+### Implementer hooks
+- **Before the first edit** for issue NNN (github active): create/switch to
+  branch `agent/<TEAM>-NNN-<slug>` from current HEAD. Exception: if the shared
+  workspace already has UNRELATED uncommitted work, do NOT branch and do NOT
+  stash anyone's work — report `pr: blocked-dirty-worktree` in your reply and
+  let the human decide; the issue still completes locally as usual.
+- **On the coordinator's "Open PR" request**: commit the issue-scoped changes
+  with an explicit file list (message `<type>(NNN): <title>`), then:
+  ```bash
+  git push -u origin agent/<TEAM>-NNN-<slug>
+  gh pr create --title "[<TEAM>-NNN] <title>" --body "<template below>"
+  ```
+  PR body template: Spec + Plan paths; one-line verdict summaries from BOTH
+  reviewers; test evidence line (commands + counts); `Closes #<gh-issue>`;
+  footer `🤖 via agent-chat issue-workflow`. Reply PR number + URL to the
+  coordinator.
+- **Hard limits:** NEVER `gh pr merge` (merging is the human's decision or repo
+  policy — not yours), never force-push, never edit PRs you didn't open, no
+  `gh` mutations beyond issue/PR create + comment.
+
+### Reviewer / final-reviewer hooks (cheap, optional)
+When github is active and a PR already exists (re-review of a delivered issue),
+mirror your verdict with `gh pr comment <pr> --body "<verdict + top findings>"`.
+The room verdict remains authoritative; the GH comment is a mirror.
+
+### Bookkeeping invariants
+- Every GH artifact title starts with `[<TEAM>-NNN]` — that prefix is what makes the
+  idempotency searches safe.
+- The issue file carries `- **GitHub:** #N` and `- **PR:** #N` metadata lines
+  (parseable by the Workflow Board later); `state.json` mirrors both numbers.
+- One GH issue and at most one open PR per room issue; a re-run after `reject`
+  pushes to the SAME branch/PR, never opens a second one.
+
+---
+
+## Multi-member collaboration convention (one member, one room, one worktree)
+
+Multiple humans can collaborate on ONE project with THEIR OWN agent teams —
+without sharing a workspace or a room. The integration point is git (PRs), not
+a shared directory.
+
+### Topology
+
+```text
+Project P (GitHub repo = integration source of truth)
+ ├─ Room A (Alex) → team wf   → worktree P-wf   (branch team/wf)   → PRs
+ ├─ Room B (Bob)  → team bob  → worktree P-bob  (branch team/bob)  → PRs
+ └─ Optional main room: humans only — discussion + PR notifications, NO group binding
+```
+
+Rules:
+- **One room ↔ one team ↔ one worktree.** Never bind two teams to one room, and
+  never point two teams at the same working directory. Cross-team integration
+  happens ONLY through PRs on the shared GitHub repo.
+- **Always provision the full 4-role team** (coordinator/implementer/reviewer/
+  final_reviewer). Partial teams hit the single-member default-wake edge case
+  and break the review chain.
+- Issue ids are per-worktree (each team scans its own `issues/`), and all GitHub
+  artifacts are team-namespaced (`[<TEAM>-NNN]` titles, `agent/<TEAM>-NNN-<slug>`
+  branches — see the gh convention above), so nothing collides across teams.
+- Never message or peek another team's agents (the existing TEAM-prefix rule).
+
+### Member onboarding (provision-team)
+
+One command creates the worktree and the four agent homes with the worktree
+symlink-mounted into each agent's `workdir/projects/`:
+
+```bash
+node scripts/provision-team.mjs --team bob --project /path/to/project
+# options: --branch team/bob  --worktree <path>  --final-type codex  --dry-run
+```
+
+It deliberately does NOT touch secrets or the backend. The printed next steps
+are explicit operator actions:
+1. Register the Matrix accounts for the new agents (register-accounts.mjs).
+2. Mint agent tokens (hard mode) BEFORE backend registration.
+3. `POST /api/agents` + `POST /api/agents/<name>/start` for each agent.
+4. In the member's room: invite `<team>_coordinator` (the observer bot follows
+   automatically), then `!mkgroup <group> <team>_coordinator <team>_implementer
+   <team>_reviewer <team>_final_reviewer`.
+
+### Keeping the worktree healthy
+
+- The team branch (`team/<team>`) is the member's integration line; per-issue
+  branches (`agent/<TEAM>-NNN-<slug>`) fork from it and PR back to the shared
+  default branch per the gh convention.
+- Rebase/sync of `team/<team>` onto upstream default is a HUMAN decision — the
+  coordinator may post a reminder when the branch falls behind, but agents never
+  rebase or force-push on their own.
+- If the worktree is deleted, re-provisioning is NOT automatic recovery: check
+  `git -C <project> worktree list` and prune stale entries first.
+
+### Shared-room variant (all members' coordinators in ONE room)
+
+When the whole team prefers a single shared Matrix room instead of one room per
+member (agent-chat instances stay one-per-member on each member's machine;
+Palpo is the shared cloud homeserver):
+
+1. **Every member's bridge sets `MATRIX_DEFAULT_WAKE=off`** for this deployment.
+   Without it, each instance sees "exactly one of my agents in the room" and
+   wakes its own coordinator on every unaddressed message — four coordinators
+   answering every line of chatter.
+2. Commands are therefore ALWAYS mention-addressed: `@ac_<team>_coordinator
+   /create-issue …`. Unaddressed messages are stored for the room but wake
+   nobody.
+3. Each member binds the SAME room to their OWN group with `!bindroom <team>`
+   (tier-2 command; the room must already exist — `!mkgroup` would create a new
+   one). Each bridge keeps its own local binding; they do not conflict.
+4. Each member's `MATRIX_IGNORED_SENDER_MXIDS` lists the OTHER members' bridge
+   bots and agents (prevents cross-instance routing loops). Bridge bots are
+   per-member: `MATRIX_BOT_USERNAME=agent-bridge-<team>`; Robrix auto-invites
+   `agent-bridge-<team>` (derived from the invited agent's name) plus the
+   legacy `agent-bridge` as best-effort fallback.
+5. Everything else (worktree-or-clone per member, `[<TEAM>-NNN]` GitHub
+   namespacing, PR integration) is identical to the one-room-per-member form.

--- a/roadmap/agentchat-demo/palpo/.env.example
+++ b/roadmap/agentchat-demo/palpo/.env.example
@@ -1,0 +1,19 @@
+# Copy to a private env file or export these values in the operator shell.
+PALPO_SERVER_NAME=127.0.0.1:8128
+PALPO_PUBLIC_URL=http://127.0.0.1:8128
+PALPO_HOST_PORT=8128
+PALPO_DB_HOST=palpo-postgres
+PALPO_DB_PORT=5432
+PALPO_DB_NAME=palpo
+PALPO_DB_USER=palpo
+PALPO_DB_PASSWORD='<generate-a-private-database-password>'
+PALPO_APPSERVICE_URL=http://host.docker.internal:8091
+PALPO_AS_TOKEN='<generate-with-openssl-rand-hex-32>'
+PALPO_HS_TOKEN='<generate-with-openssl-rand-hex-32>'
+PALPO_REGISTRATION_TOKEN='<generate-with-openssl-rand-hex-32>'
+PALPO_SENDER_LOCALPART=_agentchat_appservice
+PALPO_ADMIN_USER=admin
+PALPO_ADMIN_PASSWORD='<generate-a-private-admin-password>'
+PALPO_BOT_USER=agent-bridge
+PALPO_BOT_PASSWORD='<generate-a-private-bot-password>'
+PALPO_RUNTIME_DIR=./.runtime

--- a/roadmap/agentchat-demo/palpo/FSF0-A-IMPLEMENTATION-PLAN.md
+++ b/roadmap/agentchat-demo/palpo/FSF0-A-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,217 @@
+# FSF-0A Palpo Deployment Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide a deterministic local/team Palpo profile with generated
+appservice configuration, idempotent account bootstrap, machine-readable doctor
+checks, and a safe reset path.
+
+**Architecture:** Keep all new deployment artifacts under
+`roadmap/agentchat-demo/palpo/`. A Node configuration tool renders TOML/YAML from
+validated environment values into an ignored runtime directory. Docker Compose
+consumes only rendered files. Node's built-in test runner uses fake Matrix HTTP
+servers and temporary directories, so default verification never starts Palpo,
+Docker, Claude, or an agent runtime.
+
+**Tech Stack:** Docker Compose, POSIX shell, Node.js ESM and `node:test`, Palpo
+Matrix Client-Server API.
+
+## Global Constraints
+
+- Do not modify the existing Makepad UI files or run `cargo fmt`/`rustfmt`.
+- Do not commit real tokens, passwords, access tokens, or signing keys.
+- Local and team profiles use the same Compose file and rendered templates.
+- Tests must not start Docker, Palpo, Claude, agent-chat, Matrix, or remote services.
+- Real container execution remains an explicit operator action after tests pass.
+
+---
+
+### Task 1: Deterministic Configuration Renderer
+
+**Files:**
+- Create: `roadmap/agentchat-demo/palpo/.env.example`
+- Create: `roadmap/agentchat-demo/palpo/templates/palpo.toml.tpl`
+- Create: `roadmap/agentchat-demo/palpo/templates/appservice-agentchat.yaml.tpl`
+- Create: `roadmap/agentchat-demo/palpo/palpo-config.mjs`
+- Test: `roadmap/agentchat-demo/palpo/tests/palpo-config.test.mjs`
+
+**Interfaces:**
+- Consumes: validated environment values and an explicit output directory.
+- Produces: `renderConfig({ env, outputDir })` and immutable rendered
+`palpo.toml`, `appservice-agentchat.yaml`, and `deployment.json` files. Palpo
+registration is token-gated; open dummy registration is forbidden.
+
+- [x] **Step 1: Write renderer failure tests**
+
+Test missing/placeholder secrets, invalid port/server names, unsafe YAML/TOML
+characters, and token leakage in `deployment.json`.
+
+- [x] **Step 2: Run tests and observe missing module failure**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/palpo-config.test.mjs`
+Expected: FAIL because `palpo-config.mjs` does not exist.
+
+- [x] **Step 3: Implement strict rendering**
+
+Validate server name, public URL, port, database values, appservice URL, sender
+localpart, and two non-placeholder secrets. Replace only closed template markers;
+write files with mode `0600`; store only SHA-256 secret fingerprints in
+`deployment.json`.
+
+- [x] **Step 4: Run renderer tests**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/palpo-config.test.mjs`
+Expected: PASS.
+
+### Task 2: Parameterized Compose Profile
+
+**Files:**
+- Create: `roadmap/agentchat-demo/palpo/compose.yml`
+- Create: `roadmap/agentchat-demo/palpo/README.md`
+- Modify: `roadmap/agentchat-demo/.gitignore`
+- Test: `roadmap/agentchat-demo/palpo/tests/compose-contract.test.mjs`
+
+**Interfaces:**
+- Consumes: rendered config directory and the existing
+  `palpo-and-octos-deploy/palpo.Dockerfile` build context.
+- Produces: `palpo-local` Compose profile with healthy Postgres and Palpo
+  services, parameterized host port/data/config paths, and no embedded secret.
+
+- [x] **Step 1: Write Compose contract test**
+
+Verify the profile name, health dependencies, read-only config/appservice
+mounts, parameterized host port, and absence of literal token/password values.
+
+- [x] **Step 2: Run test and observe missing Compose failure**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/compose-contract.test.mjs`
+Expected: FAIL because `compose.yml` does not exist.
+
+- [x] **Step 3: Add Compose and operator documentation**
+
+Use one profile for local and team-server settings. Document render, start,
+doctor, stop, and reset commands without invoking agent runtimes.
+
+- [x] **Step 4: Run Compose contract test**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/compose-contract.test.mjs`
+Expected: PASS.
+
+### Task 3: Idempotent Account Bootstrap
+
+**Files:**
+- Create: `roadmap/agentchat-demo/palpo/bootstrap-accounts.mjs`
+- Test: `roadmap/agentchat-demo/palpo/tests/bootstrap-accounts.test.mjs`
+
+**Interfaces:**
+- Consumes: homeserver URL plus explicit account name/password list.
+- Produces: `bootstrapAccounts({ homeserver, accounts, registrationToken,
+  promoteAdmin, fetchImpl })` with one result per account and no printed
+  password/access token. The CLI promotes the configured first admin with one
+  bounded, idempotent update through the local Compose Postgres service.
+
+- [x] **Step 1: Write fake-homeserver tests**
+
+Cover token-gated first registration, second-run login without another account,
+registration race, wrong existing password, admin promotion, and partial failure
+continuation.
+
+- [x] **Step 2: Run test and observe missing module failure**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/bootstrap-accounts.test.mjs`
+Expected: FAIL because bootstrap module does not exist.
+
+- [x] **Step 3: Implement Matrix dummy-registration/login flow**
+
+Try password login first; register through `m.login.registration_token` only
+when absent; retry login after an `M_USER_IN_USE` race; promote and verify the
+configured admin; return redacted structured results.
+
+- [x] **Step 4: Run bootstrap tests**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/bootstrap-accounts.test.mjs`
+Expected: PASS.
+
+### Task 4: Doctor and Safe Reset
+
+**Files:**
+- Create: `roadmap/agentchat-demo/palpo/demo-doctor.mjs`
+- Create: `roadmap/agentchat-demo/palpo/demo-reset.sh`
+- Test: `roadmap/agentchat-demo/palpo/tests/demo-doctor.test.mjs`
+- Test: `roadmap/agentchat-demo/palpo/tests/reset-contract.test.mjs`
+
+**Interfaces:**
+- Consumes: rendered deployment manifest, homeserver URL, account credentials,
+  and injected fetch/command functions.
+- Produces: `runDoctor` JSON/text checks for homeserver, loaded appservice
+  credential, admin role, and bot login with non-zero failure status, plus a
+  reset command that requires an explicit state root plus confirmation flag.
+
+- [x] **Step 1: Write doctor/reset negative tests**
+
+Cover unreachable homeserver, appservice token fingerprint mismatch, missing bot
+account, wrong bot password, healthy state, path traversal, root/empty reset
+paths, and dry-run behavior.
+
+- [x] **Step 2: Run tests and observe missing module/script failures**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/demo-doctor.test.mjs roadmap/agentchat-demo/palpo/tests/reset-contract.test.mjs`
+Expected: FAIL.
+
+- [x] **Step 3: Implement structured doctor and guarded reset**
+
+Doctor reports exact failing dependency and emits JSON with no secrets. Reset
+runs Compose down, validates the state root is below the demo directory, removes
+only generated config/state, and is idempotent.
+
+- [x] **Step 4: Run doctor/reset tests**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/demo-doctor.test.mjs roadmap/agentchat-demo/palpo/tests/reset-contract.test.mjs`
+Expected: PASS.
+
+### Task 5: FSF-0 A Contract Verification
+
+**Files:**
+- Modify: `roadmap/agentchat-demo/palpo/README.md`
+- Modify: `roadmap/agentchat-demo/README.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-4 outputs and OpenFab
+  `specs/phase1/fsf0-a-palpo-deploy.spec.md`.
+- Produces: one default test command and exact operator commands for the opt-in
+  real profile.
+
+- [x] **Step 1: Run all Node tests**
+
+Run: `node --test roadmap/agentchat-demo/palpo/tests/*.test.mjs`
+Expected: unit/contract tests PASS and five real acceptance selectors are
+explicitly SKIPPED with no container started.
+
+- [x] **Step 2: Validate shell and configuration artifacts**
+
+Run: `bash -n roadmap/agentchat-demo/palpo/demo-reset.sh`
+Expected: PASS.
+
+Run: `docker compose -f roadmap/agentchat-demo/palpo/compose.yml config`
+Expected: PASS when Docker Compose is installed; otherwise record the tool as an
+operator preflight dependency without starting services.
+
+- [x] **Step 3: Validate the source task contract**
+
+Run: `agent-spec parse /Users/zhangalex/Work/Projects/FW/openfab/specs/phase1/fsf0-a-palpo-deploy.spec.md`
+
+Run: `agent-spec lint /Users/zhangalex/Work/Projects/FW/openfab/specs/phase1/fsf0-a-palpo-deploy.spec.md --min-score 0.7`
+
+Expected: parse succeeds and lint quality is 100%.
+
+- [ ] **Step 4: Present for user testing**
+
+Do not commit or open a PR. Report the exact render/start/doctor/reset commands
+and wait for user confirmation as required by the Robrix2 repository rules.
+
+The opt-in real acceptance command is:
+
+`PALPO_REAL_E2E=1 node --test roadmap/agentchat-demo/palpo/tests/real-e2e.test.mjs`
+
+It starts Docker/Palpo only, uses an isolated Compose project and runtime, and
+does not start Claude, Codex, agent-chat, or another agent runtime.

--- a/roadmap/agentchat-demo/palpo/README.md
+++ b/roadmap/agentchat-demo/palpo/README.md
@@ -1,0 +1,72 @@
+# FSF-0 Palpo profile
+
+This directory owns the deterministic Palpo substrate used by the agent-chat
+demo. Default tests are hermetic: they do not start Docker, Palpo, an agent, or
+any remote service.
+
+## Prepare configuration
+
+```bash
+cd roadmap/agentchat-demo/palpo
+cp .env.example .env
+chmod 600 .env
+# Replace the six quoted placeholders. Generate each credential independently:
+openssl rand -hex 32
+
+set -a
+. ./.env
+set +a
+node palpo-config.mjs "$(pwd)/.runtime/config"
+```
+
+For a team server, use the same files and change `PALPO_SERVER_NAME`,
+`PALPO_PUBLIC_URL`, `PALPO_HOST_PORT`, and appservice URL in `.env`. Do not
+commit `.env` or `.runtime/`.
+
+## Start and stop
+
+The Palpo source must exist at
+`palpo-and-octos-deploy/repos/palpo`, matching the existing Dockerfile build
+context.
+
+```bash
+docker compose --env-file .env --profile palpo-local up -d --build --wait
+node bootstrap-accounts.mjs
+node demo-doctor.mjs --json
+docker compose --env-file .env --profile palpo-local down
+```
+
+Reset is deliberately separate from stop and requires explicit confirmation:
+
+```bash
+./demo-reset.sh --state-root "$(pwd)/.runtime" --confirm
+# A reset removes rendered config and Palpo/Postgres data. Render again before restart:
+node palpo-config.mjs "$(pwd)/.runtime/config"
+docker compose --env-file .env --profile palpo-local up -d --build --wait
+node bootstrap-accounts.mjs
+node demo-doctor.mjs --json
+```
+
+Registration is protected by `PALPO_REGISTRATION_TOKEN`; unrestricted open
+registration is disabled. The appservice sender is `_agentchat_appservice`,
+separate from the password-login bot `agent-bridge`. On first bootstrap, the
+admin account is registered through Matrix UIA and then promoted by one bounded
+`users.is_admin` update through the local Compose Postgres service. Doctor logs
+in with that account and verifies the role through Palpo's admin API.
+
+## Contract tests
+
+```bash
+node --test tests/*.test.mjs
+```
+
+The five FSF acceptance selectors are present in `tests/real-e2e.test.mjs` and
+are skipped by default. After reviewing the generated `.env`, run the isolated
+real profile explicitly:
+
+```bash
+PALPO_REAL_E2E=1 node --test tests/real-e2e.test.mjs
+```
+
+This starts Docker and Palpo, but no Claude, Codex, agent-chat, or other agent
+runtime.

--- a/roadmap/agentchat-demo/palpo/bootstrap-accounts.mjs
+++ b/roadmap/agentchat-demo/palpo/bootstrap-accounts.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function validateHomeserver(homeserver) {
+  let parsed;
+  try {
+    parsed = new URL(homeserver);
+  } catch {
+    throw new Error('homeserver must be an absolute HTTP(S) URL');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname) {
+    throw new Error('homeserver must be an absolute HTTP(S) URL');
+  }
+  return homeserver.replace(/\/$/, '');
+}
+
+function validateAccounts(accounts) {
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    throw new Error('accounts must contain at least one account');
+  }
+  return accounts.map((account) => {
+    const username = String(account.username ?? '').trim();
+    const password = String(account.password ?? '');
+    if (!/^[a-z0-9._=-]+$/i.test(username)) throw new Error(`invalid account username: ${username || '(empty)'}`);
+    if (password.length < 12 || /[<>]/.test(password)) throw new Error(`invalid password for ${username}`);
+    const role = account.role === 'admin' ? 'admin' : undefined;
+    return { username, password, role };
+  });
+}
+
+async function requestJson(fetchImpl, url, body) {
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  let payload = {};
+  try {
+    payload = await response.json();
+  } catch {
+    payload = {};
+  }
+  return { status: response.status, payload };
+}
+
+async function login(fetchImpl, homeserver, account) {
+  const response = await requestJson(fetchImpl, `${homeserver}/_matrix/client/v3/login`, {
+    type: 'm.login.password',
+    identifier: { type: 'm.id.user', user: account.username },
+    password: account.password,
+  });
+  if (response.status === 200 && response.payload.user_id) {
+    return { kind: 'ready', userId: response.payload.user_id };
+  }
+  if (response.status === 401 || response.status === 403) return { kind: 'not-ready' };
+  throw new Error(`login endpoint returned HTTP ${response.status}`);
+}
+
+async function loginAfterConflict(fetchImpl, homeserver, account) {
+  const retry = await login(fetchImpl, homeserver, account);
+  if (retry.kind === 'ready') {
+    return {
+      username: account.username,
+      userId: retry.userId,
+      ok: true,
+      status: 'existing-after-race',
+    };
+  }
+  return {
+    username: account.username,
+    ok: false,
+    status: 'password-mismatch',
+    error: 'account exists but its password does not match the configured credential',
+  };
+}
+
+async function bootstrapAccount(fetchImpl, homeserver, account, registrationToken) {
+  const initialLogin = await login(fetchImpl, homeserver, account);
+  if (initialLogin.kind === 'ready') {
+    return {
+      username: account.username,
+      userId: initialLogin.userId,
+      ok: true,
+      status: 'existing',
+    };
+  }
+
+  const probe = await requestJson(fetchImpl, `${homeserver}/_matrix/client/v3/register`, {
+    username: account.username,
+    password: account.password,
+  });
+  if (probe.status === 200 && probe.payload.user_id) {
+    return { username: account.username, userId: probe.payload.user_id, ok: true, status: 'created' };
+  }
+  if (probe.payload.errcode === 'M_USER_IN_USE') {
+    return loginAfterConflict(fetchImpl, homeserver, account);
+  }
+  const supportsRegistrationToken = probe.payload.flows?.some((flow) =>
+    flow.stages?.includes('m.login.registration_token'));
+  if (!probe.payload.session || !supportsRegistrationToken) {
+    throw new Error(`registration endpoint did not offer m.login.registration_token (HTTP ${probe.status})`);
+  }
+
+  const registration = await requestJson(fetchImpl, `${homeserver}/_matrix/client/v3/register`, {
+    username: account.username,
+    password: account.password,
+    auth: {
+      type: 'm.login.registration_token',
+      token: registrationToken,
+      session: probe.payload.session,
+    },
+  });
+  if (registration.status === 200 && registration.payload.user_id) {
+    return {
+      username: account.username,
+      userId: registration.payload.user_id,
+      ok: true,
+      status: 'created',
+    };
+  }
+  if (registration.payload.errcode === 'M_USER_IN_USE') {
+    return loginAfterConflict(fetchImpl, homeserver, account);
+  }
+  throw new Error(`registration failed with HTTP ${registration.status}`);
+}
+
+export async function bootstrapAccounts({
+  homeserver,
+  accounts,
+  registrationToken,
+  promoteAdmin,
+  fetchImpl = globalThis.fetch,
+}) {
+  const baseUrl = validateHomeserver(homeserver);
+  const validatedAccounts = validateAccounts(accounts);
+  if (typeof registrationToken !== 'string' || registrationToken.length < 16 || /[<>]/.test(registrationToken)) {
+    throw new Error('registrationToken must be a non-placeholder secret of at least 16 characters');
+  }
+  if (typeof fetchImpl !== 'function') throw new Error('fetchImpl must be a function');
+
+  const results = [];
+  for (const account of validatedAccounts) {
+    try {
+      const result = await bootstrapAccount(fetchImpl, baseUrl, account, registrationToken);
+      if (result.ok && account.role === 'admin') {
+        if (typeof promoteAdmin !== 'function') throw new Error('admin promotion is not configured');
+        try {
+          await promoteAdmin(account.username);
+          result.admin = true;
+        } catch {
+          result.ok = false;
+          result.status = 'admin-promotion-failed';
+          result.error = 'admin promotion failed';
+        }
+      }
+      results.push(result);
+    } catch (error) {
+      results.push({
+        username: account.username,
+        ok: false,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'unknown bootstrap failure',
+      });
+    }
+  }
+  return { ok: results.every((result) => result.ok), results };
+}
+
+function defaultRunCommand(command, args, options) {
+  return spawnSync(command, args, { ...options, encoding: 'utf8' });
+}
+
+export function createComposeAdminPromoter({
+  demoDir,
+  serverName,
+  dbUser = 'palpo',
+  dbName = 'palpo',
+  envFile = path.join(demoDir, '.env'),
+  projectName,
+  runCommand = defaultRunCommand,
+}) {
+  if (!path.isAbsolute(demoDir)) throw new Error('demoDir must be absolute');
+  if (!/^[a-z0-9.-]+(?::[0-9]{1,5})?$/i.test(serverName)) throw new Error('invalid serverName');
+  if (!/^[a-z0-9._=-]+$/i.test(dbUser) || !/^[a-z0-9._=-]+$/i.test(dbName)) {
+    throw new Error('invalid database identifier');
+  }
+
+  return async (username) => {
+    if (!/^[a-z0-9._=-]+$/.test(username)) throw new Error('invalid admin username');
+    const userId = `@${username}:${serverName}`;
+    const sql = `WITH promoted AS (UPDATE users SET is_admin = TRUE WHERE id = '${userId}' RETURNING is_admin) SELECT is_admin FROM promoted;`;
+    const composeArgs = ['compose'];
+    if (projectName) composeArgs.push('--project-name', projectName);
+    composeArgs.push(
+      '--env-file', envFile,
+      '-f', path.join(demoDir, 'compose.yml'),
+      '--profile', 'palpo-local',
+      'exec', '-T', 'palpo-postgres',
+      'psql', '-U', dbUser, '-d', dbName,
+      '-tA', '-v', 'ON_ERROR_STOP=1', '-c', sql,
+    );
+    const result = await runCommand('docker', composeArgs, { cwd: demoDir });
+    if (result.status !== 0) throw new Error('admin promotion command failed');
+    if (!String(result.stdout ?? '').split(/\s+/).includes('t')) {
+      throw new Error(`admin account ${userId} was not found`);
+    }
+  };
+}
+
+async function main() {
+  const accounts = [
+    { username: process.env.PALPO_ADMIN_USER, password: process.env.PALPO_ADMIN_PASSWORD, role: 'admin' },
+    { username: process.env.PALPO_BOT_USER, password: process.env.PALPO_BOT_PASSWORD },
+  ];
+  const result = await bootstrapAccounts({
+    homeserver: process.env.PALPO_PUBLIC_URL || 'http://127.0.0.1:8128',
+    accounts,
+    registrationToken: process.env.PALPO_REGISTRATION_TOKEN,
+    promoteAdmin: createComposeAdminPromoter({
+      demoDir: moduleDir,
+      serverName: process.env.PALPO_SERVER_NAME,
+      dbUser: process.env.PALPO_DB_USER || 'palpo',
+      dbName: process.env.PALPO_DB_NAME || 'palpo',
+    }),
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    process.stderr.write(`[bootstrap-accounts] ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/roadmap/agentchat-demo/palpo/compose.yml
+++ b/roadmap/agentchat-demo/palpo/compose.yml
@@ -1,0 +1,48 @@
+name: agentchat-palpo
+
+services:
+  palpo-postgres:
+    profiles: ["palpo-local"]
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "${PALPO_DB_NAME:-palpo}"
+      POSTGRES_USER: "${PALPO_DB_USER:-palpo}"
+      POSTGRES_PASSWORD: "${PALPO_DB_PASSWORD:?PALPO_DB_PASSWORD is required}"
+    volumes:
+      - "${PALPO_RUNTIME_DIR:-./.runtime}/state/postgres:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PALPO_DB_USER:-palpo} -d ${PALPO_DB_NAME:-palpo}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks: [palpo-internal]
+
+  palpo:
+    profiles: ["palpo-local"]
+    build:
+      context: "${PALPO_BUILD_CONTEXT:-../../../palpo-and-octos-deploy}"
+      dockerfile: palpo.Dockerfile
+    restart: unless-stopped
+    environment:
+      PALPO_CONFIG: /var/palpo/palpo.toml
+    ports:
+      - "${PALPO_HOST_PORT:-8128}:8008"
+    volumes:
+      - "${PALPO_RUNTIME_DIR:-./.runtime}/config/palpo.toml:/var/palpo/palpo.toml:ro"
+      - "${PALPO_RUNTIME_DIR:-./.runtime}/config/appservice-agentchat.yaml:/var/palpo/appservices/appservice-agentchat.yaml:ro"
+      - "${PALPO_RUNTIME_DIR:-./.runtime}/state/media:/var/palpo/media"
+    depends_on:
+      palpo-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8008/_matrix/client/versions"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    networks: [palpo-internal]
+
+networks:
+  palpo-internal:
+    attachable: true

--- a/roadmap/agentchat-demo/palpo/demo-doctor.mjs
+++ b/roadmap/agentchat-demo/palpo/demo-doctor.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function fingerprint(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function request(fetchImpl, url, options = {}) {
+  try {
+    return await fetchImpl(url, options);
+  } catch {
+    return null;
+  }
+}
+
+export async function runDoctor({
+  deployment,
+  homeserver,
+  asToken,
+  hsToken,
+  registrationToken,
+  botAccount,
+  adminAccount,
+  fetchImpl = globalThis.fetch,
+}) {
+  const checks = [];
+  const baseUrl = String(homeserver ?? '').replace(/\/$/, '');
+
+  const versions = await request(fetchImpl, `${baseUrl}/_matrix/client/versions`);
+  const homeserverReady = versions?.status === 200;
+  checks.push(homeserverReady
+    ? { name: 'homeserver', ok: true }
+    : { name: 'homeserver', ok: false, cause: 'homeserver unreachable or unhealthy' });
+
+  const configMatches = Boolean(
+    deployment?.fingerprints?.asToken
+      && deployment?.fingerprints?.hsToken
+      && typeof asToken === 'string'
+      && typeof hsToken === 'string'
+      && typeof registrationToken === 'string'
+      && fingerprint(asToken) === deployment.fingerprints.asToken
+      && fingerprint(hsToken) === deployment.fingerprints.hsToken
+      && fingerprint(registrationToken) === deployment.fingerprints.registrationToken,
+  );
+  checks.push(configMatches
+    ? { name: 'appservice-config', ok: true }
+    : { name: 'appservice-config', ok: false, cause: 'appservice registration mismatch' });
+
+  if (!configMatches) {
+    checks.push({
+      name: 'appservice-credential',
+      ok: false,
+      cause: 'appservice credential not checked because registration configuration mismatched',
+    });
+  } else {
+    const sender = `@${deployment.senderLocalpart}:${deployment.serverName}`;
+    const whoami = await request(
+      fetchImpl,
+      `${baseUrl}/_matrix/client/v3/account/whoami?user_id=${encodeURIComponent(sender)}`,
+      { headers: { authorization: `Bearer ${asToken}` } },
+    );
+    checks.push(whoami?.status === 200
+      ? { name: 'appservice-credential', ok: true }
+      : {
+          name: 'appservice-credential',
+          ok: false,
+          cause: 'appservice registration mismatch: credential rejected by homeserver',
+        });
+  }
+
+  const adminLogin = await request(fetchImpl, `${baseUrl}/_matrix/client/v3/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'm.login.password',
+      identifier: { type: 'm.id.user', user: adminAccount?.username },
+      password: adminAccount?.password,
+    }),
+  });
+  if (adminLogin?.status !== 200) {
+    checks.push({ name: 'admin-account', ok: false, cause: 'admin account login rejected' });
+  } else {
+    let adminSession = {};
+    try {
+      adminSession = await adminLogin.json();
+    } catch {
+      adminSession = {};
+    }
+    const adminStatus = adminSession.access_token && adminSession.user_id
+      ? await request(
+          fetchImpl,
+          `${baseUrl}/_synapse/admin/v1/users/${encodeURIComponent(adminSession.user_id)}/admin`,
+          { headers: { authorization: `Bearer ${adminSession.access_token}` } },
+        )
+      : null;
+    let statusBody = {};
+    try {
+      statusBody = adminStatus ? await adminStatus.json() : {};
+    } catch {
+      statusBody = {};
+    }
+    checks.push(adminStatus?.status === 200 && statusBody.admin === true
+      ? { name: 'admin-account', ok: true }
+      : { name: 'admin-account', ok: false, cause: 'configured admin account is not a server admin' });
+  }
+
+  const login = await request(fetchImpl, `${baseUrl}/_matrix/client/v3/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'm.login.password',
+      identifier: { type: 'm.id.user', user: botAccount?.username },
+      password: botAccount?.password,
+    }),
+  });
+  checks.push(login?.status === 200
+    ? { name: 'bot-account', ok: true }
+    : { name: 'bot-account', ok: false, cause: 'bot account login rejected' });
+
+  return { ok: checks.every((check) => check.ok), checks };
+}
+
+function printText(result) {
+  return result.checks
+    .map((check) => `${check.ok ? 'OK' : 'FAIL'} ${check.name}${check.cause ? `: ${check.cause}` : ''}`)
+    .join('\n');
+}
+
+async function main() {
+  const deploymentPath = path.resolve(
+    process.env.PALPO_DEPLOYMENT_FILE
+      || path.join(process.env.PALPO_RUNTIME_DIR || path.join(moduleDir, '.runtime'), 'config', 'deployment.json'),
+  );
+  const deployment = JSON.parse(await readFile(deploymentPath, 'utf8'));
+  const result = await runDoctor({
+    deployment,
+    homeserver: process.env.PALPO_PUBLIC_URL || deployment.publicUrl,
+    asToken: process.env.PALPO_AS_TOKEN,
+    hsToken: process.env.PALPO_HS_TOKEN,
+    registrationToken: process.env.PALPO_REGISTRATION_TOKEN,
+    adminAccount: {
+      username: process.env.PALPO_ADMIN_USER,
+      password: process.env.PALPO_ADMIN_PASSWORD,
+    },
+    botAccount: {
+      username: process.env.PALPO_BOT_USER,
+      password: process.env.PALPO_BOT_PASSWORD,
+    },
+  });
+  process.stdout.write(process.argv.includes('--json')
+    ? `${JSON.stringify(result, null, 2)}\n`
+    : `${printText(result)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    process.stderr.write(`[demo-doctor] ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/roadmap/agentchat-demo/palpo/demo-reset.sh
+++ b/roadmap/agentchat-demo/palpo/demo-reset.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+STATE_ROOT=""
+CONFIRMED=0
+DRY_RUN=0
+
+usage() {
+  echo "usage: $0 --state-root PATH --confirm [--dry-run]" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --state-root)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      STATE_ROOT="$2"
+      shift 2
+      ;;
+    --confirm)
+      CONFIRMED=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[ "$CONFIRMED" -eq 1 ] || { echo "[demo-reset] --confirm is required" >&2; exit 2; }
+[ -n "$STATE_ROOT" ] || { echo "[demo-reset] --state-root must not be empty" >&2; exit 2; }
+[ -d "$STATE_ROOT" ] || { echo "[demo-reset] state root must be an existing directory" >&2; exit 2; }
+
+mkdir -p "$DEMO_DIR/.runtime"
+ALLOWED_ROOT="$(cd "$DEMO_DIR/.runtime" && pwd -P)"
+STATE_ROOT="$(cd "$STATE_ROOT" && pwd -P)"
+case "$STATE_ROOT" in
+  "$ALLOWED_ROOT"|"$ALLOWED_ROOT"/*) ;;
+  *) echo "[demo-reset] state root must be inside $ALLOWED_ROOT" >&2; exit 2 ;;
+esac
+
+CONFIGURED_RUNTIME="${PALPO_RUNTIME_DIR:-./.runtime}"
+case "$CONFIGURED_RUNTIME" in
+  /*) ;;
+  *) CONFIGURED_RUNTIME="$DEMO_DIR/$CONFIGURED_RUNTIME" ;;
+esac
+[ -d "$CONFIGURED_RUNTIME" ] || {
+  echo "[demo-reset] PALPO_RUNTIME_DIR must be an existing directory" >&2
+  exit 2
+}
+CONFIGURED_RUNTIME="$(cd "$CONFIGURED_RUNTIME" && pwd -P)"
+[ "$STATE_ROOT" = "$CONFIGURED_RUNTIME" ] || {
+  echo "[demo-reset] --state-root must match PALPO_RUNTIME_DIR ($CONFIGURED_RUNTIME)" >&2
+  exit 2
+}
+
+COMPOSE_FILE="$DEMO_DIR/compose.yml"
+ENV_FILE="${PALPO_ENV_FILE:-$DEMO_DIR/.env}"
+PROJECT_ARGS=()
+if [ -n "${PALPO_COMPOSE_PROJECT_NAME:-}" ]; then
+  PROJECT_ARGS=(--project-name "$PALPO_COMPOSE_PROJECT_NAME")
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "DRY-RUN docker compose ${PROJECT_ARGS[*]} --env-file $ENV_FILE -f $COMPOSE_FILE --profile palpo-local down --remove-orphans"
+  echo "DRY-RUN rm -rf -- $STATE_ROOT/config $STATE_ROOT/state"
+  exit 0
+fi
+
+docker compose "${PROJECT_ARGS[@]}" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" --profile palpo-local down --remove-orphans
+rm -rf -- "$STATE_ROOT/config" "$STATE_ROOT/state"
+echo "[demo-reset] removed generated config and state below $STATE_ROOT"

--- a/roadmap/agentchat-demo/palpo/palpo-config.mjs
+++ b/roadmap/agentchat-demo/palpo/palpo-config.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const placeholderPattern = /^(?:change[-_ ]?me|your[-_].*|dev[-_].*)$/i;
+
+function required(env, name) {
+  const value = String(env[name] ?? '').trim();
+  if (!value || /[<>]/.test(value) || placeholderPattern.test(value)) {
+    throw new Error(`${name} must be set to a non-placeholder value`);
+  }
+  if (/\p{Cc}/u.test(value)) {
+    throw new Error(`${name} contains a control character`);
+  }
+  return value;
+}
+
+function validatePort(env, name) {
+  const value = required(env, name);
+  if (!/^[0-9]{1,5}$/.test(value) || Number(value) < 1 || Number(value) > 65535) {
+    throw new Error(`${name} must be a TCP port between 1 and 65535`);
+  }
+  return value;
+}
+
+function validateServerName(env) {
+  const value = required(env, 'PALPO_SERVER_NAME');
+  const host = value.startsWith('[')
+    ? value.match(/^\[([0-9a-f:]+)\](?::[0-9]{1,5})?$/i)?.[1]
+    : value.match(/^([a-z0-9.-]+)(?::[0-9]{1,5})?$/i)?.[1];
+  if (!host || host.startsWith('.') || host.endsWith('.') || host.includes('..')) {
+    throw new Error('PALPO_SERVER_NAME must be a hostname or IP address with an optional port');
+  }
+  const port = value.match(/:([0-9]{1,5})$/)?.[1];
+  if (port && (Number(port) < 1 || Number(port) > 65535)) {
+    throw new Error('PALPO_SERVER_NAME contains an invalid port');
+  }
+  return value;
+}
+
+function validateUrl(env, name) {
+  const value = required(env, name);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an absolute HTTP(S) URL`);
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname
+      || parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error(`${name} must be an absolute HTTP(S) URL without credentials, query, or fragment`);
+  }
+  return value.replace(/\/$/, '');
+}
+
+function validateIdentifier(env, name) {
+  const value = required(env, name);
+  if (!/^[a-z0-9._=-]+$/i.test(value)) {
+    throw new Error(`${name} contains unsupported characters`);
+  }
+  return value;
+}
+
+function validateSecret(env, name) {
+  const value = required(env, name);
+  if (value.length < 16 || !/^[A-Za-z0-9._~+-]+$/.test(value)) {
+    throw new Error(`${name} must contain at least 16 URL-safe characters`);
+  }
+  return value;
+}
+
+function fingerprint(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function renderTemplate(template, values) {
+  const rendered = template.replace(/\{\{([A-Z0-9_]+)\}\}/g, (marker, name) => {
+    if (!(name in values)) throw new Error(`unknown template marker ${marker}`);
+    return values[name];
+  });
+  if (/\{\{[A-Z0-9_]+\}\}/.test(rendered)) throw new Error('unresolved template marker');
+  return rendered;
+}
+
+async function writePrivate(filename, content) {
+  await writeFile(filename, content, { encoding: 'utf8', mode: 0o600 });
+  await chmod(filename, 0o600);
+}
+
+export async function renderConfig({ env, outputDir }) {
+  if (!outputDir || !path.isAbsolute(outputDir)) {
+    throw new Error('outputDir must be an absolute path');
+  }
+
+  const serverName = validateServerName(env);
+  const publicUrl = validateUrl(env, 'PALPO_PUBLIC_URL');
+  validatePort(env, 'PALPO_HOST_PORT');
+  const dbHost = validateIdentifier(env, 'PALPO_DB_HOST');
+  const dbPort = validatePort(env, 'PALPO_DB_PORT');
+  const dbName = validateIdentifier(env, 'PALPO_DB_NAME');
+  const dbUser = validateIdentifier(env, 'PALPO_DB_USER');
+  const dbPassword = validateSecret(env, 'PALPO_DB_PASSWORD');
+  const appserviceUrl = validateUrl(env, 'PALPO_APPSERVICE_URL');
+  const asToken = validateSecret(env, 'PALPO_AS_TOKEN');
+  const hsToken = validateSecret(env, 'PALPO_HS_TOKEN');
+  const registrationToken = validateSecret(env, 'PALPO_REGISTRATION_TOKEN');
+  const senderLocalpart = validateIdentifier(env, 'PALPO_SENDER_LOCALPART');
+
+  const [palpoTemplate, appserviceTemplate] = await Promise.all([
+    readFile(path.join(moduleDir, 'templates', 'palpo.toml.tpl'), 'utf8'),
+    readFile(path.join(moduleDir, 'templates', 'appservice-agentchat.yaml.tpl'), 'utf8'),
+  ]);
+  const serverRegex = serverName.replace(/[\\.^$|?*+()[\]{}-]/g, '\\$&').replace(/\\/g, '\\\\');
+  const palpo = renderTemplate(palpoTemplate, {
+    SERVER_NAME: serverName,
+    PUBLIC_URL: publicUrl,
+    DB_HOST: dbHost,
+    DB_PORT: dbPort,
+    DB_NAME: dbName,
+    DB_USER: dbUser,
+    DB_PASSWORD: dbPassword,
+    REGISTRATION_TOKEN: registrationToken,
+  });
+  const appservice = renderTemplate(appserviceTemplate, {
+    APPSERVICE_URL: appserviceUrl,
+    AS_TOKEN: asToken,
+    HS_TOKEN: hsToken,
+    SENDER_LOCALPART: senderLocalpart,
+    SERVER_REGEX: serverRegex,
+  });
+  const deployment = {
+    schemaVersion: 1,
+    serverName,
+    publicUrl,
+    appserviceUrl,
+    senderLocalpart,
+    fingerprints: {
+      asToken: fingerprint(asToken),
+      hsToken: fingerprint(hsToken),
+      registrationToken: fingerprint(registrationToken),
+    },
+  };
+
+  await mkdir(outputDir, { recursive: true, mode: 0o700 });
+  const files = {
+    palpo: path.join(outputDir, 'palpo.toml'),
+    appservice: path.join(outputDir, 'appservice-agentchat.yaml'),
+    deployment: path.join(outputDir, 'deployment.json'),
+  };
+  await Promise.all([
+    writePrivate(files.palpo, palpo),
+    writePrivate(files.appservice, appservice),
+    writePrivate(files.deployment, `${JSON.stringify(deployment, null, 2)}\n`),
+  ]);
+  return { files, deployment };
+}
+
+async function main() {
+  const outputDir = path.resolve(
+    process.argv[2]
+      || path.join(process.env.PALPO_RUNTIME_DIR || path.join(moduleDir, '.runtime'), 'config'),
+  );
+  const { files } = await renderConfig({ env: process.env, outputDir });
+  process.stdout.write(`${JSON.stringify({ ok: true, files }, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    process.stderr.write(`[palpo-config] ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/roadmap/agentchat-demo/palpo/templates/appservice-agentchat.yaml.tpl
+++ b/roadmap/agentchat-demo/palpo/templates/appservice-agentchat.yaml.tpl
@@ -1,0 +1,16 @@
+id: agentchat-matrix-appservice
+url: "{{APPSERVICE_URL}}"
+as_token: "{{AS_TOKEN}}"
+hs_token: "{{HS_TOKEN}}"
+sender_localpart: "{{SENDER_LOCALPART}}"
+rate_limited: false
+
+namespaces:
+  users:
+    - exclusive: true
+      regex: "@{{SENDER_LOCALPART}}:{{SERVER_REGEX}}"
+    - exclusive: true
+      regex: "@ac_.*:{{SERVER_REGEX}}"
+  aliases: []
+  rooms: []
+

--- a/roadmap/agentchat-demo/palpo/templates/palpo.toml.tpl
+++ b/roadmap/agentchat-demo/palpo/templates/palpo.toml.tpl
@@ -1,0 +1,21 @@
+server_name = "{{SERVER_NAME}}"
+allow_registration = true
+yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse = false
+registration_token = "{{REGISTRATION_TOKEN}}"
+rc_registration = { per_second = 1.0, burst = 10 }
+enable_admin_room = true
+appservice_registration_dir = "/var/palpo/appservices"
+
+[[listeners]]
+address = "0.0.0.0:8008"
+
+[logger]
+format = "pretty"
+
+[db]
+url = "postgres://{{DB_USER}}:{{DB_PASSWORD}}@{{DB_HOST}}:{{DB_PORT}}/{{DB_NAME}}"
+pool_size = 10
+
+[well_known]
+server = "{{SERVER_NAME}}"
+client = "{{PUBLIC_URL}}"

--- a/roadmap/agentchat-demo/palpo/tests/bootstrap-accounts.test.mjs
+++ b/roadmap/agentchat-demo/palpo/tests/bootstrap-accounts.test.mjs
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { bootstrapAccounts, createComposeAdminPromoter } from '../bootstrap-accounts.mjs';
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function fakeHomeserver({
+  existing = {},
+  raceUsers = [],
+  unavailableUsers = [],
+  registrationToken = 'registration-token-0123456789',
+} = {}) {
+  const accounts = new Map(Object.entries(existing));
+  const races = new Set(raceUsers);
+  const unavailable = new Set(unavailableUsers);
+  let registrations = 0;
+  let session = 0;
+
+  const fetchImpl = async (url, options = {}) => {
+    const endpoint = new URL(url).pathname;
+    const body = JSON.parse(options.body || '{}');
+    const username = body.identifier?.user || body.username;
+
+    if (unavailable.has(username)) return json(503, { errcode: 'M_UNAVAILABLE' });
+
+    if (endpoint.endsWith('/login')) {
+      return accounts.get(username) === body.password
+        ? json(200, { user_id: `@${username}:example.test`, access_token: `login-token-${username}` })
+        : json(403, { errcode: 'M_FORBIDDEN', error: 'Invalid username or password' });
+    }
+
+    if (!endpoint.endsWith('/register')) return json(404, { errcode: 'M_NOT_FOUND' });
+    if (accounts.has(username)) return json(400, { errcode: 'M_USER_IN_USE' });
+
+    if (!body.auth) {
+      session += 1;
+      return json(401, {
+        session: `session-${session}`,
+        flows: [{ stages: ['m.login.registration_token'] }],
+      });
+    }
+
+    if (body.auth.type !== 'm.login.registration_token' || body.auth.token !== registrationToken) {
+      return json(401, { errcode: 'M_FORBIDDEN' });
+    }
+
+    if (races.has(username)) {
+      races.delete(username);
+      accounts.set(username, body.password);
+      return json(400, { errcode: 'M_USER_IN_USE' });
+    }
+
+    registrations += 1;
+    accounts.set(username, body.password);
+    return json(200, {
+      user_id: `@${username}:example.test`,
+      access_token: `registration-token-${username}`,
+    });
+  };
+
+  return {
+    fetchImpl,
+    accountCount: () => accounts.size,
+    registrations: () => registrations,
+  };
+}
+
+const accounts = [
+  { username: 'admin', password: 'admin-secret-012345' },
+  { username: 'agent-bridge', password: 'bot-secret-01234567' },
+];
+const registrationToken = 'registration-token-0123456789';
+
+test('first bootstrap registers and second bootstrap only logs in', async () => {
+  const server = fakeHomeserver();
+
+  const first = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts,
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+  });
+  const countAfterFirst = server.accountCount();
+  const second = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts,
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+  });
+
+  assert.equal(first.ok, true);
+  assert.deepEqual(first.results.map((result) => result.status), ['created', 'created']);
+  assert.equal(second.ok, true);
+  assert.deepEqual(second.results.map((result) => result.status), ['existing', 'existing']);
+  assert.equal(server.registrations(), 2);
+  assert.equal(server.accountCount(), countAfterFirst);
+  assert.equal(JSON.stringify([first, second]).includes('secret-'), false);
+  assert.equal(JSON.stringify([first, second]).includes('token-'), false);
+});
+
+test('registration race retries login and reports the account ready', async () => {
+  const server = fakeHomeserver({ raceUsers: ['agent-bridge'] });
+  const result = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts: [accounts[1]],
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.results[0].status, 'existing-after-race');
+});
+
+test('wrong password for an existing account is surfaced without a secret', async () => {
+  const server = fakeHomeserver({ existing: { admin: 'different-password-000' } });
+  const result = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts: [accounts[0]],
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.results[0].status, 'password-mismatch');
+  assert.match(result.results[0].error, /password/i);
+  assert.equal(JSON.stringify(result).includes(accounts[0].password), false);
+});
+
+test('one unavailable account does not prevent later accounts from bootstrapping', async () => {
+  const server = fakeHomeserver({ unavailableUsers: ['offline'] });
+  const result = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts: [
+      { username: 'offline', password: 'offline-secret-0123' },
+      accounts[1],
+    ],
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.results[0].status, 'failed');
+  assert.equal(result.results[1].status, 'created');
+  assert.equal(server.accountCount(), 1);
+});
+
+test('bootstrap rejects a missing or placeholder registration token', async () => {
+  const server = fakeHomeserver();
+  await assert.rejects(
+    bootstrapAccounts({
+      homeserver: 'http://matrix.example.test',
+      accounts: [accounts[0]],
+      registrationToken: '<generate-me>',
+      fetchImpl: server.fetchImpl,
+    }),
+    /registrationToken/,
+  );
+});
+
+test('admin account promotion is idempotent and promotion failures fail bootstrap', async () => {
+  const server = fakeHomeserver();
+  const promoted = [];
+  const admin = { ...accounts[0], role: 'admin' };
+
+  const first = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts: [admin],
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+    promoteAdmin: async (username) => promoted.push(username),
+  });
+  const second = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts: [admin],
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+    promoteAdmin: async (username) => promoted.push(username),
+  });
+
+  assert.equal(first.ok, true);
+  assert.equal(first.results[0].admin, true);
+  assert.equal(second.ok, true);
+  assert.equal(second.results[0].admin, true);
+  assert.deepEqual(promoted, ['admin', 'admin']);
+
+  const failed = await bootstrapAccounts({
+    homeserver: 'http://matrix.example.test',
+    accounts: [admin],
+    registrationToken,
+    fetchImpl: server.fetchImpl,
+    promoteAdmin: async () => { throw new Error('database rejected promotion'); },
+  });
+  assert.equal(failed.ok, false);
+  assert.equal(failed.results[0].status, 'admin-promotion-failed');
+  assert.match(failed.results[0].error, /promotion failed/i);
+});
+
+test('compose admin promoter performs one bounded database update', async () => {
+  const calls = [];
+  const promote = createComposeAdminPromoter({
+    demoDir: '/private/demo/palpo',
+    serverName: 'matrix.example.test',
+    dbUser: 'palpo',
+    dbName: 'palpo',
+    envFile: '/private/runtime/e2e.env',
+    projectName: 'agentchat-palpo-e2e',
+    runCommand: async (command, args, options) => {
+      calls.push({ command, args, options });
+      return { status: 0, stdout: 't\n', stderr: '' };
+    },
+  });
+
+  await promote('admin');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'docker');
+  assert.deepEqual(calls[0].args.slice(0, 9), [
+    'compose', '--project-name', 'agentchat-palpo-e2e',
+    '--env-file', '/private/runtime/e2e.env',
+    '-f', '/private/demo/palpo/compose.yml', '--profile', 'palpo-local',
+  ]);
+  assert.match(calls[0].args.at(-1), /UPDATE users SET is_admin = TRUE/);
+  assert.match(calls[0].args.at(-1), /@admin:matrix\.example\.test/);
+  assert.equal(JSON.stringify(calls).includes('password'), false);
+
+  const noRowPromoter = createComposeAdminPromoter({
+    demoDir: '/private/demo/palpo',
+    serverName: 'matrix.example.test',
+    runCommand: async () => ({ status: 0, stdout: '', stderr: '' }),
+  });
+  await assert.rejects(noRowPromoter('admin'), /not found/i);
+});

--- a/roadmap/agentchat-demo/palpo/tests/compose-contract.test.mjs
+++ b/roadmap/agentchat-demo/palpo/tests/compose-contract.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const composePath = path.join(testDir, '..', 'compose.yml');
+
+test('compose defines a deterministic Palpo profile', async () => {
+  const compose = await readFile(composePath, 'utf8');
+
+  assert.match(compose, /profiles:\s*\["palpo-local"\]/);
+  assert.match(compose, /palpo-postgres:[\s\S]*?healthcheck:/);
+  assert.match(compose, /depends_on:[\s\S]*?palpo-postgres:[\s\S]*?condition: service_healthy/);
+  assert.match(compose, /\$\{PALPO_HOST_PORT:-8128\}:8008/);
+  assert.match(compose, /\$\{PALPO_RUNTIME_DIR:-\.\/\.runtime\}\/config\/palpo\.toml:\/var\/palpo\/palpo\.toml:ro/);
+  assert.match(compose, /\$\{PALPO_RUNTIME_DIR:-\.\/\.runtime\}\/config\/appservice-agentchat\.yaml:\/var\/palpo\/appservices\/appservice-agentchat\.yaml:ro/);
+  assert.match(compose, /\$\{PALPO_RUNTIME_DIR:-\.\/\.runtime\}\/state/);
+  assert.doesNotMatch(compose, /PALPO_(?:RENDERED|STATE)_DIR/);
+  assert.match(compose, /PALPO_CONFIG: \/var\/palpo\/palpo\.toml/);
+});
+
+test('compose requires operator-provided database credentials', async () => {
+  const compose = await readFile(composePath, 'utf8');
+
+  assert.match(compose, /PALPO_DB_PASSWORD:\?PALPO_DB_PASSWORD is required/);
+  assert.equal(/(?:password|token)[^\n]*(?:change-me|dev-token|palpo_dev_password)/i.test(compose), false);
+  assert.equal(/(?:as_token|hs_token)\s*:/i.test(compose), false);
+});

--- a/roadmap/agentchat-demo/palpo/tests/demo-doctor.test.mjs
+++ b/roadmap/agentchat-demo/palpo/tests/demo-doctor.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+
+import { runDoctor } from '../demo-doctor.mjs';
+
+function fingerprint(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function json(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const asToken = 'as-token-0123456789abcdef';
+const hsToken = 'hs-token-0123456789abcdef';
+const registrationToken = 'registration-token-0123456789';
+const botAccount = { username: 'agent-bridge', password: 'bot-secret-01234567' };
+const adminAccount = { username: 'admin', password: 'admin-secret-012345' };
+const deployment = {
+  schemaVersion: 1,
+  serverName: 'matrix.example.test',
+  publicUrl: 'http://matrix.example.test',
+  senderLocalpart: '_agentchat_appservice',
+  fingerprints: {
+    asToken: fingerprint(asToken),
+    hsToken: fingerprint(hsToken),
+    registrationToken: fingerprint(registrationToken),
+  },
+};
+
+function fakeHomeserver({
+  reachable = true,
+  registeredAsToken = asToken,
+  botPassword = botAccount.password,
+  botExists = true,
+  adminIsAdmin = true,
+} = {}) {
+  return async (url, options = {}) => {
+    if (!reachable) throw new TypeError('connect ECONNREFUSED');
+    const endpoint = new URL(url).pathname;
+    if (endpoint === '/_matrix/client/versions') return json(200, { versions: ['v1.11'] });
+    if (endpoint.endsWith('/account/whoami')) {
+      return options.headers?.authorization === `Bearer ${registeredAsToken}`
+        ? json(200, { user_id: '@agent-bridge:matrix.example.test' })
+        : json(401, { errcode: 'M_UNKNOWN_TOKEN' });
+    }
+    if (endpoint.endsWith('/login')) {
+      const body = JSON.parse(options.body || '{}');
+      if (botExists && body.identifier?.user === botAccount.username && body.password === botPassword) {
+        return json(200, { user_id: '@agent-bridge:matrix.example.test', access_token: 'private-login-token' });
+      }
+      if (body.identifier?.user === adminAccount.username && body.password === adminAccount.password) {
+        return json(200, { user_id: '@admin:matrix.example.test', access_token: 'private-admin-token' });
+      }
+      return json(403, { errcode: 'M_FORBIDDEN' });
+    }
+    if (endpoint.startsWith('/_synapse/admin/v1/users/') && endpoint.endsWith('/admin')) {
+      return options.headers?.authorization === 'Bearer private-admin-token'
+        ? json(200, { admin: adminIsAdmin })
+        : json(401, { errcode: 'M_UNKNOWN_TOKEN' });
+    }
+    return json(404, { errcode: 'M_NOT_FOUND' });
+  };
+}
+
+function doctor(overrides = {}) {
+  return runDoctor({
+    deployment,
+    homeserver: 'http://matrix.example.test',
+    asToken,
+    hsToken,
+    registrationToken,
+    botAccount,
+    adminAccount,
+    fetchImpl: fakeHomeserver(),
+    ...overrides,
+  });
+}
+
+test('healthy doctor reports homeserver, appservice, and bot account ready', async () => {
+  const result = await doctor();
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.checks.map((check) => [check.name, check.ok]), [
+    ['homeserver', true],
+    ['appservice-config', true],
+    ['appservice-credential', true],
+    ['admin-account', true],
+    ['bot-account', true],
+  ]);
+  assert.equal(JSON.stringify(result).includes(asToken), false);
+  assert.equal(JSON.stringify(result).includes(hsToken), false);
+  assert.equal(JSON.stringify(result).includes(botAccount.password), false);
+  assert.equal(JSON.stringify(result).includes(adminAccount.password), false);
+  assert.equal(JSON.stringify(result).includes('private-login-token'), false);
+  assert.equal(JSON.stringify(result).includes('private-admin-token'), false);
+});
+
+test('unreachable homeserver names the failed dependency', async () => {
+  const result = await doctor({ fetchImpl: fakeHomeserver({ reachable: false }) });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.find((check) => check.name === 'homeserver').ok, false);
+  assert.match(result.checks.find((check) => check.name === 'homeserver').cause, /unreachable/i);
+});
+
+test('token fingerprint mismatch is explicit', async () => {
+  const result = await doctor({ asToken: 'different-as-token-01234567' });
+  const check = result.checks.find((item) => item.name === 'appservice-config');
+
+  assert.equal(result.ok, false);
+  assert.equal(check.ok, false);
+  assert.match(check.cause, /registration mismatch/i);
+});
+
+test('homeserver rejection names the appservice credential', async () => {
+  const wrongAsToken = 'wrong-as-token-012345678901';
+  const matchingManifest = {
+    ...deployment,
+    fingerprints: { ...deployment.fingerprints, asToken: fingerprint(wrongAsToken) },
+  };
+  const result = await doctor({
+    deployment: matchingManifest,
+    asToken: wrongAsToken,
+    fetchImpl: fakeHomeserver({ registeredAsToken: asToken }),
+  });
+  const check = result.checks.find((item) => item.name === 'appservice-credential');
+
+  assert.equal(result.ok, false);
+  assert.equal(check.ok, false);
+  assert.match(check.cause, /credential rejected/i);
+});
+
+test('missing bot account and wrong bot password are surfaced', async (t) => {
+  await t.test('missing account', async () => {
+    const result = await doctor({ fetchImpl: fakeHomeserver({ botExists: false }) });
+    const check = result.checks.find((item) => item.name === 'bot-account');
+    assert.equal(check.ok, false);
+    assert.match(check.cause, /login rejected/i);
+  });
+  await t.test('wrong password', async () => {
+    const result = await doctor({ botAccount: { ...botAccount, password: 'wrong-secret-0123456' } });
+    const check = result.checks.find((item) => item.name === 'bot-account');
+    assert.equal(check.ok, false);
+    assert.match(check.cause, /login rejected/i);
+  });
+});
+
+test('admin account must exist and hold server-admin privileges', async (t) => {
+  await t.test('wrong admin password', async () => {
+    const result = await doctor({ adminAccount: { ...adminAccount, password: 'wrong-admin-secret-000' } });
+    const check = result.checks.find((item) => item.name === 'admin-account');
+    assert.equal(check.ok, false);
+    assert.match(check.cause, /login rejected/i);
+  });
+  await t.test('normal account is not accepted as admin', async () => {
+    const result = await doctor({ fetchImpl: fakeHomeserver({ adminIsAdmin: false }) });
+    const check = result.checks.find((item) => item.name === 'admin-account');
+    assert.equal(check.ok, false);
+    assert.match(check.cause, /not a server admin/i);
+  });
+});

--- a/roadmap/agentchat-demo/palpo/tests/palpo-config.test.mjs
+++ b/roadmap/agentchat-demo/palpo/tests/palpo-config.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { renderConfig } from '../palpo-config.mjs';
+
+const validEnv = {
+  PALPO_SERVER_NAME: 'matrix.example.test',
+  PALPO_PUBLIC_URL: 'https://matrix.example.test:8448',
+  PALPO_HOST_PORT: '8448',
+  PALPO_DB_HOST: 'palpo-postgres',
+  PALPO_DB_PORT: '5432',
+  PALPO_DB_NAME: 'palpo',
+  PALPO_DB_USER: 'palpo',
+  PALPO_DB_PASSWORD: 'db-secret-0123456789',
+  PALPO_APPSERVICE_URL: 'http://host.docker.internal:8091',
+  PALPO_AS_TOKEN: 'as-token-0123456789abcdef',
+  PALPO_HS_TOKEN: 'hs-token-0123456789abcdef',
+  PALPO_REGISTRATION_TOKEN: 'registration-token-0123456789',
+  PALPO_SENDER_LOCALPART: '_agentchat_appservice',
+};
+
+async function outputDir() {
+  return mkdtemp(path.join(os.tmpdir(), 'palpo-config-test-'));
+}
+
+test('renderConfig rejects missing and placeholder secrets', async () => {
+  for (const [key, value] of [
+    ['PALPO_AS_TOKEN', ''],
+    ['PALPO_HS_TOKEN', '<generate-me>'],
+    ['PALPO_DB_PASSWORD', 'change-me'],
+    ['PALPO_REGISTRATION_TOKEN', '<generate-me>'],
+  ]) {
+    await assert.rejects(
+      renderConfig({ env: { ...validEnv, [key]: value }, outputDir: await outputDir() }),
+      new RegExp(key),
+    );
+  }
+});
+
+test('renderConfig rejects invalid network and identity values', async () => {
+  for (const [key, value] of [
+    ['PALPO_SERVER_NAME', 'https://matrix.example.test'],
+    ['PALPO_PUBLIC_URL', 'ftp://matrix.example.test'],
+    ['PALPO_HOST_PORT', '70000'],
+    ['PALPO_DB_PORT', 'not-a-port'],
+    ['PALPO_SENDER_LOCALPART', 'Agent Bridge'],
+  ]) {
+    await assert.rejects(
+      renderConfig({ env: { ...validEnv, [key]: value }, outputDir: await outputDir() }),
+      new RegExp(key),
+    );
+  }
+});
+
+test('renderConfig rejects TOML and YAML control characters', async () => {
+  for (const [key, value] of [
+    ['PALPO_SERVER_NAME', 'matrix.example.test\nadmin = true'],
+    ['PALPO_APPSERVICE_URL', 'http://bridge:8091\nadmin: true'],
+    ['PALPO_DB_NAME', 'palpo\"; injected=true'],
+    ['PALPO_AS_TOKEN', 'safe-prefix\nunsafe'],
+  ]) {
+    await assert.rejects(
+      renderConfig({ env: { ...validEnv, [key]: value }, outputDir: await outputDir() }),
+      new RegExp(key),
+    );
+  }
+});
+
+test('renderConfig writes deterministic private files and redacts deployment metadata', async () => {
+  const dir = await outputDir();
+  const result = await renderConfig({ env: validEnv, outputDir: dir });
+
+  assert.deepEqual(Object.keys(result.files).sort(), [
+    'appservice',
+    'deployment',
+    'palpo',
+  ]);
+
+  const palpo = await readFile(path.join(dir, 'palpo.toml'), 'utf8');
+  const appservice = await readFile(path.join(dir, 'appservice-agentchat.yaml'), 'utf8');
+  const deploymentText = await readFile(path.join(dir, 'deployment.json'), 'utf8');
+  const deployment = JSON.parse(deploymentText);
+
+  assert.match(palpo, /server_name = "matrix\.example\.test"/);
+  assert.match(palpo, /postgres:\/\/palpo:db-secret-0123456789@palpo-postgres:5432\/palpo/);
+  assert.match(palpo, /registration_token = "registration-token-0123456789"/);
+  assert.match(palpo, /rc_registration = \{ per_second = 1\.0, burst = 10 \}/);
+  assert.doesNotMatch(palpo, /open_registration_server_prone_to_abuse = true/);
+  assert.match(appservice, /as_token: "as-token-0123456789abcdef"/);
+  assert.match(appservice, /hs_token: "hs-token-0123456789abcdef"/);
+  assert.match(appservice, /sender_localpart: "_agentchat_appservice"/);
+  assert.doesNotMatch(appservice, /@agent-bridge:/);
+  assert.equal(deployment.serverName, 'matrix.example.test');
+  assert.match(deployment.fingerprints.asToken, /^[a-f0-9]{64}$/);
+  assert.match(deployment.fingerprints.hsToken, /^[a-f0-9]{64}$/);
+  assert.match(deployment.fingerprints.registrationToken, /^[a-f0-9]{64}$/);
+
+  for (const secret of [
+    validEnv.PALPO_DB_PASSWORD,
+    validEnv.PALPO_AS_TOKEN,
+    validEnv.PALPO_HS_TOKEN,
+    validEnv.PALPO_REGISTRATION_TOKEN,
+  ]) {
+    assert.equal(deploymentText.includes(secret), false);
+  }
+
+  for (const filename of ['palpo.toml', 'appservice-agentchat.yaml', 'deployment.json']) {
+    assert.equal((await stat(path.join(dir, filename))).mode & 0o777, 0o600);
+  }
+});

--- a/roadmap/agentchat-demo/palpo/tests/real-e2e.test.mjs
+++ b/roadmap/agentchat-demo/palpo/tests/real-e2e.test.mjs
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { randomBytes, createHash } from 'node:crypto';
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { bootstrapAccounts, createComposeAdminPromoter } from '../bootstrap-accounts.mjs';
+import { runDoctor } from '../demo-doctor.mjs';
+import { renderConfig } from '../palpo-config.mjs';
+
+const palpoDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const realEnabled = process.env.PALPO_REAL_E2E === '1';
+const realOptions = {
+  skip: realEnabled ? false : 'set PALPO_REAL_E2E=1 to run Docker/Palpo acceptance',
+  timeout: 15 * 60 * 1000,
+};
+
+function secret(prefix) {
+  return `${prefix}-${randomBytes(24).toString('hex')}`;
+}
+
+function fingerprint(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function redact(text, values) {
+  return values.reduce((output, value) => output.replaceAll(value, '<redacted>'), String(text ?? ''));
+}
+
+function run(command, args, { cwd = palpoDir, env = process.env, secrets = [] } = {}) {
+  const result = spawnSync(command, args, { cwd, env, encoding: 'utf8' });
+  if (result.status !== 0) {
+    const detail = redact(`${result.stdout || ''}\n${result.stderr || ''}`, secrets).trim().slice(-4000);
+    throw new Error(`${command} failed with status ${result.status}${detail ? `\n${detail}` : ''}`);
+  }
+  return result.stdout;
+}
+
+async function login(homeserver, account) {
+  const response = await fetch(`${homeserver}/_matrix/client/v3/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'm.login.password',
+      identifier: { type: 'm.id.user', user: account.username },
+      password: account.password,
+    }),
+  });
+  assert.equal(response.status, 200, `login failed for ${account.username}`);
+  return response.json();
+}
+
+async function withRealStack(fn) {
+  const runId = `${process.pid}-${randomBytes(4).toString('hex')}`;
+  const projectName = `agentchat-palpo-e2e-${runId}`;
+  const runtimeDir = path.join(palpoDir, '.runtime', `e2e-${runId}`);
+  const envFile = path.join(runtimeDir, 'operator.env');
+  const port = Number(process.env.PALPO_E2E_HOST_PORT || 18128);
+  const secrets = {
+    db: secret('db'),
+    as: secret('as'),
+    hs: secret('hs'),
+    registration: secret('registration'),
+    admin: secret('admin'),
+    bot: secret('bot'),
+  };
+  const palpoEnv = {
+    COMPOSE_PROJECT_NAME: projectName,
+    PALPO_SERVER_NAME: `127.0.0.1:${port}`,
+    PALPO_PUBLIC_URL: `http://127.0.0.1:${port}`,
+    PALPO_HOST_PORT: String(port),
+    PALPO_DB_HOST: 'palpo-postgres',
+    PALPO_DB_PORT: '5432',
+    PALPO_DB_NAME: 'palpo',
+    PALPO_DB_USER: 'palpo',
+    PALPO_DB_PASSWORD: secrets.db,
+    PALPO_APPSERVICE_URL: 'http://host.docker.internal:8091',
+    PALPO_AS_TOKEN: secrets.as,
+    PALPO_HS_TOKEN: secrets.hs,
+    PALPO_REGISTRATION_TOKEN: secrets.registration,
+    PALPO_SENDER_LOCALPART: '_agentchat_appservice',
+    PALPO_ADMIN_USER: 'admin',
+    PALPO_ADMIN_PASSWORD: secrets.admin,
+    PALPO_BOT_USER: 'agent-bridge',
+    PALPO_BOT_PASSWORD: secrets.bot,
+    PALPO_RUNTIME_DIR: runtimeDir,
+  };
+  const env = { ...process.env, ...palpoEnv };
+  const secretValues = Object.values(secrets);
+  const composeBase = [
+    'compose', '--project-name', projectName,
+    '--env-file', envFile,
+    '-f', path.join(palpoDir, 'compose.yml'),
+    '--profile', 'palpo-local',
+  ];
+  const accounts = [
+    { username: env.PALPO_ADMIN_USER, password: env.PALPO_ADMIN_PASSWORD, role: 'admin' },
+    { username: env.PALPO_BOT_USER, password: env.PALPO_BOT_PASSWORD },
+  ];
+
+  await mkdir(runtimeDir, { recursive: true, mode: 0o700 });
+  const envText = Object.entries(palpoEnv)
+    .map(([name, value]) => `${name}=${value}`)
+    .join('\n');
+  await writeFile(envFile, `${envText}\n`, { mode: 0o600 });
+  await chmod(envFile, 0o600);
+
+  const start = async () => {
+    await renderConfig({ env, outputDir: path.join(runtimeDir, 'config') });
+    run('docker', [...composeBase, 'up', '-d', '--build', '--wait'], { env, secrets: secretValues });
+  };
+  const bootstrap = () => bootstrapAccounts({
+    homeserver: env.PALPO_PUBLIC_URL,
+    accounts,
+    registrationToken: env.PALPO_REGISTRATION_TOKEN,
+    promoteAdmin: createComposeAdminPromoter({
+      demoDir: palpoDir,
+      serverName: env.PALPO_SERVER_NAME,
+      envFile,
+      projectName,
+    }),
+  });
+  const doctor = (overrides = {}) => runDoctor({
+    deployment: overrides.deployment,
+    homeserver: env.PALPO_PUBLIC_URL,
+    asToken: overrides.asToken || env.PALPO_AS_TOKEN,
+    hsToken: env.PALPO_HS_TOKEN,
+    registrationToken: env.PALPO_REGISTRATION_TOKEN,
+    adminAccount: accounts[0],
+    botAccount: accounts[1],
+  });
+  const psql = (sql) => run('docker', [
+    ...composeBase,
+    'exec', '-T', 'palpo-postgres',
+    'psql', '-U', 'palpo', '-d', 'palpo', '-tA', '-v', 'ON_ERROR_STOP=1', '-c', sql,
+  ], { env, secrets: secretValues }).trim();
+
+  try {
+    await start();
+    const rendered = await renderConfig({ env, outputDir: path.join(runtimeDir, 'config') });
+    const bootstrapResult = await bootstrap();
+    assert.equal(bootstrapResult.ok, true, JSON.stringify(bootstrapResult));
+    await fn({
+      env,
+      envFile,
+      runtimeDir,
+      projectName,
+      accounts,
+      deployment: rendered.deployment,
+      composeBase,
+      start,
+      bootstrap,
+      doctor,
+      psql,
+      secretValues,
+    });
+  } finally {
+    try {
+      run('docker', [...composeBase, 'down', '-v', '--remove-orphans'], { env, secrets: secretValues });
+    } finally {
+      await rm(runtimeDir, { recursive: true, force: true });
+    }
+  }
+}
+
+test('test_palpo_fresh_start_healthy', realOptions, async () => {
+  await withRealStack(async ({ deployment, doctor }) => {
+    const result = await doctor({ deployment });
+    assert.equal(result.ok, true, JSON.stringify(result));
+  });
+});
+
+test('test_bootstrap_idempotent', realOptions, async () => {
+  await withRealStack(async ({ env, bootstrap, psql }) => {
+    const ids = [`@admin:${env.PALPO_SERVER_NAME}`, `@agent-bridge:${env.PALPO_SERVER_NAME}`];
+    const query = `SELECT count(*) FROM users WHERE id IN ('${ids.join("','")}');`;
+    const before = psql(query);
+    const second = await bootstrap();
+    const after = psql(query);
+    assert.equal(second.ok, true, JSON.stringify(second));
+    assert.deepEqual(second.results.map((result) => result.status), ['existing', 'existing']);
+    assert.equal(after, before);
+  });
+});
+
+test('test_doctor_reports_appservice_mismatch', realOptions, async () => {
+  await withRealStack(async ({ env, runtimeDir, deployment, doctor }) => {
+    const before = await doctor({ deployment });
+    assert.equal(before.ok, true, JSON.stringify(before));
+    const wrongToken = secret('wrong-as');
+    const rerendered = await renderConfig({
+      env: { ...env, PALPO_AS_TOKEN: wrongToken },
+      outputDir: path.join(runtimeDir, 'config'),
+    });
+    const result = await doctor({ deployment: rerendered.deployment, asToken: wrongToken });
+    const check = result.checks.find((item) => item.name === 'appservice-credential');
+    assert.equal(check.ok, false);
+    assert.match(check.cause, /registration mismatch/i);
+  });
+});
+
+test('test_wrong_as_token_rejected', realOptions, async () => {
+  await withRealStack(async ({ deployment, doctor }) => {
+    const wrongToken = secret('wrong-as');
+    const matchingManifest = {
+      ...deployment,
+      fingerprints: { ...deployment.fingerprints, asToken: fingerprint(wrongToken) },
+    };
+    const result = await doctor({ deployment: matchingManifest, asToken: wrongToken });
+    assert.equal(result.ok, false);
+    assert.equal(result.checks.find((item) => item.name === 'appservice-credential').ok, false);
+  });
+});
+
+test('test_reset_restores_clean_state', realOptions, async () => {
+  await withRealStack(async (context) => {
+    const session = await login(context.env.PALPO_PUBLIC_URL, context.accounts[0]);
+    const created = await fetch(`${context.env.PALPO_PUBLIC_URL}/_matrix/client/v3/createRoom`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${session.access_token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ name: `fsf0-reset-${context.projectName}` }),
+    });
+    assert.equal(created.status, 200);
+    const { room_id: roomId } = await created.json();
+
+    run('bash', [path.join(palpoDir, 'demo-reset.sh'),
+      '--state-root', context.runtimeDir, '--confirm'], {
+      env: {
+        ...context.env,
+        PALPO_ENV_FILE: context.envFile,
+        PALPO_COMPOSE_PROJECT_NAME: context.projectName,
+      },
+      secrets: context.secretValues,
+    });
+    await context.start();
+    const bootstrapResult = await context.bootstrap();
+    assert.equal(bootstrapResult.ok, true, JSON.stringify(bootstrapResult));
+    const rendered = await renderConfig({
+      env: context.env,
+      outputDir: path.join(context.runtimeDir, 'config'),
+    });
+    const health = await context.doctor({ deployment: rendered.deployment });
+    assert.equal(health.ok, true, JSON.stringify(health));
+
+    const newSession = await login(context.env.PALPO_PUBLIC_URL, context.accounts[0]);
+    const oldRoom = await fetch(
+      `${context.env.PALPO_PUBLIC_URL}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state`,
+      { headers: { authorization: `Bearer ${newSession.access_token}` } },
+    );
+    assert.notEqual(oldRoom.status, 200, 'room from the pre-reset database still exists');
+  });
+});

--- a/roadmap/agentchat-demo/palpo/tests/reset-contract.test.mjs
+++ b/roadmap/agentchat-demo/palpo/tests/reset-contract.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const palpoDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const resetScript = path.join(palpoDir, 'demo-reset.sh');
+
+function run(args, env = {}) {
+  return spawnSync('bash', [resetScript, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+test('reset script rejects empty, root, traversal, and unconfirmed paths', async () => {
+  for (const args of [
+    ['--state-root', '', '--confirm'],
+    ['--state-root', '/', '--confirm'],
+    ['--state-root', path.join(palpoDir, '..', 'outside'), '--confirm'],
+    ['--state-root', path.join(palpoDir, '.runtime')],
+  ]) {
+    const result = run(args);
+    assert.notEqual(result.status, 0, `${args.join(' ')} must be rejected`);
+    assert.doesNotMatch(result.stderr, /No such file or directory/);
+  }
+});
+
+test('reset dry-run reports bounded actions and preserves state', async () => {
+  const runtime = path.join(palpoDir, '.runtime');
+  await mkdir(runtime, { recursive: true });
+  const marker = path.join(runtime, `reset-marker-${process.pid}.txt`);
+  await writeFile(marker, 'keep', 'utf8');
+
+  try {
+    const result = run(['--state-root', runtime, '--confirm', '--dry-run']);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /docker compose/);
+    assert.match(result.stdout, /config/);
+    assert.match(result.stdout, /state/);
+    assert.equal(await readFile(marker, 'utf8'), 'keep');
+  } finally {
+    await rm(marker, { force: true });
+  }
+});
+
+test('reset rejects a state root that differs from the Compose runtime root', async () => {
+  const runtime = path.join(palpoDir, '.runtime');
+  const other = path.join(runtime, 'other');
+  await mkdir(other, { recursive: true });
+  try {
+    const result = run(
+      ['--state-root', runtime, '--confirm', '--dry-run'],
+      { PALPO_RUNTIME_DIR: other },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must match PALPO_RUNTIME_DIR/);
+  } finally {
+    await rm(other, { recursive: true, force: true });
+  }
+});
+
+test('reset forwards an isolated Compose project and env file', async () => {
+  const runtime = path.join(palpoDir, '.runtime');
+  const envFile = path.join(runtime, `e2e-${process.pid}.env`);
+  await mkdir(runtime, { recursive: true });
+  await writeFile(envFile, 'PALPO_DB_PASSWORD=not-used-in-dry-run\n', 'utf8');
+  try {
+    const result = run(
+      ['--state-root', runtime, '--confirm', '--dry-run'],
+      {
+        PALPO_RUNTIME_DIR: runtime,
+        PALPO_ENV_FILE: envFile,
+        PALPO_COMPOSE_PROJECT_NAME: 'agentchat-palpo-e2e',
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /--project-name agentchat-palpo-e2e/);
+    assert.match(result.stdout, new RegExp(`--env-file ${envFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  } finally {
+    await rm(envFile, { force: true });
+  }
+});
+
+test('reset contract is explicit and idempotent', async () => {
+  const script = await readFile(resetScript, 'utf8');
+
+  assert.match(script, /--confirm/);
+  assert.match(script, /--dry-run/);
+  assert.match(script, /docker compose[\s\S]*down[\s\S]*--remove-orphans/);
+  assert.match(script, /rm -rf --/);
+  assert.match(script, /\/config/);
+  assert.match(script, /\/state/);
+});


### PR DESCRIPTION
## What

Ships the standalone-stack **scaffolding** that until now lived only on one machine:

### 1. Deterministic Palpo substrate (`roadmap/agentchat-demo/palpo/`)
Anyone who clones the repo can bring up an identical Matrix homeserver: parameterized compose profile (same file for local and team-server), config renderer, idempotent account bootstrap, doctor, guarded reset — plus a **28-test contract suite** (and 5 opt-in real-docker E2E). Secret-free by construction; local `.env`/`.runtime`/tokens covered by the extended `.gitignore`.

### 2. issue-workflow conventions (SKILL.md, +163 lines)
Three sections the agents execute from:
- **GitHub integration**: mirror each room issue to a GH issue, deliver via PR with `[<TEAM>-NNN]` namespacing; GitHub failure never blocks the local workflow; agents never merge.
- **Multi-member collaboration**: one member / one room / one worktree; `provision-team` onboarding; PR-only cross-team integration.
- **Shared-room variant**: `MATRIX_DEFAULT_WAKE=off` + `!bindroom` + per-team observer bots — the doc counterpart of robrix2 #258 and the agent-chat bridge features already merged on its main.

### 3. Demo README
Palpo substrate quick-start pointer (the FSF-0C cockpit verification section is deliberately NOT included — it ships with the cockpit PR).

## Tests
`node --test roadmap/agentchat-demo/palpo/tests/*.test.mjs` → **28 pass / 0 fail** from this branch. Secret scan of the copied profile: clean.

Pairs with #258 (code) — together they make the multi-member topology 'clone and go'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)