### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "robrix"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 categories = ["gui"]
 repository = "https://github.com/Project-Robius-China/robrix2"
-version = "1.0.0"
+version = "1.1.0"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]


### PR DESCRIPTION
## Release v1.1.0

Bumps the crate version from `1.0.0` → `1.1.0` in preparation for cutting the **v1.1.0** release.

### Changes
- `Cargo.toml`: `version = "1.1.0"`
- `Cargo.lock`: `robrix` entry synced to `1.1.0`

### Why both files
`release.yml`'s `check_tag_version` job runs `cargo metadata --no-deps --format-version 1 --frozen`. `--frozen` fails if `Cargo.lock` is out of sync with `Cargo.toml`, so both must be bumped together. Verified locally: the command resolves to `1.1.0`.

### Release procedure (after this merges)
1. Squash-merge this PR into `main`.
2. Tag the merged `main` commit `v1.1.0` and push to `robrix2` — the tag push triggers `release.yml` (Clippy Gate → version-consistency gate → multi-platform build & GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)