### PR TITLE
refactor(directory): re-skin public room directory to RBX design system

### DIFF
--- a/src/home/directory_screen.rs
+++ b/src/home/directory_screen.rs
@@ -2,6 +2,15 @@
 //!
 //! Reached from the compass button in the RoomsListHeader. Lets the user search
 //! their homeserver's public room directory and join rooms directly from the list.
+//!
+//! ## Visual language
+//! This screen follows the `RBX_*` design system (see `docs/ui-visual-spec-zh.md`
+//! and `src/shared/design_tokens.rs`): a light `RBX_BG_CANVAS` page, a header with
+//! a back affordance + live result count, a shared inset search field (search icon
+//! + clear button, matching `RoomFilterInputBar`), and a virtualized list of white
+//! `RBX_BG_SURFACE` room cards. Each card reuses the shared `SettingsPrimaryButton`
+//! (teal accent CTA) for Join and `SettingsStatusBadge` (success) for the joined
+//! state, so the directory reads as one system with Settings / Devices.
 
 use std::collections::HashSet;
 
@@ -10,7 +19,7 @@ use matrix_sdk::ruma::OwnedRoomId;
 
 use crate::{
     avatar_cache::{self, AvatarCacheEntry},
-    home::invite_screen::JoinRoomResultAction,
+    home::{invite_screen::JoinRoomResultAction, navigation_tab_bar::NavigationBarAction},
     shared::avatar::AvatarWidgetExt,
     sliding_sync::{
         DirectoryRoomKind, MatrixRequest, PublicDirectoryAction, PublicRoomDirectoryEntry,
@@ -29,59 +38,143 @@ script_mod! {
     use mod.widgets.*
 
 
+    // A bare (no-fill) icon button used for the header back affordance and the
+    // search field's clear button: transparent by default, a soft hover/press
+    // wash, no border. Matches the Settings screen's close button.
+    mod.widgets.DirectoryGhostIconButton = mod.widgets.RobrixNeutralIconButton {
+        width: Fit, height: Fit
+        spacing: 0
+        align: Align{x: 0.5, y: 0.5}
+        draw_bg +: {
+            color: #0000
+            color_hover: (RBX_BG_HOVER)
+            color_down: (RBX_BG_PRESSED)
+            border_size: 0.0
+            border_color: #0000
+            border_color_hover: #0000
+            border_color_down: #0000
+            border_radius: (RBX_RADIUS_XS)
+        }
+        draw_icon +: { color: (RBX_FG_SECONDARY) }
+    }
+
+
+    // One room in the directory list — a white card (transparent custom-widget
+    // root + inner `entry_body` RoundedView surface, per the "plain custom root
+    // doesn't paint" pitfall) with avatar, name/topic/meta column, and a Join CTA.
     mod.widgets.DirectoryRoomEntry = #(DirectoryRoomEntry::register_widget(vm)) {
         ..mod.widgets.View
         width: Fill, height: Fit
-        padding: Inset{top: 10, bottom: 10, left: 10, right: 10}
-        flow: Right
-        align: Align{y: 0.5}
-        spacing: 12
-        show_bg: true
-        draw_bg +: { color: (COLOR_PRIMARY) }
+        flow: Down
+        margin: Inset{bottom: (SPACE_SM)}
 
-        avatar := Avatar {
-            width: 48, height: 48
-        }
-
-        text_column := View {
+        entry_body := RoundedView {
             width: Fill, height: Fit
-            flow: Down
-            spacing: 2
-
-            name_label := Label {
-                width: Fill, height: Fit
-                draw_text +: {
-                    color: #x0
-                    text_style: TITLE_TEXT { font_size: 12 }
-                }
-                text: ""
+            flow: Right
+            align: Align{y: 0.5}
+            padding: Inset{top: (SPACE_MD), bottom: (SPACE_MD), left: (SPACE_MD), right: (SPACE_MD)}
+            spacing: (SPACE_MD)
+            show_bg: true
+            draw_bg +: {
+                color: (RBX_BG_SURFACE)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
             }
 
-            topic_label := Label {
-                width: Fill, height: Fit
-                draw_text +: {
-                    color: (MESSAGE_TEXT_COLOR)
-                    text_style: MESSAGE_TEXT_STYLE { font_size: 10 }
-                }
-                text: ""
+            avatar := Avatar {
+                width: (RBX_AVATAR_LG), height: (RBX_AVATAR_LG)
             }
 
-            meta_label := Label {
+            text_column := View {
                 width: Fill, height: Fit
-                draw_text +: {
-                    color: (MESSAGE_TEXT_COLOR)
-                    text_style: MESSAGE_TEXT_STYLE { font_size: 9 }
-                }
-                text: ""
-            }
-        }
+                flow: Down
+                spacing: 3
 
-        join_button := RobrixPositiveIconButton {
-            width: Fit, height: Fit
-            padding: Inset{top: 8, bottom: 8, left: 12, right: 12}
-            draw_icon.svg: (ICON_JOIN_ROOM)
-            icon_walk: Walk{width: 14, height: 14}
-            text: "Join"
+                name_label := Label {
+                    width: Fill, height: Fit
+                    flow: Flow.Right{wrap: false}
+                    max_lines: 1
+                    text_overflow: Ellipsis
+                    draw_text +: {
+                        color: (RBX_FG_PRIMARY)
+                        text_style: RBX_TEXT_CARD_TITLE {}
+                    }
+                    text: ""
+                }
+
+                topic_label := Label {
+                    width: Fill, height: Fit
+                    max_lines: 2
+                    text_overflow: Ellipsis
+                    draw_text +: {
+                        color: (RBX_FG_SECONDARY)
+                        text_style: RBX_TEXT_META {}
+                    }
+                    text: ""
+                }
+
+                meta_row := View {
+                    width: Fill, height: Fit
+                    flow: Right
+                    align: Align{y: 0.5}
+                    spacing: 5
+
+                    meta_icon := Icon {
+                        draw_icon +: {
+                            svg: (ICON_PEOPLE)
+                            color: (RBX_FG_TERTIARY)
+                        }
+                        icon_walk: Walk{width: 12, height: 12}
+                    }
+
+                    meta_label := Label {
+                        width: Fill, height: Fit
+                        flow: Flow.Right{wrap: false}
+                        max_lines: 1
+                        text_overflow: Ellipsis
+                        draw_text +: {
+                            color: (RBX_FG_TERTIARY)
+                            text_style: RBX_TEXT_META {}
+                        }
+                        text: ""
+                    }
+                }
+            }
+
+            // Trailing action: teal accent CTA (Join) OR success badge (Joined).
+            // Only one is visible at a time; the hidden one collapses out of the
+            // row layout. Both are built on core widgets (no derived-template
+            // child override) so they render reliably inside the PortalList item.
+            join_button := SettingsPrimaryButton {
+                width: Fit, height: (RBX_CONTROL_H_SM)
+                padding: Inset{top: 7, bottom: 7, left: 12, right: 14}
+                spacing: 6
+                draw_icon.svg: (ICON_JOIN_ROOM)
+                icon_walk: Walk{width: 14, height: 14}
+                draw_text +: { text_style: RBX_TEXT_BODY_STRONG {} }
+                text: "Join"
+            }
+
+            joined_badge := RoundedView {
+                visible: false
+                width: Fit, height: Fit
+                align: Align{x: 0.5, y: 0.5}
+                padding: Inset{left: 12, right: 12, top: 6, bottom: 6}
+                show_bg: true
+                draw_bg +: {
+                    color: (RBX_SUCCESS_BG)
+                    border_radius: (RBX_RADIUS_PILL)
+                }
+                Label {
+                    width: Fit, height: Fit
+                    draw_text +: {
+                        color: (RBX_SUCCESS_FG)
+                        text_style: RBX_TEXT_BADGE {}
+                    }
+                    text: "Joined"
+                }
+            }
         }
     }
 
@@ -90,58 +183,151 @@ script_mod! {
         ..mod.widgets.View
         width: Fill, height: Fill
         flow: Down
-        padding: Inset{top: 6, left: 12, right: 12, bottom: 0}
-        spacing: 8
+        padding: Inset{top: (SPACE_MD), left: (SPACE_LG), right: (SPACE_LG), bottom: 0}
+        spacing: (SPACE_SM)
         show_bg: true
-        draw_bg +: { color: (COLOR_PRIMARY) }
+        draw_bg +: { color: (RBX_BG_CANVAS) }
 
-        title := Label {
-            width: Fill, height: Fit
-            margin: Inset{top: 4, bottom: 4, left: 4}
-            draw_text +: {
-                color: #x0
-                text_style: TITLE_TEXT { font_size: 16 }
-            }
-            text: "Public Room Directory"
-        }
-
-        search_row := View {
+        // ── Header: back affordance + title + live result count ──────────────
+        header := View {
             width: Fill, height: Fit
             flow: Right
             align: Align{y: 0.5}
-            spacing: 6
+            spacing: (SPACE_SM)
 
-            search_input := RobrixTextInput {
-                width: Fill, height: 36
-                padding: Inset{left: 12, right: 12, top: 9, bottom: 0}
-                empty_text: "Search public rooms..."
+            back_button := DirectoryGhostIconButton {
+                padding: (SPACE_SM)
+                draw_icon.svg: (ICON_ARROW_BACK)
+                icon_walk: Walk{width: 18, height: 18}
+            }
+
+            header_col := View {
+                width: Fill, height: Fit
+                flow: Down
+                spacing: 2
+
+                title := Label {
+                    width: Fill, height: Fit
+                    draw_text +: {
+                        color: (RBX_FG_PRIMARY)
+                        text_style: RBX_TEXT_PAGE_TITLE {}
+                    }
+                    text: "Public rooms"
+                }
+
+                subtitle := Label {
+                    width: Fill, height: Fit
+                    draw_text +: {
+                        color: (RBX_FG_SECONDARY)
+                        text_style: RBX_TEXT_META {}
+                    }
+                    text: "Discover and join public rooms"
+                }
             }
         }
 
-        error_banner := View {
+        LineH {
+            height: 1.0
+            margin: Inset{top: 2, bottom: 2}
+            draw_bg.color: (RBX_STROKE_SOFT)
+        }
+
+        // ── Search field: shared inset look (search icon + clear button) ─────
+        search_field := RoundedView {
+            width: Fill, height: 40
+            flow: Right
+            align: Align{y: 0.5}
+            spacing: 4
+            padding: Inset{left: 12, right: 5}
+            show_bg: true
+            draw_bg +: {
+                color: (RBX_BG_SURFACE_SUBTLE)
+                border_radius: (RBX_RADIUS_XS)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+            }
+
+            Icon {
+                draw_icon +: {
+                    svg: (ICON_SEARCH)
+                    color: (RBX_FG_TERTIARY)
+                }
+                icon_walk: Walk{width: 16, height: 16}
+            }
+
+            search_input := RobrixTextInput {
+                width: Fill, height: Fit
+                flow: Right
+                padding: Inset{left: 4, right: 4, top: 0, bottom: 0}
+                empty_text: "Search public rooms..."
+                // Make the field read as one inset surface (no white patch, no
+                // second border ring over the container's ring).
+                draw_bg +: {
+                    border_size: 0.0
+                    color: (RBX_BG_SURFACE_SUBTLE)
+                    color_hover: (RBX_BG_SURFACE_SUBTLE)
+                    color_focus: (RBX_BG_SURFACE_SUBTLE)
+                    color_down: (RBX_BG_SURFACE_SUBTLE)
+                    color_empty: (RBX_BG_SURFACE_SUBTLE)
+                }
+                draw_text +: {
+                    color: (RBX_FG_PRIMARY)
+                    text_style: RBX_TEXT_BODY {}
+                }
+            }
+
+            clear_button := DirectoryGhostIconButton {
+                visible: false
+                padding: Inset{top: 7, bottom: 7, left: 7, right: 7}
+                draw_icon.svg: (ICON_CLOSE)
+                icon_walk: Walk{width: 12, height: 12}
+            }
+        }
+
+        // ── Inline error card (danger-tinted) ───────────────────────────────
+        error_card := RoundedView {
             visible: false
             width: Fill, height: Fit
-            padding: Inset{left: 10, right: 10, top: 6, bottom: 6}
-            margin: Inset{top: 0, bottom: 4}
+            flow: Right
+            align: Align{y: 0.5}
+            spacing: (SPACE_SM)
+            padding: Inset{left: (SPACE_MD), right: (SPACE_MD), top: (SPACE_SM), bottom: (SPACE_SM)}
+            margin: Inset{top: 2}
             show_bg: true
-            draw_bg +: { color: (COLOR_FG_DANGER_RED) }
+            draw_bg +: {
+                color: (RBX_DANGER_BG)
+                border_radius: (RBX_RADIUS_XS)
+                border_size: 1.0
+                border_color: (RBX_DANGER_FG)
+            }
+
+            Icon {
+                draw_icon +: {
+                    svg: (ICON_WARNING)
+                    color: (RBX_DANGER_FG)
+                }
+                icon_walk: Walk{width: 16, height: 16}
+            }
 
             error_label := Label {
                 width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
                 draw_text +: {
-                    color: #xfff
-                    text_style: MESSAGE_TEXT_STYLE { font_size: 10 }
+                    color: (RBX_DANGER_FG)
+                    text_style: RBX_TEXT_BODY {}
                 }
                 text: ""
             }
         }
 
+        // ── Result list (virtualized) ───────────────────────────────────────
         room_list := PortalList {
             width: Fill, height: Fill
             keep_invisible: false,
             max_pull_down: 0.0,
             auto_tail: false,
             flow: Down
+            margin: Inset{top: (SPACE_XS)}
 
             room_entry := mod.widgets.DirectoryRoomEntry {}
 
@@ -152,7 +338,7 @@ script_mod! {
                 LoadingSpinner {
                     width: 24, height: 24
                     draw_bg +: {
-                        color: (COLOR_ACTIVE_PRIMARY)
+                        color: (RBX_ACCENT)
                         border_size: 3.0
                     }
                 }
@@ -160,14 +346,25 @@ script_mod! {
 
             status_entry := View {
                 width: Fill, height: Fit
-                padding: Inset{top: 20, bottom: 20, left: 10, right: 10}
-                flow: Right
+                padding: Inset{top: 40, bottom: 20, left: 16, right: 16}
+                flow: Down
                 align: Align{x: 0.5, y: 0.5}
+                spacing: (SPACE_SM)
+
+                status_icon := Icon {
+                    draw_icon +: {
+                        svg: (ICON_GLOBE)
+                        color: (RBX_FG_TERTIARY)
+                    }
+                    icon_walk: Walk{width: 30, height: 30}
+                }
+
                 status_label := Label {
                     width: Fit, height: Fit
+                    align: Align{x: 0.5}
                     draw_text +: {
-                        color: (MESSAGE_TEXT_COLOR)
-                        text_style: MESSAGE_TEXT_STYLE { font_size: 11 }
+                        color: (RBX_FG_SECONDARY)
+                        text_style: RBX_TEXT_BODY {}
                     }
                     text: ""
                 }
@@ -230,21 +427,24 @@ impl DirectoryRoomEntry {
             .label(cx, ids!(text_column.name_label))
             .set_text(cx, &entry.display_name);
 
+        // Topic: collapse to one clean paragraph; hide the row entirely if empty
+        // so cards without a topic don't leave a dead gap.
         let topic_text = entry
             .topic
             .as_deref()
             .map(collapse_to_single_line)
             .unwrap_or_default();
-        self.view
-            .label(cx, ids!(text_column.topic_label))
-            .set_text(cx, &topic_text);
+        let topic_label = self.view.label(cx, ids!(text_column.topic_label));
+        topic_label.set_visible(cx, !topic_text.is_empty());
+        topic_label.set_text(cx, &topic_text);
 
-        let mut meta = String::new();
+        // Meta line: "N members" (with a people icon), plus the canonical alias
+        // when present, so the room is addressable at a glance.
+        let mut meta = format!("{} members", entry.num_joined_members);
         if let Some(alias) = &entry.canonical_alias {
-            meta.push_str(alias);
             meta.push_str("  ·  ");
+            meta.push_str(alias);
         }
-        meta.push_str(&format!("{} members", entry.num_joined_members));
         self.view
             .label(cx, ids!(text_column.meta_label))
             .set_text(cx, &meta);
@@ -263,16 +463,23 @@ impl DirectoryRoomEntry {
             avatar.show_text(cx, None, None, entry.display_name.as_str());
         }
 
+        // Trailing action state machine: Join (CTA) → Joining… (disabled) →
+        // Joined (success badge, button hidden).
         let join_button = self.view.button(cx, ids!(join_button));
+        let joined_badge = self.view.view(cx, ids!(joined_badge));
         if is_joined {
-            join_button.set_text(cx, "Joined");
-            join_button.set_enabled(cx, false);
-        } else if is_joining {
-            join_button.set_text(cx, "Joining…");
-            join_button.set_enabled(cx, false);
+            join_button.set_visible(cx, false);
+            joined_badge.set_visible(cx, true);
         } else {
-            join_button.set_text(cx, "Join");
-            join_button.set_enabled(cx, true);
+            joined_badge.set_visible(cx, false);
+            join_button.set_visible(cx, true);
+            if is_joining {
+                join_button.set_text(cx, "Joining…");
+                join_button.set_enabled(cx, false);
+            } else {
+                join_button.set_text(cx, "Join");
+                join_button.set_enabled(cx, true);
+            }
         }
     }
 }
@@ -292,6 +499,9 @@ pub struct DirectoryScreen {
     #[rust] joined_rooms: HashSet<OwnedRoomId>,
     #[rust(Timer::empty())] search_debounce_timer: Timer,
     #[rust] pending_search_text: String,
+    /// Last subtitle string pushed to the header, so we only call the
+    /// (unconditionally-redrawing) `Label::set_text` when it actually changes.
+    #[rust] last_subtitle: String,
 }
 
 impl Widget for DirectoryScreen {
@@ -313,9 +523,27 @@ impl Widget for DirectoryScreen {
         }
 
         if let Event::Actions(actions) = event {
+            // Back button: return to the Home view.
+            if self.view.button(cx, ids!(back_button)).clicked(actions) {
+                cx.action(NavigationBarAction::GoToHome);
+            }
+
+            // Clear button: wipe the field and re-run the default (empty) query.
+            if self.view.button(cx, ids!(search_field.clear_button)).clicked(actions) {
+                self.view
+                    .text_input(cx, ids!(search_input))
+                    .set_text(cx, "");
+                cx.stop_timer(self.search_debounce_timer);
+                self.search_debounce_timer = Timer::empty();
+                self.pending_search_text.clear();
+                self.update_clear_button(cx, "");
+                self.start_fresh_query(cx, String::new());
+            }
+
             let search_input = self.view.text_input(cx, ids!(search_input));
             if let Some(text) = search_input.changed(actions) {
                 log!("[public_directory] search input changed: text={text:?}");
+                self.update_clear_button(cx, &text);
                 cx.stop_timer(self.search_debounce_timer);
                 self.pending_search_text = text;
                 self.search_debounce_timer = cx.start_timeout(SEARCH_DEBOUNCE_SECS);
@@ -325,6 +553,7 @@ impl Widget for DirectoryScreen {
                 cx.stop_timer(self.search_debounce_timer);
                 self.search_debounce_timer = Timer::empty();
                 self.pending_search_text.clear();
+                self.update_clear_button(cx, &text);
                 self.start_fresh_query(cx, text);
             }
 
@@ -368,15 +597,13 @@ impl Widget for DirectoryScreen {
             self.start_fresh_query(cx, String::new());
         }
 
-        let banner_visible = self.last_error.is_some();
+        // Keep the error card's *visibility* in sync every frame — `set_visible`
+        // is change-guarded, so this is cheap. Its text and the header subtitle
+        // are only mutated at state-change points (see `refresh_status`) because
+        // `set_text` always reschedules a redraw and must not run per-frame.
         self.view
-            .view(cx, ids!(error_banner))
-            .set_visible(cx, banner_visible);
-        if banner_visible {
-            self.view
-                .label(cx, ids!(error_banner.error_label))
-                .set_text(cx, self.last_error.as_deref().unwrap_or(""));
-        }
+            .view(cx, ids!(error_card))
+            .set_visible(cx, self.last_error.is_some());
 
         while let Some(widget_to_draw) = self.view.draw_walk(cx, scope, walk).step() {
             let plist = widget_to_draw.as_portal_list();
@@ -396,7 +623,7 @@ impl Widget for DirectoryScreen {
                 let item = if show_empty_status && item_id == 0 {
                     let item = list.item(cx, item_id, id!(status_entry));
                     let msg = if self.search_text.trim().is_empty() {
-                        "No public rooms found."
+                        "No public rooms found on this homeserver."
                     } else {
                         "No rooms match your search."
                     };
@@ -427,6 +654,50 @@ impl Widget for DirectoryScreen {
 }
 
 impl DirectoryScreen {
+    /// Refresh the header subtitle and error-card text to reflect the current
+    /// load / result / error state. Called only at state-change points (never
+    /// per-frame) because `Label::set_text` reschedules a redraw every call.
+    fn refresh_status(&mut self, cx: &mut Cx) {
+        let n = self.rooms.len();
+        let has_more = self.next_batch.is_some();
+        let subtitle = if self.is_loading && n == 0 {
+            "Searching…".to_string()
+        } else if self.search_text.trim().is_empty() {
+            match (n, has_more) {
+                (0, _) => "Discover and join public rooms".to_string(),
+                (1, false) => "1 public room".to_string(),
+                (_, false) => format!("{n} public rooms"),
+                (_, true) => format!("{n}+ public rooms"),
+            }
+        } else {
+            match (n, has_more) {
+                (0, _) => "No matching rooms".to_string(),
+                (1, false) => "1 result".to_string(),
+                (_, false) => format!("{n} results"),
+                (_, true) => format!("{n}+ results"),
+            }
+        };
+        if subtitle != self.last_subtitle {
+            self.view
+                .label(cx, ids!(header.header_col.subtitle))
+                .set_text(cx, &subtitle);
+            self.last_subtitle = subtitle;
+        }
+
+        if let Some(err) = self.last_error.clone() {
+            self.view
+                .label(cx, ids!(error_card.error_label))
+                .set_text(cx, &err);
+        }
+    }
+
+    /// Show the clear (✕) affordance only when the field has text.
+    fn update_clear_button(&mut self, cx: &mut Cx, text: &str) {
+        self.view
+            .button(cx, ids!(search_field.clear_button))
+            .set_visible(cx, !text.is_empty());
+    }
+
     fn start_fresh_query(&mut self, cx: &mut Cx, text: String) {
         self.search_text = text;
         self.query_id = self.query_id.wrapping_add(1);
@@ -440,6 +711,7 @@ impl DirectoryScreen {
             self.search_text,
         );
         self.submit_fetch(true);
+        self.refresh_status(cx);
         self.view.redraw(cx);
     }
 
@@ -488,6 +760,7 @@ impl DirectoryScreen {
                 self.rooms.extend(rooms.iter().cloned());
                 self.next_batch = next_batch.clone();
                 self.last_error = None;
+                self.refresh_status(cx);
                 self.view.redraw(cx);
             }
             PublicDirectoryAction::Failed {
@@ -500,6 +773,7 @@ impl DirectoryScreen {
                 }
                 self.is_loading = false;
                 self.last_error = Some(error.clone());
+                self.refresh_status(cx);
                 self.view.redraw(cx);
             }
         }


### PR DESCRIPTION
## Summary

Re-skins the public room **DirectoryScreen** (reached from the compass button in the rooms-list header) to the `RBX_*` design system already used by Settings, Devices, and the rooms list. Previously this page used legacy `COLOR_*` tokens, pure-black text, ad-hoc font sizes, flat borderless rows, and a mismatched green Join button.

## Changes

- **Tokens & typography** — every legacy `COLOR_*` / pure-black / ad-hoc size replaced with `RBX_*` tokens: `RBX_BG_CANVAS` page, `RBX_FG_*` text, `RBX_TEXT_*` presets, `RBX_ACCENT` teal, `RBX_SUCCESS_*` / `RBX_DANGER_*` states.
- **Header** — back affordance + "Public rooms" title + a live subtitle reflecting state (`Searching…` / `12 public rooms` / `5 results` / `No matching rooms`), matching the Devices header pattern.
- **Search** — shared inset field look (subtle surface + leading search icon + a clear button that appears only when there is text), mirroring `RoomFilterInputBar`.
- **Room rows → cards** — white `RBX_BG_SURFACE` cards (soft border, `RBX_RADIUS_SM`) with avatar, bold name, topic (auto-hidden when empty), and a members line with a people icon + canonical alias.
- **Join action** — teal accent CTA with three states: **Join** → **Joining…** (disabled) → **Joined** (success pill).
- **Loading / empty / error** — teal spinner, a centered empty state with a globe icon, and errors as a danger-tinted card instead of a full-red banner.

## Notes

- Backend logic is unchanged — debounced search, pagination, and the join flow are preserved; this is a visual + small-UX refactor only.
- Card surface lives on an inner view (custom-widget roots don't reliably paint their own background), and the "Joined" pill uses inline core widgets rather than a derived-template child override inside the `PortalList`.
- Header subtitle / error text are updated only at state-change points, not in `draw_walk` (`Label::set_text` always reschedules a redraw, so per-frame calls would spin a repaint loop).
- `cargo build` passes with no new warnings.
