### PR TITLE
docs(demo): require MATRIX_BRIDGE_SECRET in every profile (report N2)

### DIFF
--- a/roadmap/agentchat-demo/agent-chat.env.demo
+++ b/roadmap/agentchat-demo/agent-chat.env.demo
@@ -8,8 +8,10 @@
 #   - MATRIX_BOT_PASSWORD ...... INVENT a password for the @agent-bridge account.
 #   - MATRIX_AGENT_PASSWORD_SECRET  INVENT a long random string; agent passwords
 #                                are derived = sha256("<secret>:<agentname>").
-#   - MATRIX_BRIDGE_SECRET ..... OPTIONAL locally (leave blank). Only set if you
-#                                want the bridge↔backend secret enforced.
+#   - MATRIX_BRIDGE_SECRET ..... OPTIONAL for a LOCAL single-host demo (leave blank).
+#                                REQUIRED for hosted-server / multi-member / production
+#                                deploys (set it; the supervisor "production" profile
+#                                runs hard-token mode and enforces this secret).
 #   - MATRIX_HOMESERVER / _SERVER_NAME  LOOK UP from Palpo (already filled below).
 # Generate randoms with:  openssl rand -hex 24
 
@@ -25,11 +27,17 @@ AGENT_CHAT_BACKEND_PORT=8090
 # (Do NOT use AGENT_CHAT_WEB_URL for this: it also drives the :8084 dashboard queue URL.)
 MSG_BASE_URL=http://127.0.0.1:8090/msg
 
-# OPTIONAL locally: shared secret the bridge sends as X-Bridge-Secret on
-# POST /api/groups (used by `!mkgroup`). When BLANK, the backend SKIPS the check
-# (createRequireBridgeSecret) and 127.0.0.1 is bearer-exempt — so a local demo
-# works with this empty. Read by both sides as process.env.MATRIX_BRIDGE_SECRET
-# (bridge-matrix.js:845, backend lib/backend/auth-adapter.js:235). Not in .env.example.
+# OPTIONAL for a LOCAL single-host demo: shared secret the bridge sends as
+# X-Bridge-Secret on POST /api/groups (used by `!mkgroup`). When BLANK, the backend
+# SKIPS the check (createRequireBridgeSecret) and 127.0.0.1 is bearer-exempt — so a
+# local demo works with this empty. The bridge itself does NOT fail to start on an
+# empty secret; it simply omits the header (bridge-matrix.js: `if (MATRIX_BRIDGE_SECRET)
+# opts.headers['X-Bridge-Secret'] = ...`).
+# REQUIRED once you leave localhost: on a hosted server / multi-member / production
+# deploy, set a strong value (e.g. `openssl rand -hex 24`) so bridge↔backend calls are
+# authenticated. The supervisor "production" profile (configure-standalone-env
+# --agent-token-mode hard) enforces it. Read by both sides as
+# process.env.MATRIX_BRIDGE_SECRET. Not in .env.example.
 MATRIX_BRIDGE_SECRET=
 
 # ── Matrix / Palpo ────────────────────────────────────────────────────

--- a/roadmap/agentchat-demo/agent-chat.env.demo
+++ b/roadmap/agentchat-demo/agent-chat.env.demo
@@ -8,10 +8,9 @@
 #   - MATRIX_BOT_PASSWORD ...... INVENT a password for the @agent-bridge account.
 #   - MATRIX_AGENT_PASSWORD_SECRET  INVENT a long random string; agent passwords
 #                                are derived = sha256("<secret>:<agentname>").
-#   - MATRIX_BRIDGE_SECRET ..... OPTIONAL for a LOCAL single-host demo (leave blank).
-#                                REQUIRED for hosted-server / multi-member / production
-#                                deploys (set it; the supervisor "production" profile
-#                                runs hard-token mode and enforces this secret).
+#   - MATRIX_BRIDGE_SECRET ..... INVENT a long random string. REQUIRED by the
+#                                current agent-chat bridge in every profile,
+#                                including a local single-host demo.
 #   - MATRIX_HOMESERVER / _SERVER_NAME  LOOK UP from Palpo (already filled below).
 # Generate randoms with:  openssl rand -hex 24
 
@@ -27,17 +26,13 @@ AGENT_CHAT_BACKEND_PORT=8090
 # (Do NOT use AGENT_CHAT_WEB_URL for this: it also drives the :8084 dashboard queue URL.)
 MSG_BASE_URL=http://127.0.0.1:8090/msg
 
-# OPTIONAL for a LOCAL single-host demo: shared secret the bridge sends as
-# X-Bridge-Secret on POST /api/groups (used by `!mkgroup`). When BLANK, the backend
-# SKIPS the check (createRequireBridgeSecret) and 127.0.0.1 is bearer-exempt — so a
-# local demo works with this empty. The bridge itself does NOT fail to start on an
-# empty secret; it simply omits the header (bridge-matrix.js: `if (MATRIX_BRIDGE_SECRET)
-# opts.headers['X-Bridge-Secret'] = ...`).
-# REQUIRED once you leave localhost: on a hosted server / multi-member / production
-# deploy, set a strong value (e.g. `openssl rand -hex 24`) so bridge↔backend calls are
-# authenticated. The supervisor "production" profile (configure-standalone-env
-# --agent-token-mode hard) enforces it. Read by both sides as
-# process.env.MATRIX_BRIDGE_SECRET. Not in .env.example.
+# REQUIRED in the current agent-chat stack: bridge-matrix.js refuses to start when
+# this is blank, and backend-v2.js requires the matching X-Bridge-Secret for Matrix
+# ingestion. Generate a strong value (e.g. `openssl rand -hex 24`) and load this same
+# env file into both backend and bridge. This is independent of
+# AGENTCHAT_AGENT_TOKEN_MODE; hard mode does not generate or enforce this value for
+# you. Run `node services/configure-standalone-env.mjs --env <file> --generate-bridge-secret`
+# to populate it without printing the value.
 MATRIX_BRIDGE_SECRET=
 
 # ── Matrix / Palpo ────────────────────────────────────────────────────


### PR DESCRIPTION
Corrects N2 from the matrix.palpo.im end-to-end report.

Current agent-chat `fork/master` requires `MATRIX_BRIDGE_SECRET` in every profile, including a local single-host demo:
- `bridge-matrix.js` refuses to start when the value is empty
- `backend-v2.js` requires the matching `X-Bridge-Secret` for Matrix ingestion
- this behavior is independent of `AGENTCHAT_AGENT_TOKEN_MODE`; hard token mode does not generate or enforce the bridge secret

The demo env now tells operators to generate a strong value, load the same env into backend and bridge, and optionally use:
`node services/configure-standalone-env.mjs --env <file> --generate-bridge-secret`

Verification:
- checked against agent-chat `fork/master` behavior
- user manual test approved on 2026-07-22