### PR TITLE
feat(accounts): quick account switcher in the desktop nav rail

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -203,6 +203,12 @@
   "bot_binding_modal.popup.inviting": "Adding bot {bot_user_id} to this room...",
   "bot_binding_modal.popup.removing": "Removing bot {bot_user_id} from this room...",
 
+  "account_menu.badge.active": "Active",
+  "account_menu.item.add_account": "Log Into More Accounts",
+  "account_menu.item.settings": "Account Settings",
+  "account_menu.item.logout": "Log Out",
+  "account_menu.switching": "Switching account…",
+  "account_menu.switched": "Switched to {user}",
   "add_menu.item.new_room": "New room",
   "add_menu.item.new_dm": "New direct message",
   "add_menu.item.join": "Join with a link",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -203,6 +203,12 @@
   "bot_binding_modal.popup.inviting": "正在将机器人 {bot_user_id} 添加到该房间...",
   "bot_binding_modal.popup.removing": "正在将机器人 {bot_user_id} 从该房间移除...",
 
+  "account_menu.badge.active": "当前",
+  "account_menu.item.add_account": "登录更多账号",
+  "account_menu.item.settings": "账号设置",
+  "account_menu.item.logout": "退出登录",
+  "account_menu.switching": "正在切换账号…",
+  "account_menu.switched": "已切换到 {user}",
   "add_menu.item.new_room": "新建房间",
   "add_menu.item.new_dm": "新建私信",
   "add_menu.item.join": "通过链接加入",

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,13 +16,14 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use crate::{
     avatar_cache::{self, clear_avatar_cache}, room_preview_cache::clear_room_preview_cache, home::{
+        account_menu::{AccountMenuAction, AccountMenuWidgetRefExt},
         add_menu::{AddMenuAction, AddMenuWidgetRefExt},
         add_room::{CreateRoomModalAction, CreateRoomModalWidgetRefExt, JoinRoomModalAction, JoinRoomModalWidgetRefExt, StartChatModalAction, StartChatModalWidgetRefExt},
         bot_binding_modal::{BotBindingModalAction, BotBindingModalWidgetRefExt},
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt, mark_invite_modal_closed}, invite_screen::{InviteScreenWidgetRefExt, LeaveRoomResultAction}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::{RoomContextMenuAction, RoomContextMenuWidgetRefExt}, room_screen::{InviteAction, MessageAction, ReportRoomModalAction, ReportRoomModalWidgetRefExt, ReportRoomResultAction, RoomScreenWidgetRefExt, TimelineUpdate, clear_timeline_states, set_room_info_action_modal_open}, room_settings_modal::{RoomSettingsAction, RoomSettingsModalWidgetRefExt}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, space_lobby::SpaceLobbyScreenWidgetRefExt, spaces_bar::SpacesBarRef
     }, i18n::{AppLanguage, tr_fmt, tr_key}, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
-    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, register::RegisterAction, room::BasicRoomDetails, shared::{confirmation_modal::{ConfirmationModalAction, ConfirmationModalContent, ConfirmationModalWidgetRefExt}, file_upload_modal::{FilePreviewerAction, FileUploadModalWidgetRefExt}, forward_modal::{ForwardMessageModalAction, ForwardMessageModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, room_filter_input_bar::FilterAction}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, RemoteDirectorySearchKind, RemoteDirectorySearchResult, RoomSettingsFetchedAction, RoomAvatarUploadedAction, TimelineKind, AccountSwitchAction, current_user_id, get_client, submit_async_request, get_timeline_update_sender}, updater::{UpdateCheckOutcome, check_for_updates, load_skipped_update_version, save_skipped_update_version, update_release_page_url}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
+    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, register::RegisterAction, room::BasicRoomDetails, shared::{confirmation_modal::{ConfirmationModalAction, ConfirmationModalContent, ConfirmationModalWidgetRefExt}, file_upload_modal::{FilePreviewerAction, FileUploadModalWidgetRefExt}, forward_modal::{ForwardMessageModalAction, ForwardMessageModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, room_filter_input_bar::FilterAction}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, RemoteDirectorySearchKind, RemoteDirectorySearchResult, RoomSettingsFetchedAction, RoomAvatarUploadedAction, TimelineKind, AccountSwitchAction, current_user_id, get_client, submit_async_request, get_timeline_update_sender, end_account_switch_guard}, updater::{UpdateCheckOutcome, check_for_updates, load_skipped_update_version, save_skipped_update_version, update_release_page_url}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
     }, settings::app_preferences::{AppPreferences, AppPreferencesAction, UiZoom, effective_is_desktop}
@@ -134,6 +135,10 @@ script_mod! {
                         // anchored next to the "+" button. Like the context menus,
                         // it is a self-positioning overlay in front of the content.
                         add_menu := AddMenu { }
+
+                        // The account switcher popup, anchored at the desktop rail's
+                        // bottom-left avatar. Same self-positioning overlay pattern.
+                        account_menu := AccountMenu { }
 
                         // A modal to confirm sending out an invite to a room.
                         invite_confirmation_modal := Modal {
@@ -1168,6 +1173,16 @@ impl MatchEvent for App {
             match action.downcast_ref() {
                 Some(AccountSwitchAction::Starting(user_id)) => {
                     log!("Account switch starting to: {}", user_id);
+                    // Show a loading toast so the heavy client teardown + rebuild + resync
+                    // doesn't look frozen. The popup list is append-only (no dismiss-by-key),
+                    // so this Info toast just auto-dismisses on its own timer; the Switched
+                    // success toast then confirms completion. A short duration keeps the two
+                    // from overlapping for long on a fast switch.
+                    enqueue_popup_notification(
+                        tr_key(self.app_state.app_language, "account_menu.switching"),
+                        PopupKind::Info,
+                        Some(4.0),
+                    );
                     // Clear UI state during account switch
                     clear_all_app_state(cx);
                     self.app_state.selected_room = None;
@@ -1181,8 +1196,14 @@ impl MatchEvent for App {
                 }
                 Some(AccountSwitchAction::Switched(user_id)) => {
                     log!("Account switch completed to: {}", user_id);
+                    // Release the UI-thread switch guard so the next switch can proceed.
+                    end_account_switch_guard();
                     enqueue_popup_notification(
-                        format!("Switched to account {}", user_id),
+                        tr_fmt(
+                            self.app_state.app_language,
+                            "account_menu.switched",
+                            &[("user", user_id.as_str())],
+                        ),
                         PopupKind::Success,
                         Some(3.0),
                     );
@@ -1191,6 +1212,8 @@ impl MatchEvent for App {
                 }
                 Some(AccountSwitchAction::Failed(error)) => {
                     log!("Account switch failed: {}", error);
+                    // Release the UI-thread switch guard so the user can retry.
+                    end_account_switch_guard();
                     let error_text = error.to_string();
                     let error_for_copy = error_text.clone();
                     enqueue_notification(NotificationItem {
@@ -1498,6 +1521,27 @@ impl MatchEvent for App {
                 let pos_y = (pos.y - rect.pos.y).min(rect.size.y - expected_dimensions.y).max(0.0);
                 let margin = Inset { left: pos_x, top: pos_y, right: 0.0, bottom: 0.0 };
                 let mut main_content_view = add_menu.view(cx, ids!(main_content));
+                script_apply_eval!(cx, main_content_view, {
+                    margin: #(margin)
+                });
+                self.ui.redraw(cx);
+                continue;
+            }
+
+            // Handle an action requesting to open the account switcher menu. Unlike the
+            // add menu, `pos` is the desired BOTTOM-left corner of the card (the avatar
+            // sits low in the rail), so we subtract the card height to grow it upward.
+            if let Some(AccountMenuAction::Open { pos }) = action.downcast_ref::<AccountMenuAction>() {
+                self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
+                let account_menu = self.ui.account_menu(cx, ids!(account_menu));
+                let expected_dimensions = account_menu.show(cx, self.app_state.app_language);
+                let rect = self.ui.view(cx, ids!(overlay_container)).area().rect(cx);
+                let pos_x = (pos.x - rect.pos.x).min(rect.size.x - expected_dimensions.x).max(0.0);
+                let pos_y = (pos.y - expected_dimensions.y - rect.pos.y)
+                    .min(rect.size.y - expected_dimensions.y)
+                    .max(0.0);
+                let margin = Inset { left: pos_x, top: pos_y, right: 0.0, bottom: 0.0 };
+                let mut main_content_view = account_menu.view(cx, ids!(main_content));
                 script_apply_eval!(cx, main_content_view, {
                     margin: #(margin)
                 });

--- a/src/home/account_menu.rs
+++ b/src/home/account_menu.rs
@@ -1,0 +1,510 @@
+//! A small popup menu, anchored at the account-switcher button in the bottom-left of the
+//! desktop navigation rail, that lets you quickly switch between logged-in accounts and
+//! add another account — the "Feishu-style" account switcher.
+//!
+//! Structure of the anchored card (top → bottom; it opens *upward* from the bottom of the
+//! rail):
+//!   * Active account header  → avatar + display name + user ID + an "Active" marker
+//!   * One row per *other* logged-in account → click to switch to it
+//!   * A divider
+//!   * "Log Into More Accounts" → opens the login screen in add-account mode
+//!   * "Account Settings"       → opens Settings
+//!   * "Log Out"                → opens the LogoutConfirmModal
+//!
+//! It reuses the same anchored-overlay pattern as [`crate::home::add_menu::AddMenu`]:
+//! a full-screen scrim whose inner `main_content` card is positioned by the App
+//! (which clamps it to the overlay container and sets its `margin` via
+//! `script_apply_eval!`). Unlike AddMenu, the number of account rows is dynamic, so a
+//! fixed pool of [`MAX_SWITCH_ROWS`] row buttons is shown/hidden at `show()` time, and
+//! `show()` returns the *computed* card height so the App can anchor it upward.
+//!
+//! Desktop-only: opened from the rail's account-switcher button, and auto-closes if the
+//! layout crosses the desktop/mobile breakpoint while open. Mobile keeps its existing
+//! "switch account in Settings" flow.
+
+use makepad_widgets::*;
+use matrix_sdk::ruma::OwnedUserId;
+
+use crate::{
+    account_manager,
+    app::AppState,
+    home::navigation_tab_bar::{get_own_profile, NavigationBarAction},
+    i18n::{tr_key, AppLanguage},
+    login::login_screen::LoginAction,
+    logout::logout_confirm_modal::LogoutConfirmModalAction,
+    settings::app_preferences::effective_is_desktop,
+    shared::avatar::AvatarWidgetExt,
+    sliding_sync::{current_user_id, request_switch_account},
+    utils,
+};
+
+/// The fixed width of the account menu card, in DIPs.
+pub const ACCOUNT_MENU_WIDTH: f64 = 272.0;
+
+/// The maximum number of *other* accounts shown as switchable rows. Realistically
+/// nobody logs into more accounts than this at once; if they do, the extras are hidden
+/// (and logged). Settings → Account applies the same cap, so the only case affected is
+/// 10+ simultaneous logins — to reach a hidden account, log out one of the visible ones.
+pub const MAX_SWITCH_ROWS: usize = 8;
+
+// --- Height constants, kept in sync with the DSL below so `show()` can compute the
+// card's total height for upward anchoring + clamping (main_content is height:Fit, so
+// there is no measurable height until it has been drawn). ---
+const CARD_VPAD: f64 = 6.0; // main_content padding (top == bottom == this)
+const ROW_SPACING: f64 = 2.0; // main_content `spacing` between children
+const HEADER_H: f64 = 58.0; // active-account header (avatar 40 + 9+9 padding)
+const SWITCH_ROW_H: f64 = 40.0; // one switchable account row
+const DIVIDER_H: f64 = 10.0; // LineH (shared height 2) + its 4 + 4 vertical margins
+const ACTION_H: f64 = 40.0; // one action item (add / settings / logout)
+const ACTION_COUNT: f64 = 3.0;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+
+    // A single action row (add account / settings): left-aligned icon + label, with an
+    // RBX surface/hover/pressed background and a soft rounded highlight. Mirrors
+    // `AddMenuItem`.
+    mod.widgets.AccountMenuItem = RobrixIconButton {
+        height: 40,
+        width: Fill,
+        margin: 0,
+        padding: Inset{left: 12, right: 12, top: 8, bottom: 8}
+        spacing: 12,
+        align: Align{x: 0.0, y: 0.5}
+        icon_walk: Walk{width: 18, height: 18, margin: Inset{right: 2}}
+
+        draw_bg +: {
+            color: (RBX_BG_SURFACE)
+            color_hover: (RBX_BG_HOVER)
+            color_down: (RBX_BG_PRESSED)
+            border_size: 0.0
+            border_radius: (RBX_RADIUS_SM)
+        }
+        draw_icon.color: (RBX_ACCENT)
+        draw_text +: {
+            color: (RBX_FG_PRIMARY)
+            color_hover: (RBX_FG_PRIMARY)
+            color_down: (RBX_FG_PRIMARY)
+            text_style: RBX_TEXT_BODY {}
+        }
+    }
+
+    // Danger-styled action row (log out): red icon/text, red-tinted hover.
+    mod.widgets.AccountMenuDangerItem = mod.widgets.AccountMenuItem {
+        draw_bg +: {
+            color: (RBX_BG_SURFACE)
+            color_hover: (RBX_DANGER_BG)
+            color_down: (RBX_DANGER_BG)
+        }
+        draw_icon.color: (RBX_DANGER_FG)
+        draw_text +: {
+            color: (RBX_DANGER_FG)
+            color_hover: (RBX_DANGER_FG)
+            color_down: (RBX_DANGER_FG)
+        }
+    }
+
+    // A switchable "other account" row: a generic user icon + the account's user ID. A
+    // button (not a custom avatar row) so it integrates with the overlay's standard
+    // button-click event flow, exactly like the AddMenu items.
+    mod.widgets.AccountSwitchItem = RobrixIconButton {
+        height: 40,
+        width: Fill,
+        margin: 0,
+        visible: false,
+        padding: Inset{left: 10, right: 12, top: 6, bottom: 6}
+        spacing: 10,
+        align: Align{x: 0.0, y: 0.5}
+        icon_walk: Walk{width: 22, height: 22, margin: Inset{right: 2}}
+
+        draw_bg +: {
+            color: (RBX_BG_SURFACE)
+            color_hover: (RBX_BG_HOVER)
+            color_down: (RBX_BG_PRESSED)
+            border_size: 0.0
+            border_radius: (RBX_RADIUS_SM)
+        }
+        // ICON_PEOPLE, not ICON_ADD_USER: an "add user" glyph on a *switch* row reads as
+        // "add this account" right above the real "Log Into More Accounts" item.
+        draw_icon +: { svg: (ICON_PEOPLE), color: (RBX_FG_SECONDARY) }
+        draw_text +: {
+            color: (RBX_FG_PRIMARY)
+            color_hover: (RBX_FG_PRIMARY)
+            color_down: (RBX_FG_PRIMARY)
+            text_style: RBX_TEXT_BODY {}
+        }
+        text: "@other:server"
+    }
+
+    mod.widgets.AccountMenu = set_type_default() do #(AccountMenu::register_widget(vm)) {
+        ..mod.widgets.SolidView
+
+        visible: false,
+        flow: Overlay,
+        width: Fill,
+        height: Fill,
+        cursor: MouseCursor.Default,
+        align: Align{x: 0, y: 0}
+
+        show_bg: true
+        draw_bg +: {
+            color: (RBX_SCRIM)
+        }
+
+        main_content := RoundedView {
+            flow: Down
+            width: 272,
+            height: Fit,
+            padding: 6,
+            spacing: 2,
+
+            show_bg: true
+            // Flat card: tight corners, a defined border, no drop shadow (the scrim
+            // already separates it from the content behind).
+            draw_bg +: {
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_STRONG)
+            }
+
+            // --- Active account header ---
+            // height: Fit so the two-line name + user id is never clipped by the card.
+            active_account_header := RoundedView {
+                width: Fill,
+                height: Fit,
+                flow: Right,
+                align: Align{y: 0.5}
+                padding: Inset{left: 8, right: 8, top: 9, bottom: 9}
+                spacing: 10,
+                show_bg: true
+                draw_bg +: {
+                    color: (RBX_ACCENT_SOFT)
+                    border_radius: (RBX_RADIUS_SM)
+                }
+
+                active_avatar := Avatar {
+                    width: 40, height: 40
+                }
+
+                View {
+                    width: Fill, height: Fit,
+                    flow: Down,
+                    spacing: 0,
+
+                    active_name := Label {
+                        width: Fill, height: Fit,
+                        margin: 0, padding: 0,
+                        text_overflow: Ellipsis
+                        draw_text +: {
+                            color: (RBX_FG_PRIMARY)
+                            text_style: RBX_TEXT_BODY_STRONG {}
+                        }
+                        text: "Display Name"
+                    }
+                    active_user_id := Label {
+                        width: Fill, height: Fit,
+                        margin: 0, padding: 0,
+                        text_overflow: Ellipsis
+                        draw_text +: {
+                            color: (RBX_FG_SECONDARY)
+                            text_style: RBX_TEXT_META {}
+                        }
+                        text: "@user:server"
+                    }
+                }
+
+                // "Current account" marker on the right.
+                //
+                // Deliberately plain bold ACCENT TEXT rather than a filled pill: the
+                // pill's rounded-box fill did not render here, which left white-on-pale
+                // text that was almost unreadable. Text always renders, and teal-on-pale
+                // has ample contrast, so this is unambiguous without depending on a
+                // background being drawn.
+                active_badge_label := Label {
+                    width: Fit, height: Fit,
+                    margin: 0, padding: 0,
+                    draw_text +: {
+                        color: (RBX_ACCENT)
+                        text_style: theme.font_bold { font_size: 10.5 }
+                    }
+                    text: "Active"
+                }
+            }
+
+            // --- Other accounts (fixed pool, populated dynamically) ---
+            account_switch_item_0 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_1 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_2 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_3 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_4 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_5 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_6 := mod.widgets.AccountSwitchItem {}
+            account_switch_item_7 := mod.widgets.AccountSwitchItem {}
+
+            divider := LineH {
+                margin: Inset{top: 4, bottom: 4, left: 8, right: 8}
+                draw_bg.color: (RBX_DIVIDER)
+            }
+
+            // --- Actions ---
+            add_account_item := mod.widgets.AccountMenuItem {
+                draw_icon +: { svg: (ICON_ADD) }
+                text: "Log Into More Accounts"
+            }
+            settings_item := mod.widgets.AccountMenuItem {
+                draw_icon +: { svg: (ICON_SETTINGS) }
+                text: "Account Settings"
+            }
+            logout_item := mod.widgets.AccountMenuDangerItem {
+                draw_icon +: { svg: (ICON_LOGOUT) }
+                text: "Log Out"
+            }
+        }
+    }
+}
+
+
+/// Action to request showing the account menu, anchored so the card's *bottom-left*
+/// corner sits at `pos` (already computed by the emitter — the bottom-right of the
+/// account-switcher button, so the menu opens upward). The App clamps this into the
+/// overlay container using the height returned by [`AccountMenu::show`].
+#[derive(Clone, Debug, Default)]
+pub enum AccountMenuAction {
+    Open { pos: DVec2 },
+    #[default]
+    None,
+}
+
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct AccountMenu {
+    #[deref] view: View,
+    #[source] source: ScriptObjectRef,
+    #[rust] app_language: AppLanguage,
+    /// The effective layout (desktop vs mobile) at the moment the menu was opened. If
+    /// it changes while the menu is open, the menu auto-closes — its anchored position
+    /// is only valid for the layout it was opened in.
+    #[rust(true)] opened_is_desktop: bool,
+    /// The user IDs of the *other* accounts, index-aligned with the visible switch rows,
+    /// so a row click maps back to the account to switch to.
+    #[rust] switch_targets: Vec<OwnedUserId>,
+}
+
+impl Widget for AccountMenu {
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let step = self.view.draw_walk(cx, scope, walk);
+        if self.visible {
+            let main_content_area = self.view(cx, ids!(main_content)).area();
+            cx.block_scrolling_except_within(main_content_area);
+        }
+        step
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if !self.visible {
+            return;
+        }
+        // Close if the layout switched between desktop and mobile while open, so the
+        // menu can't linger at a now-wrong anchor in the other layout.
+        if effective_is_desktop(cx) != self.opened_is_desktop {
+            self.close(cx);
+            return;
+        }
+        if let Some(app_state) = scope.data.get::<AppState>()
+            && self.app_language != app_state.app_language
+        {
+            self.set_app_language(cx, app_state.app_language);
+        }
+        self.view.handle_event(cx, event, scope);
+
+        // Close on backdrop click, Escape, or a system back gesture. Opened from a
+        // button *click* (FingerUp) which is fully consumed by the time we become
+        // visible, so no stray FingerUp lands on the scrim.
+        let area = self.view.area();
+        let close_menu = event.back_pressed()
+            || match event.hits_with_capture_overload(cx, area, true) {
+                Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
+                Hit::FingerUp(fue) if fue.is_over => {
+                    !self.view(cx, ids!(main_content)).area().rect(cx).contains(fue.abs)
+                }
+                _ => false,
+            };
+        if close_menu {
+            self.close(cx);
+            return;
+        }
+
+        self.widget_match_event(cx, event, scope);
+    }
+}
+
+impl WidgetMatchEvent for AccountMenu {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        // A switchable account row was clicked → switch to that account.
+        let switch_ids = [
+            ids!(account_switch_item_0),
+            ids!(account_switch_item_1),
+            ids!(account_switch_item_2),
+            ids!(account_switch_item_3),
+            ids!(account_switch_item_4),
+            ids!(account_switch_item_5),
+            ids!(account_switch_item_6),
+            ids!(account_switch_item_7),
+        ];
+        for (i, id) in switch_ids.into_iter().enumerate() {
+            if self.button(cx, id).clicked(actions) {
+                if let Some(user_id) = self.switch_targets.get(i).cloned() {
+                    log!("AccountMenu: switching to account {user_id}");
+                    request_switch_account(user_id);
+                }
+                self.close(cx);
+                return;
+            }
+        }
+
+        if self.button(cx, ids!(add_account_item)).clicked(actions) {
+            cx.action(LoginAction::ShowAddAccountScreen);
+            self.close(cx);
+        } else if self.button(cx, ids!(settings_item)).clicked(actions) {
+            cx.action(NavigationBarAction::OpenSettings);
+            self.close(cx);
+        } else if self.button(cx, ids!(logout_item)).clicked(actions) {
+            cx.action(LogoutConfirmModalAction::Open);
+            self.close(cx);
+        }
+    }
+}
+
+impl AccountMenu {
+    fn set_app_language(&mut self, cx: &mut Cx, app_language: AppLanguage) {
+        self.app_language = app_language;
+        self.label(cx, ids!(active_badge_label))
+            .set_text(cx, tr_key(self.app_language, "account_menu.badge.active"));
+        self.button(cx, ids!(add_account_item))
+            .set_text(cx, tr_key(self.app_language, "account_menu.item.add_account"));
+        self.button(cx, ids!(settings_item))
+            .set_text(cx, tr_key(self.app_language, "account_menu.item.settings"));
+        self.button(cx, ids!(logout_item))
+            .set_text(cx, tr_key(self.app_language, "account_menu.item.logout"));
+    }
+
+    /// Populates the menu from the current account state and shows it, returning its
+    /// expected `(width, height)` so the App can anchor + clamp it. `height` is computed
+    /// from the number of visible rows (the card is height:Fit).
+    fn show(&mut self, cx: &mut Cx, app_language: AppLanguage) -> DVec2 {
+        self.opened_is_desktop = effective_is_desktop(cx);
+        self.set_app_language(cx, app_language);
+
+        // Determine the active account and the list of other accounts. Sorted, because the
+        // AccountManager stores accounts in a HashMap — without this the rows would appear
+        // in a different order on every launch.
+        let active_id = account_manager::get_active_user_id().or_else(current_user_id);
+        self.switch_targets = account_manager::get_all_user_ids()
+            .into_iter()
+            .filter(|id| Some(id) != active_id.as_ref())
+            .collect();
+        self.switch_targets.sort();
+
+        // Populate the active-account header from our own profile (real avatar + display
+        // name when available), mirroring how ProfileIcon draws its avatar.
+        let own_profile = get_own_profile(cx);
+        let active_avatar = self.view.avatar(cx, ids!(active_avatar));
+        let (name_text, user_id_text) = if let Some(profile) = own_profile.as_ref() {
+            let mut drew_image = false;
+            if let Some(avatar_img_data) = profile.avatar_state.data() {
+                drew_image = active_avatar
+                    .show_image(cx, None, |cx, img| utils::load_png_or_jpg(&img, cx, avatar_img_data))
+                    .is_ok();
+            }
+            if !drew_image {
+                active_avatar.show_text(cx, None, None, profile.displayable_name());
+            }
+            (profile.displayable_name().to_string(), profile.user_id.to_string())
+        } else if let Some(active) = active_id.as_ref() {
+            active_avatar.show_text(cx, None, None, active.as_str());
+            (active.to_string(), active.to_string())
+        } else {
+            active_avatar.show_text(cx, None, None, "");
+            (
+                tr_key(self.app_language, "settings.account.user_id.not_logged_in").to_string(),
+                String::new(),
+            )
+        };
+        self.label(cx, ids!(active_name)).set_text(cx, &name_text);
+        self.label(cx, ids!(active_user_id)).set_text(cx, &user_id_text);
+        // Hide the user-id line when it would just duplicate the name (no display name).
+        self.label(cx, ids!(active_user_id))
+            .set_visible(cx, !user_id_text.is_empty() && user_id_text != name_text);
+
+        // Populate / toggle the fixed pool of other-account rows.
+        let switch_ids = [
+            ids!(account_switch_item_0),
+            ids!(account_switch_item_1),
+            ids!(account_switch_item_2),
+            ids!(account_switch_item_3),
+            ids!(account_switch_item_4),
+            ids!(account_switch_item_5),
+            ids!(account_switch_item_6),
+            ids!(account_switch_item_7),
+        ];
+        let shown = self.switch_targets.len().min(MAX_SWITCH_ROWS);
+        if self.switch_targets.len() > MAX_SWITCH_ROWS {
+            log!(
+                "AccountMenu: {} other accounts exceed the {} switchable rows; the extras \
+                 are hidden (Settings applies the same cap — log out a visible account to \
+                 reach them).",
+                self.switch_targets.len(),
+                MAX_SWITCH_ROWS,
+            );
+        }
+        for (i, id) in switch_ids.into_iter().enumerate() {
+            if i < shown {
+                // Extract the text first: `self.switch_targets[i]` borrows self, which
+                // would conflict with the `&mut self` from `self.button(...)`.
+                let text = self.switch_targets[i].to_string();
+                self.button(cx, id).set_text(cx, &text);
+                self.button(cx, id).set_visible(cx, true);
+                self.button(cx, id).reset_hover(cx);
+            } else {
+                self.button(cx, id).set_visible(cx, false);
+            }
+        }
+        for id in [ids!(add_account_item), ids!(settings_item), ids!(logout_item)] {
+            self.button(cx, id).reset_hover(cx);
+        }
+
+        self.visible = true;
+        cx.set_key_focus(self.view.area());
+        self.redraw(cx);
+
+        let visible_rows = shown as f64;
+        let height = 2.0 * CARD_VPAD
+            + HEADER_H
+            + visible_rows * SWITCH_ROW_H
+            + DIVIDER_H
+            + ACTION_COUNT * ACTION_H
+            + (visible_rows + 4.0) * ROW_SPACING;
+        dvec2(ACCOUNT_MENU_WIDTH, height)
+    }
+
+    fn close(&mut self, cx: &mut Cx) {
+        self.visible = false;
+        cx.revert_key_focus();
+        cx.unblock_scrolling();
+        self.redraw(cx);
+    }
+}
+
+impl AccountMenuRef {
+    pub fn show(&self, cx: &mut Cx, app_language: AppLanguage) -> DVec2 {
+        let Some(mut inner) = self.borrow_mut() else { return DVec2::default() };
+        inner.show(cx, app_language)
+    }
+
+    pub fn is_currently_shown(&self) -> bool {
+        self.borrow().is_some_and(|inner| inner.visible)
+    }
+}

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -1,5 +1,6 @@
 use makepad_widgets::{ScriptVm, event::{DigitId, FingerDownEvent, FingerLongPressEvent, FingerUpEvent}};
 
+pub mod account_menu;
 pub mod add_menu;
 pub mod add_room;
 pub mod bot_binding_modal;
@@ -98,6 +99,9 @@ pub fn script_mod(vm: &mut ScriptVm) {
     // `add_menu` only depends on base widgets (RobrixIconButton, SolidView,
     // RoundedShadowView) so its order among the home widgets is not sensitive.
     add_menu::script_mod(vm);
+    // `account_menu` likewise only depends on base + shared widgets (RobrixIconButton,
+    // SolidView, RoundedView, Avatar, LineH), so its order here is not sensitive.
+    account_menu::script_mod(vm);
     bot_binding_modal::script_mod(vm);
     create_bot_modal::script_mod(vm);
     delete_bot_modal::script_mod(vm);

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -34,7 +34,7 @@ use crate::{
     app::AppState, avatar_cache::{self, AvatarCacheEntry}, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::LogoutAction, profile::{
         user_profile::UserProfile,
         user_profile_cache::{self, UserProfileUpdate},
-    }, home::{spaces_bar::SpacesBarWidgetExt, add_menu::AddMenuAction}, shared::{
+    }, home::{spaces_bar::SpacesBarWidgetExt, add_menu::AddMenuAction, account_menu::AccountMenuAction}, shared::{
         avatar::{AvatarState, AvatarWidgetExt}, styles::*, verification_badge::VerificationBadgeWidgetExt
     }, settings::app_preferences::{effective_is_desktop, AppPreferencesGlobal, AppPreferencesAction, ViewModeOverride}, sliding_sync::{current_user_id, AccountDataAction, AccountSwitchAction}, utils::{self, RoomNameId}
 };
@@ -55,10 +55,13 @@ script_mod! {
         flow: Down,
         text: "",
 
+        // Match the app-wide icon scale (RBX_ICON_LG) so the rail's Tabler icons carry the
+        // same visual stroke weight as icons everywhere else. Rendering them at ~34px made
+        // the 24px-viewBox / stroke-2 glyphs look noticeably heavier than the rest of the UI.
         icon_walk: Walk{
             margin: 0,
-            width: (NAVIGATION_TAB_BAR_SIZE / 2.2),
-            height: (NAVIGATION_TAB_BAR_SIZE / 2.2)
+            width: (RBX_ICON_LG),
+            height: (RBX_ICON_LG)
         }
         // Fully hide the text with zero size, zero margin, and zero spacing
         label_walk: Walk{margin: 0, width: 0, height: 0}
@@ -278,6 +281,36 @@ script_mod! {
         }
     }
 
+    // The bottom rail item that opens the account switcher. A plain icon button (NOT a
+    // second ProfileIcon): the switcher is an action, not the user's avatar, and this
+    // keeps the rail's icon language consistent with Home / "+". It also avoids the
+    // runtime show/hide juggling that a shared avatar template needed.
+    mod.widgets.AccountSwitcherButton = RobrixIconButton {
+        width: Fill,
+        height: (NAVIGATION_TAB_BAR_SIZE - 5),
+        margin: (SPACE_XS),
+        padding: (SPACE_XS),
+        align: Align{x: 0.5, y: 0.5}
+        spacing: 0,
+        text: "",
+        // Hide the label entirely so only the icon shows (mirrors NavigationTabButton).
+        label_walk: Walk{margin: 0, width: 0, height: 0}
+        icon_walk: Walk{margin: 0, width: (RBX_ICON_LG), height: (RBX_ICON_LG)}
+
+        draw_bg +: {
+            color: #0000
+            color_hover: (RBX_NAV_ITEM_HOVER_BG)
+            color_down: (RBX_NAV_ITEM_HOVER_BG)
+            color_disabled: #0000
+            border_size: 0.0
+            border_radius: (RBX_RADIUS_SM)
+            border_color: #0000
+            border_color_hover: #0000
+            border_color_down: #0000
+        }
+        draw_icon +: { svg: (ICON_PEOPLE), color: (RBX_NAV_FG) }
+    }
+
     mod.widgets.HomeButton = mod.widgets.NavigationTabButton {
         draw_icon +: { svg: (ICON_HOME) }
     }
@@ -303,6 +336,7 @@ script_mod! {
             // stray hairline gap on either side.
             draw_bg.color: (RBX_NAV_BG)
 
+            // Top profile avatar — clicking it opens Settings (unchanged).
             CachedWidget {
                 profile_icon := mod.widgets.ProfileIcon {}
             }
@@ -315,8 +349,18 @@ script_mod! {
 
             mod.widgets.Separator {}
 
+            // The spaces bar takes the flexible middle (height: Fill), which pins the
+            // account switcher below it to the very bottom of the rail (Feishu-style).
             CachedWidget {
                 root_spaces_bar := mod.widgets.SpacesBar {}
+            }
+
+            mod.widgets.Separator {}
+
+            // Bottom-left account switcher: an icon button that opens the AccountMenu
+            // (quick account switcher / add account), leaving the top avatar for Settings.
+            CachedWidget {
+                account_switcher_button := mod.widgets.AccountSwitcherButton {}
             }
 
         }
@@ -377,9 +421,10 @@ script_mod! {
     }
 }
 
-/// The icon in the NavigationTabBar that show the user's avatar.
+/// The icon in the NavigationTabBar that shows the user's avatar.
 ///
-/// Clicking on this icon will open the settings screen.
+/// Clicking it opens the settings screen. (The account switcher is a separate
+/// `AccountSwitcherButton` at the bottom of the rail — it is an action, not an avatar.)
 #[derive(Script, Widget)]
 pub struct ProfileIcon {
     #[deref] view: View,
@@ -750,8 +795,20 @@ impl Widget for NavigationTabBar {
                 }
             }
 
+            // The bottom account-switcher button opens the AccountMenu, anchored so the
+            // card's BOTTOM-left sits at the button's bottom-right (the App grows it upward).
+            // Same recipe as the desktop rail "+" opening the AddMenu above.
+            if effective_is_desktop(cx)
+                && self.view.button(cx, ids!(account_switcher_button)).clicked(actions)
+            {
+                let rect = self.view.widget(cx, ids!(account_switcher_button)).area().rect(cx);
+                cx.action(AccountMenuAction::Open {
+                    pos: dvec2(rect.pos.x + rect.size.x + 4.0, rect.pos.y + rect.size.y),
+                });
+            }
+
             for action in actions {
-                // On Desktop, clicking the profile avatar opens Settings.
+                // The top profile avatar opens Settings.
                 if let ProfileIconAction::Clicked = action.as_widget_action().cast() {
                     cx.action(NavigationBarAction::OpenSettings);
                     continue;

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -6,7 +6,7 @@ use makepad_widgets::{text::selection::Cursor, *};
 use rfd::FileDialog;
 use matrix_sdk::{encryption::VerificationState, ruma::OwnedUserId};
 
-use crate::{account_manager, app::AppState, avatar_cache::{self}, home::navigation_tab_bar::get_own_profile, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::{user_profile::UserProfile, user_profile_cache}, shared::{avatar::{AvatarState, AvatarWidgetExt}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, styles::*}, sliding_sync::{get_client, current_user_id, AccessTokenCopyAction, AccessTokenCopyError, AccountDataAction, AccountSwitchAction, MatrixRequest, OwnDeviceInfo, PasswordChangeFailure, submit_async_request}, utils, verification::VerificationStateAction};
+use crate::{account_manager, app::AppState, avatar_cache::{self}, home::navigation_tab_bar::get_own_profile, i18n::{AppLanguage, tr_fmt, tr_key}, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::{user_profile::UserProfile, user_profile_cache}, shared::{avatar::{AvatarState, AvatarWidgetExt}, popup_list::{PopupKind, enqueue_popup_notification, enqueue_notification, NotificationItem, NotificationAction, NotifActionStyle}, styles::*}, sliding_sync::{get_client, current_user_id, request_switch_account, AccessTokenCopyAction, AccessTokenCopyError, AccountDataAction, AccountSwitchAction, MatrixRequest, OwnDeviceInfo, PasswordChangeFailure, submit_async_request}, utils, verification::VerificationStateAction};
 #[cfg(any(target_os = "macos", target_os = "windows", all(target_os = "linux", not(target_env = "ohos"))))]
 use crate::{app::ConfirmDeleteAction, shared::confirmation_modal::ConfirmationModalContent};
 
@@ -14,6 +14,48 @@ script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
 
+
+    // One "other account" row: the account's user ID on the left and a "Switch" button
+    // on the right. Instantiated as a fixed pool below (shown/hidden dynamically) so the
+    // full list of logged-in accounts is switchable, not just the first one.
+    mod.widgets.OtherAccountEntry = RoundedView {
+        width: Fill, height: Fit
+        flow: Right,
+        align: Align{y: 0.5}
+        padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_SM)}
+        spacing: (SPACE_SM)
+        visible: false
+        show_bg: true
+        draw_bg +: {
+            color: (RBX_BG_SURFACE_SUBTLE)
+            border_radius: (RBX_RADIUS_SM)
+            border_size: 1.0
+            border_color: (RBX_STROKE_SOFT)
+        }
+
+        View {
+            width: Fill, height: Fit
+            flow: Down,
+            spacing: 2
+
+            other_account_label := Label {
+                width: Fill, height: Fit
+                draw_text +: {
+                    color: (COLOR_TEXT),
+                    text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
+                }
+                text: "@other:server"
+            }
+        }
+
+        switch_account_button := SettingsPrimaryButton {
+            width: Fit, height: Fit
+            padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_SM), right: (SPACE_SM)}
+            draw_icon.svg: (ICON_JUMP)
+            icon_walk: Walk{width: 14, height: 14}
+            text: "Switch"
+        }
+    }
 
     // The view containing all user account-related settings.
     mod.widgets.AccountSettings = #(AccountSettings::register_widget(vm)) {
@@ -409,45 +451,17 @@ script_mod! {
                 text: "Other accounts:"
             }
 
-            // Container for other account entries (simplified: show one other account)
-            other_account_entry := RoundedView {
-                width: Fill, height: Fit
-                flow: Right,
-                align: Align{y: 0.5}
-                padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_SM)}
-                spacing: (SPACE_SM)
-                visible: false
-                show_bg: true
-                draw_bg +: {
-                    color: (RBX_BG_SURFACE_SUBTLE)
-                    border_radius: (RBX_RADIUS_SM)
-                    border_size: 1.0
-                    border_color: (RBX_STROKE_SOFT)
-                }
-
-                View {
-                    width: Fill, height: Fit
-                    flow: Down,
-                    spacing: 2
-
-                    other_account_label := Label {
-                        width: Fill, height: Fit
-                        draw_text +: {
-                            color: (COLOR_TEXT),
-                            text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
-                        }
-                        text: "@other:server"
-                    }
-                }
-
-                switch_account_button := SettingsPrimaryButton {
-                    width: Fit, height: Fit
-                    padding: Inset{top: (SPACE_SM), bottom: (SPACE_SM), left: (SPACE_SM), right: (SPACE_SM)}
-                    draw_icon.svg: (ICON_JUMP)
-                    icon_walk: Walk{width: 14, height: 14}
-                    text: "Switch"
-                }
-            }
+            // Fixed pool of other-account rows (populated dynamically). Every logged-in
+            // account other than the active one gets its own switchable row, capped at
+            // the pool size (see MAX_OTHER_ACCOUNT_ROWS in Rust).
+            other_account_entry_0 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_1 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_2 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_3 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_4 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_5 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_6 := mod.widgets.OtherAccountEntry {}
+            other_account_entry_7 := mod.widgets.OtherAccountEntry {}
 
             account_count_label := Label {
                 width: Fill, height: Fit
@@ -1066,12 +1080,15 @@ impl MatchEvent for AccountSettings {
             cx.action(LogoutConfirmModalAction::Open);
         }
 
-        // Handle "Switch Account" button click
-        if self.view.button(cx, ids!(switch_account_button)).clicked(actions) {
-            // Switch to the first other account
-            if let Some(other_id) = self.other_accounts.first().cloned() {
-                log!("Switching to account: {}", other_id);
-                submit_async_request(MatrixRequest::SwitchAccount { user_id: other_id });
+        // Handle a "Switch" button click on any of the pooled other-account rows:
+        // switch to the account that row represents (index-aligned with `other_accounts`).
+        for (i, btn_id) in switch_account_button_ids().into_iter().enumerate() {
+            if self.view.button(cx, btn_id).clicked(actions) {
+                if let Some(other_id) = self.other_accounts.get(i).cloned() {
+                    log!("Switching to account: {}", other_id);
+                    request_switch_account(other_id);
+                }
+                break;
             }
         }
 
@@ -1187,9 +1204,11 @@ impl AccountSettings {
         self.view
             .label(cx, ids!(other_accounts_label))
             .set_text(cx, tr_key(self.app_language, "settings.account.other_accounts"));
-        self.view
-            .button(cx, ids!(switch_account_button))
-            .set_text(cx, tr_key(self.app_language, "settings.account.button.switch"));
+        for btn_id in switch_account_button_ids() {
+            self.view
+                .button(cx, btn_id)
+                .set_text(cx, tr_key(self.app_language, "settings.account.button.switch"));
+        }
         self.view
             .button(cx, ids!(add_account_button))
             .set_text(cx, tr_key(self.app_language, "settings.account.button.add_another_account"));
@@ -1490,16 +1509,35 @@ impl AccountSettings {
             .into_iter()
             .filter(|id| Some(id) != active_user_id.as_ref())
             .collect();
+        // Sorted: the AccountManager stores accounts in a HashMap, so without this the
+        // rows would be ordered differently on every launch.
+        self.other_accounts.sort();
 
-        // Show "Other accounts" label and entry only if there are other accounts
+        // Show "Other accounts" label only if there are other accounts.
         let has_other_accounts = !self.other_accounts.is_empty();
         self.view.label(cx, ids!(other_accounts_label)).set_visible(cx, has_other_accounts);
-        self.view.view(cx, ids!(other_account_entry)).set_visible(cx, has_other_accounts);
 
-        // If there's at least one other account, show it
-        if let Some(other_id) = self.other_accounts.first() {
-            self.view.label(cx, ids!(other_account_label))
-                .set_text(cx, other_id.as_str());
+        // Populate / toggle every row in the fixed pool: one switchable row per other
+        // account, capped at the pool size.
+        let entry_ids = other_account_entry_ids();
+        let label_ids = other_account_label_ids();
+        let shown = self.other_accounts.len().min(MAX_OTHER_ACCOUNT_ROWS);
+        if self.other_accounts.len() > MAX_OTHER_ACCOUNT_ROWS {
+            log!(
+                "Account settings: {} other accounts exceed the {} switchable rows; \
+                 extras are hidden.",
+                self.other_accounts.len(),
+                MAX_OTHER_ACCOUNT_ROWS,
+            );
+        }
+        for i in 0..MAX_OTHER_ACCOUNT_ROWS {
+            if i < shown {
+                let text = self.other_accounts[i].to_string();
+                self.view.label(cx, label_ids[i]).set_text(cx, &text);
+                self.view.widget(cx, entry_ids[i]).set_visible(cx, true);
+            } else {
+                self.view.widget(cx, entry_ids[i]).set_visible(cx, false);
+            }
         }
     }
 
@@ -1707,6 +1745,52 @@ impl AccountSettings {
             }
         }
     }
+}
+
+/// The maximum number of *other* accounts shown as switchable rows in Settings.
+/// Matches the fixed pool of `other_account_entry_*` rows declared in the DSL.
+const MAX_OTHER_ACCOUNT_ROWS: usize = 8;
+
+/// The ids of the fixed pool of other-account row containers.
+fn other_account_entry_ids() -> [&'static [LiveId]; MAX_OTHER_ACCOUNT_ROWS] {
+    [
+        ids!(other_account_entry_0),
+        ids!(other_account_entry_1),
+        ids!(other_account_entry_2),
+        ids!(other_account_entry_3),
+        ids!(other_account_entry_4),
+        ids!(other_account_entry_5),
+        ids!(other_account_entry_6),
+        ids!(other_account_entry_7),
+    ]
+}
+
+/// The ids of the user-id labels inside each pooled other-account row.
+fn other_account_label_ids() -> [&'static [LiveId]; MAX_OTHER_ACCOUNT_ROWS] {
+    [
+        ids!(other_account_entry_0.other_account_label),
+        ids!(other_account_entry_1.other_account_label),
+        ids!(other_account_entry_2.other_account_label),
+        ids!(other_account_entry_3.other_account_label),
+        ids!(other_account_entry_4.other_account_label),
+        ids!(other_account_entry_5.other_account_label),
+        ids!(other_account_entry_6.other_account_label),
+        ids!(other_account_entry_7.other_account_label),
+    ]
+}
+
+/// The ids of the "Switch" buttons inside each pooled other-account row.
+fn switch_account_button_ids() -> [&'static [LiveId]; MAX_OTHER_ACCOUNT_ROWS] {
+    [
+        ids!(other_account_entry_0.switch_account_button),
+        ids!(other_account_entry_1.switch_account_button),
+        ids!(other_account_entry_2.switch_account_button),
+        ids!(other_account_entry_3.switch_account_button),
+        ids!(other_account_entry_4.switch_account_button),
+        ids!(other_account_entry_5.switch_account_button),
+        ids!(other_account_entry_6.switch_account_button),
+        ids!(other_account_entry_7.switch_account_button),
+    ]
 }
 
 fn effective_active_account_user_id(

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2714,6 +2714,12 @@ async fn matrix_worker_task(
             }
 
             MatrixRequest::SwitchAccount { user_id } => {
+                // Switching to the account that is already active is a no-op: don't tear
+                // down and rebuild the client/sync service for nothing.
+                if account_manager::get_active_user_id().as_ref() == Some(&user_id) {
+                    log!("Ignoring SwitchAccount request: {} is already the active account", user_id);
+                    continue;
+                }
                 // Check if the account exists in AccountManager
                 if account_manager::get_client_for_user(&user_id).is_some() {
                     // Set the target account for switch
@@ -6159,6 +6165,46 @@ fn clear_account_switch_target() {
     }
 }
 
+/// UI-thread guard preventing more than one account switch from being submitted at a
+/// time. Set synchronously in [`request_switch_account`] (so a second click in the same
+/// input frame is ignored) and cleared in [`end_account_switch_guard`] once the switch
+/// resolves. This is deliberately separate from [`ACCOUNT_SWITCH_TARGET`], whose
+/// "pending" state the async monitoring loop reads to classify worker shutdowns — we
+/// must not flip that early from the UI thread.
+static ACCOUNT_SWITCH_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// Requests a switch to `user_id` from the UI thread, guarded so that a second request
+/// submitted while a switch is already in flight is ignored. Without this, a fast
+/// double-click on two different accounts (now possible from the Settings multi-account
+/// list) would enqueue two `SwitchAccount` requests: the worker handles the first, then
+/// `return`s and drops its request receiver, silently discarding the second (stranding
+/// the user on the wrong account) — or, in a tight window, panicking on the send to a
+/// dropped receiver. Returns `true` if the request was submitted.
+pub fn request_switch_account(user_id: OwnedUserId) -> bool {
+    // Already the active account → nothing to do. (Returning here also avoids stranding
+    // the in-flight guard, since a no-op switch posts neither Switched nor Failed.)
+    if account_manager::get_active_user_id().as_ref() == Some(&user_id) {
+        log!("Ignoring account switch to {user_id}: already the active account");
+        return false;
+    }
+    // Reserve the in-flight slot synchronously; if one is already in flight, ignore.
+    if ACCOUNT_SWITCH_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        log!("Ignoring account switch to {user_id}: a switch is already in flight");
+        return false;
+    }
+    submit_async_request(MatrixRequest::SwitchAccount { user_id });
+    true
+}
+
+/// Clears the guard set by [`request_switch_account`]. Called when a switch resolves
+/// (either `AccountSwitchAction::Switched` or `Failed`) so the next switch can proceed.
+pub fn end_account_switch_guard() {
+    ACCOUNT_SWITCH_IN_FLIGHT.store(false, Ordering::Release);
+}
+
 /// Set to `true` when the access token has been rejected by the homeserver,
 /// signaling the main task to tear down the current session and wait for re-login.
 static TOKEN_EXPIRED: AtomicBool = AtomicBool::new(false);
@@ -6781,7 +6827,16 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             enqueue_rooms_list_update(RoomsListUpdate::ClearRooms);
             enqueue_rooms_list_update(RoomsListUpdate::RoomOrderUpdate(VecDiff::Clear));
 
-            // Post action to clear UI state
+            // Post Starting a second time. This is NOT redundant with the one the
+            // MatrixRequest::SwitchAccount handler posts: that one fires *before*
+            // `sync_service.stop()`, while the old client and its subscribers are still
+            // live, whereas this one fires after CLIENT/SYNC_SERVICE have been dropped.
+            // The App's Starting handler is the only caller of `clear_all_app_state()`
+            // (which clears TIMELINE_STATES), and MainDesktopUi resets the dock on the
+            // same action — closing the room tabs drops each RoomScreen, whose Drop impl
+            // saves its TimelineUiState back into TIMELINE_STATES. Without this second
+            // post, the old account's timeline state is re-inserted *after* the clear and
+            // the next account sees a stale, frozen timeline for that room.
             Cx::post_action(AccountSwitchAction::Starting(switch_user_id.clone()));
 
             // Update active account
@@ -6808,6 +6863,13 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                         Ok(ss) => ss,
                         Err(e) => {
                             error!("Failed to create SyncService: {e:?}");
+                            // We installed a fresh REQUEST_SENDER above, but bail out here
+                            // before `matrix_worker_task` is spawned, so its receiver is
+                            // dropped. Drop the now-orphaned sender too: `submit_async_request`
+                            // no-ops on a `None` sender but panics on a send to a dead
+                            // receiver, which would take down the app on the user's next
+                            // action (including retrying the switch).
+                            REQUEST_SENDER.lock().unwrap().take();
                             Cx::post_action(AccountSwitchAction::Failed(format!("Failed to create sync service: {e}")));
                             return;
                         }
@@ -6901,6 +6963,11 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                 }
                 Err(e) => {
                     error!("Failed to restore session for account switch: {e:?}");
+                    // Same as the sync-service failure above: the freshly installed
+                    // REQUEST_SENDER's receiver is dropped without a worker ever being
+                    // spawned, so drop the sender rather than leaving a live handle to a
+                    // dead receiver for `submit_async_request` to panic on.
+                    REQUEST_SENDER.lock().unwrap().take();
                     apply_restore_session_failure_policy(&e).await;
                     Cx::post_action(AccountSwitchAction::Failed(format!("Failed to restore session: {e}")));
                     enqueue_popup_notification(


### PR DESCRIPTION
Switching accounts on desktop meant a trip into Settings — which also only ever offered the *first* other account, so with three or more logged in there was no way to reach a specific one. This adds a Feishu-style quick switcher to the bottom of the desktop navigation rail.

Mobile is unchanged and keeps switching accounts from Settings.

## UI

- **New `AccountMenu`** (`src/home/account_menu.rs`) — an anchored overlay built on the same scrim + positioned-card pattern as the existing `AddMenu`. It shows:
  - the active account (avatar, display name, user ID, an "Active" marker),
  - one row per other logged-in account, click to switch,
  - **Log Into More Accounts** / **Account Settings** / **Log Out**.

  It opens *upward* from the bottom of the rail, closes on backdrop click or <kbd>Esc</kbd>, and auto-closes if the layout crosses the desktop/mobile breakpoint while open.

- **New `AccountSwitcherButton`** pinned to the bottom of the desktop rail opens the menu. It is a plain icon button, not a second avatar — the switcher is an action, and a duplicate of the profile avatar read as confusing. The **top profile avatar is untouched** and still opens Settings.

- **Rail icon scale** now matches the rest of the app (`RBX_ICON_LG`). At the previous ~34px the 24px / stroke-2 Tabler glyphs read noticeably heavier than icons everywhere else.

## Account switching

- **New `request_switch_account()`** guards submission on the UI thread, ignoring a second request while one is in flight. Without it, clicking two different accounts in quick succession enqueued two `SwitchAccount` requests: the worker handled the first, then returned and dropped its request receiver, silently discarding the second and **stranding the user on the wrong account** — or, in a tight window, **panicking** on a send to the dropped receiver. Released on `Switched` / `Failed`. This became routinely reachable once the Settings list started offering more than one switch target.

- **Switching to the already-active account is now a no-op**, instead of tearing down and rebuilding the client and sync service for nothing.

- **A failed switch no longer poisons the backend.** The restart loop installs a fresh `REQUEST_SENDER` before `restore_session`, but two bail-out paths (sync-service build failure, session-restore failure) returned without ever spawning the worker that owns the matching receiver. The stale sender stayed installed, so the *next* Matrix request — including retrying the switch — panicked via `expect("BUG: matrix worker task receiver has died!")`. Both paths now drop the sender, so later requests no-op instead. (Pre-existing, but a one-click switcher plus releasing the guard on failure makes it easy to hit.)

- **A "switching account" toast** covers the teardown → session restore → resync window, so a switch no longer looks frozen.

## Settings

- The Account section lists **every** other logged-in account, each switchable on its own row (previously only the first).
- Rows are **sorted**, so they no longer reorder between launches — accounts are stored in a `HashMap`.

## i18n

New `account_menu.*` keys in both `en` and `zh-CN`.

## Testing

Built and exercised on macOS desktop: opening the menu, switching accounts, add-account, Account Settings and Log Out entries, backdrop/Esc dismissal, and the Settings multi-account list. Rebased onto current `main` (including the OHOS port and makepad bump) and re-verified the build and a clean launch.
