### PR TITLE
feat(distribution): add cross-platform installers

### DIFF
--- a/.github/workflows/distribution-check.yml
+++ b/.github/workflows/distribution-check.yml
@@ -1,0 +1,71 @@
+name: Distribution Check
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/distribution-check.yml"
+      - ".github/workflows/release.yml"
+      - "Casks/**"
+      - "packaging/distribution/**"
+      - "packaging/homebrew/**"
+      - "packaging/npm/**"
+      - "packaging/winget/**"
+      - "scripts/generate-distribution-assets.sh"
+      - "scripts/test-distribution.sh"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/distribution-check.yml"
+      - ".github/workflows/release.yml"
+      - "Casks/**"
+      - "packaging/distribution/**"
+      - "packaging/homebrew/**"
+      - "packaging/npm/**"
+      - "packaging/winget/**"
+      - "scripts/generate-distribution-assets.sh"
+      - "scripts/test-distribution.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Validate installers and package metadata
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run distribution tests
+        run: ./scripts/test-distribution.sh
+      - name: Generate the Windows installer fixture
+        run: |
+          ./scripts/generate-distribution-assets.sh \
+            --repository Project-Robius-China/robrix2 \
+            --tag v1.1.0 \
+            --assets-json packaging/distribution/testdata/v1.1.0-assets.json \
+            --output dist/distribution-check
+      - uses: actions/upload-artifact@v4
+        with:
+          name: robrix-powershell-installer
+          path: dist/distribution-check/robrix-installer.ps1
+
+  powershell:
+    name: Validate the PowerShell installer
+    needs: test
+    runs-on: windows-2022
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: robrix-powershell-installer
+          path: distribution-check
+      - name: Exercise Windows artifact selection
+        shell: pwsh
+        run: |
+          $selection = & ./distribution-check/robrix-installer.ps1 -DryRun
+          $selection | Write-Output
+          if ($selection -notcontains "asset=robrix-1.1.0-windows-x86_64-release.exe") {
+            throw "PowerShell installer selected the wrong Windows artifact."
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 env:
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: short
@@ -209,23 +210,24 @@ jobs:
             const macos = [];
             const windows = [];
 
-            const addLinux = (os, arch) => linux.push({ os, arch });
+            const addLinux = (os, arch, artifact_platform) =>
+              linux.push({ os, arch, artifact_platform });
             const addMacos = (os, arch) => macos.push({ os, arch });
             const addWindows = () => windows.push({ os: 'windows-2022', arch: 'x86_64' });
 
             if (isPush) {
-              addLinux('ubuntu-24.04', 'x86_64');
-              addLinux('ubuntu-24.04-arm', 'aarch64');
-              addLinux('ubuntu-22.04', 'x86_64');
-              addLinux('ubuntu-22.04-arm', 'aarch64');
+              addLinux('ubuntu-24.04', 'x86_64', 'ubuntu-24.04');
+              addLinux('ubuntu-24.04-arm', 'aarch64', 'ubuntu-24.04');
+              addLinux('ubuntu-22.04', 'x86_64', 'ubuntu-22.04');
+              addLinux('ubuntu-22.04-arm', 'aarch64', 'ubuntu-22.04');
               addMacos('macos-14', 'aarch64');
               addMacos('macos-15-intel', 'x86_64');
               addWindows();
             } else {
-              if (enabled(inputs.build_ubuntu_24_x86_64)) addLinux('ubuntu-24.04', 'x86_64');
-              if (enabled(inputs.build_ubuntu_24_aarch64)) addLinux('ubuntu-24.04-arm', 'aarch64');
-              if (enabled(inputs.build_ubuntu_22_x86_64)) addLinux('ubuntu-22.04', 'x86_64');
-              if (enabled(inputs.build_ubuntu_22_aarch64)) addLinux('ubuntu-22.04-arm', 'aarch64');
+              if (enabled(inputs.build_ubuntu_24_x86_64)) addLinux('ubuntu-24.04', 'x86_64', 'ubuntu-24.04');
+              if (enabled(inputs.build_ubuntu_24_aarch64)) addLinux('ubuntu-24.04-arm', 'aarch64', 'ubuntu-24.04');
+              if (enabled(inputs.build_ubuntu_22_x86_64)) addLinux('ubuntu-22.04', 'x86_64', 'ubuntu-22.04');
+              if (enabled(inputs.build_ubuntu_22_aarch64)) addLinux('ubuntu-22.04-arm', 'aarch64', 'ubuntu-22.04');
               if (enabled(inputs.build_macos_14_aarch64)) addMacos('macos-14', 'aarch64');
               if (enabled(inputs.build_macos_15_x86_64)) addMacos('macos-15-intel', 'x86_64');
               if (enabled(inputs.build_windows_2022_x86_64)) addWindows();
@@ -258,17 +260,22 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Resolve release metadata
         id: resolve
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            resolved_tag="${{ github.ref_name }}"
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            resolved_tag="$REF_NAME"
           else
-            resolved_tag="${{ github.event.inputs.release_tag }}"
+            resolved_tag="$INPUT_RELEASE_TAG"
             if [[ -z "$resolved_tag" ]]; then
               resolved_version="$(awk '
                 /^\[package\]$/ { in_package=1; next }
@@ -354,6 +361,7 @@ jobs:
         with:
           github_token: ${{ secrets.ROBRIX_RELEASE }}
           packager_formats: deb
+          asset_name_template: __APP__-__VERSION__-${{ matrix.artifact_platform }}-__ARCH__-__MODE__.__EXT__
           uploadUpdaterJson: true
           uploadUpdaterSignatures: true
           releaseId: ${{ needs.create_release.outputs.release_id }}
@@ -496,3 +504,231 @@ jobs:
           upload_to_testflight: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.upload_testflight == 'true' }}
           args: --target aarch64-apple-ios
           releaseId: ${{ needs.create_release.outputs.release_id }}
+
+  publish_distribution:
+    name: Publish installers and package metadata
+    needs: [create_release, for_linux, for_macos, for_windows]
+    if: >-
+      ${{
+        always() &&
+        needs.create_release.result == 'success' &&
+        needs.for_linux.result == 'success' &&
+        needs.for_macos.result == 'success' &&
+        needs.for_windows.result == 'success'
+      }}
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      tag: ${{ steps.metadata.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve distribution metadata
+        id: metadata
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.create_release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate checksum-pinned distribution assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.ROBRIX_RELEASE }}
+          RELEASE_ID: ${{ needs.create_release.outputs.release_id }}
+          RELEASE_TAG: ${{ needs.create_release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          generated=false
+          for attempt in $(seq 1 12); do
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+              --jq '.assets' > release-assets.json
+            rm -rf distribution
+            if ./scripts/generate-distribution-assets.sh \
+              --repository "$GITHUB_REPOSITORY" \
+              --tag "$RELEASE_TAG" \
+              --assets-json release-assets.json \
+              --output distribution; then
+              generated=true
+              break
+            fi
+            echo "attempt ${attempt}/12: waiting for GitHub asset digests..."
+            sleep 10
+          done
+          if [[ "$generated" != true ]]; then
+            echo "::error::Could not generate distribution assets after waiting for release uploads."
+            exit 1
+          fi
+          ./scripts/test-distribution.sh
+
+      - name: Upload installers and package metadata to the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.ROBRIX_RELEASE }}
+          RELEASE_TAG: ${{ needs.create_release.outputs.tag }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" \
+            distribution/robrix-installer.sh \
+            distribution/robrix-installer.ps1 \
+            distribution/SHA256SUMS \
+            distribution/robrix-dist-manifest.json \
+            "distribution/robrix-${VERSION}-npm-package.tgz" \
+            "distribution/robrix-${VERSION}-winget-manifests.zip" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Preserve distribution assets for registry jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: robrix-distribution-assets
+          path: distribution/
+          retention-days: 14
+
+  publish_npm:
+    name: Publish npm installer wrapper
+    needs: publish_distribution
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check npm publishing credentials
+        id: credentials
+        shell: bash
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -n "$NPM_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::NPM_TOKEN is not configured; the npm package remains attached to the GitHub release."
+          fi
+
+      - uses: actions/download-artifact@v4
+        if: ${{ steps.credentials.outputs.enabled == 'true' }}
+        with:
+          name: robrix-distribution-assets
+          path: distribution
+
+      - uses: actions/setup-node@v4
+        if: ${{ steps.credentials.outputs.enabled == 'true' }}
+        with:
+          node-version: "20"
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish stable to latest and prerelease to next
+        if: ${{ steps.credentials.outputs.enabled == 'true' }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.publish_distribution.outputs.version }}
+          RELEASE_TAG: ${{ needs.publish_distribution.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" == *-* ]]; then
+            npm_tag=next
+          else
+            npm_tag=latest
+          fi
+          npm publish "distribution/robrix-${VERSION}-npm-package.tgz" \
+            --access public \
+            --tag "$npm_tag"
+
+  publish_homebrew:
+    name: Update the Homebrew cask
+    needs: publish_distribution
+    if: ${{ github.event_name == 'push' && !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.ROBRIX_RELEASE }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: robrix-distribution-assets
+          path: distribution
+
+      - name: Stage the release cask
+        id: cask
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p Casks
+          cp distribution/Casks/robrix.rb Casks/robrix.rb
+          if git diff --quiet -- Casks/robrix.rb; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open a cask update pull request
+        if: ${{ steps.cask.outputs.changed == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.ROBRIX_RELEASE }}
+          RELEASE_TAG: ${{ needs.publish_distribution.outputs.tag }}
+        run: |
+          set -euo pipefail
+          branch="distribution/homebrew-${RELEASE_TAG}"
+          git config user.name "robrix-release-bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add Casks/robrix.rb
+          git commit -m "release: update Homebrew cask for ${RELEASE_TAG}"
+          git push --force origin "$branch"
+
+          existing_url=$(gh pr list --head "$branch" --json url --jq '.[0].url // empty')
+          if [[ -n "$existing_url" ]]; then
+            echo "Updated existing Homebrew pull request: $existing_url"
+          else
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "release: update Homebrew cask for ${RELEASE_TAG}" \
+              --body "Automated checksum and version update for the Robrix Homebrew cask."
+          fi
+
+  publish_winget:
+    name: Submit the Winget manifest
+    needs: publish_distribution
+    if: ${{ github.event_name == 'push' && !contains(github.ref_name, '-') }}
+    runs-on: windows-2022
+    steps:
+      - name: Check Winget publishing credentials
+        id: credentials
+        shell: pwsh
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+        run: |
+          if ($env:WINGET_CREATE_GITHUB_TOKEN) {
+            "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            Write-Output "::notice::WINGET_CREATE_GITHUB_TOKEN is not configured; manifests remain attached to the GitHub release."
+          }
+
+      - uses: actions/download-artifact@v4
+        if: ${{ steps.credentials.outputs.enabled == 'true' }}
+        with:
+          name: robrix-distribution-assets
+          path: distribution
+
+      - name: Submit manifests to microsoft/winget-pkgs
+        if: ${{ steps.credentials.outputs.enabled == 'true' }}
+        shell: pwsh
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+          VERSION: ${{ needs.publish_distribution.outputs.version }}
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $manifestPath = "distribution/winget/ProjectRobiusChina.Robrix/$env:VERSION"
+          ./wingetcreate.exe submit `
+            --prtitle "New version: ProjectRobiusChina.Robrix version $env:VERSION" `
+            --no-open `
+            $manifestPath

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,6 @@
 [default.extend-words]
 PN = "PN"
+sur = "sur"
 
 [files]
 # Minified vendor JS (mdbook-mermaid assets) is full of short mangled

--- a/Casks/robrix.rb
+++ b/Casks/robrix.rb
@@ -1,0 +1,22 @@
+cask "robrix" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "1.1.0"
+  sha256 arm:   "783375cd75c8fc3ad38ccc3ad70e8368faf83606ad4788b99118cf6af6404e7a",
+         intel: "cbfb903acbf3ba68cb1549878e0847b5d6d53318fec7d7bc1523808cc63889b2"
+
+  url "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/robrix-#{version}-macos-#{arch}-release.dmg"
+  name "Robrix"
+  desc "Multi-platform Matrix chat client built with Rust and Makepad"
+  homepage "https://github.com/Project-Robius-China/robrix2"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Robrix.app"
+end

--- a/README.md
+++ b/README.md
@@ -41,6 +41,61 @@ The following table shows which host systems can currently be used to build Robr
 | iOS             | macOS           | ✅      | ✅    |
 | OpenHarmony     | *Any*           | ✅      | 🚧    |
 
+## Installing Robrix
+
+Prebuilt desktop releases do not require a Rust toolchain. Every generated
+installer is pinned to a release and verifies the native package's SHA-256
+digest before running it.
+
+> [!NOTE]
+> The generated shell and PowerShell installers become available with the first
+> complete desktop release created after this distribution automation is merged.
+> Earlier releases, including `v1.1.0`, remain available through the direct
+> [GitHub release downloads](https://github.com/Project-Robius-China/robrix2/releases).
+
+### Shell installer (macOS and Debian/Ubuntu)
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/Project-Robius-China/robrix2/releases/latest/download/robrix-installer.sh | sh
+```
+
+### PowerShell installer (Windows)
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://github.com/Project-Robius-China/robrix2/releases/latest/download/robrix-installer.ps1 | iex"
+```
+
+### Homebrew (macOS)
+
+This repository is its own Homebrew tap.
+
+```sh
+brew tap project-robius-china/robrix2 https://github.com/Project-Robius-China/robrix2
+brew install --cask project-robius-china/robrix2/robrix
+```
+
+### npm
+
+The npm package is a small wrapper around the same checksum-pinned native
+installers; it does not bundle Robrix inside JavaScript.
+
+```sh
+npm install --global robrix
+```
+
+### Winget (Windows)
+
+```powershell
+winget install --id ProjectRobiusChina.Robrix --exact
+```
+
+The npm and Winget commands become available after their initial registry
+submissions. Until then, use the shell, PowerShell, Homebrew, or direct
+[GitHub release downloads](https://github.com/Project-Robius-China/robrix2/releases).
+Release maintainers can find the bootstrap and automation details in
+[docs/DISTRIBUTION.md](docs/DISTRIBUTION.md).
+
 
 ## Known issues
  - Matrix-specific links (`https://matrix.to/...`) aren't fully handled in-app yet.
@@ -233,7 +288,7 @@ These are generally sorted in order of priority. If you're interested in helping
 ## Packaging Robrix for Distribution on Desktop Platforms
 
 > [!TIP]
-> We already have [pre-built releases of Robrix](https://github.com/project-robius/robrix/releases) available for download.
+> We already have [pre-built releases of Robrix](https://github.com/Project-Robius-China/robrix2/releases) available for download.
 
 
 1. Install `cargo-packager`:

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,105 @@
+# Robrix Distribution
+
+Robrix releases use native installers rather than treating the application as a
+single command-line binary:
+
+| Platform | Native package | Architectures |
+|---|---|---|
+| macOS | DMG containing `Robrix.app` | Apple Silicon, Intel |
+| Debian/Ubuntu | DEB | arm64, x86-64 |
+| Windows | NSIS installer | x86-64, including Windows on ARM emulation |
+
+The release workflow builds those packages first. After every complete desktop
+build, `scripts/generate-distribution-assets.sh` reads GitHub's SHA-256 digests
+and generates:
+
+- `robrix-installer.sh`
+- `robrix-installer.ps1`
+- `SHA256SUMS`
+- `robrix-dist-manifest.json`
+- the `robrix` npm installer package
+- a Homebrew cask
+- Winget multi-file manifests
+
+The generated installers are version-pinned. The stable
+`releases/latest/download` URLs select the newest stable installer script, but
+that script still downloads the exact tag and verifies the exact digest embedded
+when the release was built.
+
+## Initial Bootstrap
+
+The generated shell and PowerShell URLs do not exist on releases created before
+this automation. Publish one complete desktop release after merging these files
+to make those `releases/latest/download` commands live. Existing native packages
+remain available from the repository's Releases page.
+
+Homebrew becomes available when the generated cask is merged into the default
+branch. npm additionally needs the first successful publish with `NPM_TOKEN`;
+Winget needs an accepted manifest pull request in `microsoft/winget-pkgs`.
+
+## Channel Automation
+
+### Homebrew
+
+The repository acts as its own tap. Stable release tags generate
+`Casks/robrix.rb` and open a pull request containing the new version and both
+macOS checksums. The pull request is deliberately not merged automatically.
+
+No third-party Homebrew repository or credential is required.
+
+### npm
+
+Stable releases publish the unscoped `robrix` package to the `latest` npm
+distribution tag. Prereleases publish to `next`, so a release candidate cannot
+replace the default stable package.
+
+Configure the repository secret `NPM_TOKEN` with permission to publish the
+`robrix` package. Without it, the release workflow skips registry publication
+and leaves the generated npm tarball attached to the GitHub release.
+
+The npm package invokes the same native installer scripts. Set
+`ROBRIX_NPM_SKIP_INSTALL=1` to install only the wrapper, then run
+`robrix-install` later.
+
+Removing the npm package removes only the wrapper command. Robrix itself is a
+native application and must be uninstalled using the operating system's normal
+application or package removal flow.
+
+### Winget
+
+Stable releases generate manifests for `ProjectRobiusChina.Robrix`. Configure
+`WINGET_CREATE_GITHUB_TOKEN` with the permissions required by Microsoft's
+WingetCreate tool. The workflow submits those manifests as a pull request to
+`microsoft/winget-pkgs`.
+
+Without that secret, the workflow skips submission and leaves a manifest ZIP on
+the GitHub release. The initial Winget pull request must pass Microsoft's
+installer and publisher validation before `winget install` becomes available.
+
+## Local Validation
+
+Run:
+
+```sh
+./scripts/test-distribution.sh
+```
+
+The test uses checked-in release metadata and does not download or install
+Robrix. It checks shell syntax, all OS/architecture selections, the distribution
+manifest, npm package contents, Homebrew Ruby syntax, Winget YAML, and unresolved
+template placeholders.
+
+Generated installers also support selection-only checks:
+
+```sh
+ROBRIX_INSTALLER_DRY_RUN=1 ./robrix-installer.sh
+```
+
+The macOS DMG contains the MIT license and normally presents it through the
+terminal before mounting. For a noninteractive installation, review the license
+first and set `ROBRIX_ACCEPT_LICENSE=1`.
+
+For a new release, the Linux matrix gives Ubuntu 22.04 and Ubuntu 24.04 packages
+distinct asset names. The shell installer selects Ubuntu 24.04 only on that
+release and uses the Ubuntu 22.04 build as the baseline for other supported
+Debian-family systems.

--- a/packaging/distribution/robrix-installer.ps1.in
+++ b/packaging/distribution/robrix-installer.ps1.in
@@ -1,0 +1,123 @@
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [string]$DownloadDirectory,
+    [switch]$Quiet,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+$AppName = "Robrix"
+$AppVersion = "@VERSION@"
+$ReleaseTag = "@TAG@"
+$Repository = "@REPOSITORY@"
+$ReleaseBaseUrl = if ($env:ROBRIX_DOWNLOAD_BASE_URL) {
+    $env:ROBRIX_DOWNLOAD_BASE_URL.TrimEnd("/")
+} else {
+    "https://github.com/$Repository/releases/download/$ReleaseTag"
+}
+
+if ($Help) {
+    @"
+robrix-installer.ps1
+
+Install Robrix $AppVersion from the official GitHub release.
+
+OPTIONS:
+    -DownloadDirectory DIR  Verify and save the installer without running it
+    -DryRun                Print the selected artifact without downloading it
+    -Quiet                 Suppress progress messages
+    -Help                  Print this help
+
+ENVIRONMENT:
+    ROBRIX_DOWNLOAD_BASE_URL    Override the release download base URL
+    ROBRIX_GITHUB_TOKEN         Token for a private or draft GitHub release
+    ROBRIX_INSTALLER_DRY_RUN=1  Same as -DryRun
+"@
+    exit 0
+}
+
+if ($env:ROBRIX_INSTALLER_DRY_RUN -eq "1") {
+    $DryRun = $true
+}
+
+function Write-ProgressMessage([string]$Message) {
+    if (-not $Quiet) {
+        Write-Host $Message
+    }
+}
+
+$RawArchitecture = if ($env:ROBRIX_INSTALLER_ARCH) {
+    $env:ROBRIX_INSTALLER_ARCH
+} elseif ($env:PROCESSOR_ARCHITEW6432) {
+    $env:PROCESSOR_ARCHITEW6432
+} else {
+    $env:PROCESSOR_ARCHITECTURE
+}
+
+switch -Regex ($RawArchitecture) {
+    "^(AMD64|x86_64|x64)$" {
+        $Architecture = "x86_64"
+        break
+    }
+    "^(ARM64|aarch64|arm64)$" {
+        # The x64 NSIS package runs under Windows ARM64 emulation.
+        $Architecture = "x86_64"
+        break
+    }
+    default {
+        throw "Unsupported Windows architecture: $RawArchitecture"
+    }
+}
+
+$Asset = "@WINDOWS_X86_64_ASSET@"
+$ExpectedSha256 = "@WINDOWS_X86_64_SHA256@"
+$DownloadUrl = "$ReleaseBaseUrl/$Asset"
+
+if ($DryRun) {
+    Write-Output "version=$AppVersion"
+    Write-Output "platform=windows"
+    Write-Output "architecture=$Architecture"
+    Write-Output "asset=$Asset"
+    Write-Output "sha256=$ExpectedSha256"
+    Write-Output "url=$DownloadUrl"
+    exit 0
+}
+
+$Headers = @{}
+if ($env:ROBRIX_GITHUB_TOKEN) {
+    $Headers["Authorization"] = "Bearer $($env:ROBRIX_GITHUB_TOKEN)"
+}
+
+$TemporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("robrix-installer-" + [Guid]::NewGuid())
+New-Item -ItemType Directory -Path $TemporaryDirectory | Out-Null
+$DownloadedFile = Join-Path $TemporaryDirectory $Asset
+
+try {
+    Write-ProgressMessage "Downloading $AppName $AppVersion (windows/$Architecture)..."
+    Invoke-WebRequest -Uri $DownloadUrl -Headers $Headers -OutFile $DownloadedFile -UseBasicParsing
+
+    $ActualSha256 = (Get-FileHash -Path $DownloadedFile -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($ActualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
+        throw "Checksum mismatch for $Asset`: expected $ExpectedSha256, got $ActualSha256"
+    }
+    Write-ProgressMessage "Verified SHA-256: $ActualSha256"
+
+    if ($DownloadDirectory) {
+        New-Item -ItemType Directory -Force -Path $DownloadDirectory | Out-Null
+        $Destination = Join-Path $DownloadDirectory $Asset
+        Copy-Item -Force -Path $DownloadedFile -Destination $Destination
+        Write-ProgressMessage "Saved $Destination"
+        exit 0
+    }
+
+    $Process = Start-Process -FilePath $DownloadedFile -ArgumentList "/S" -Wait -PassThru
+    if ($Process.ExitCode -ne 0 -and $Process.ExitCode -ne 3010) {
+        throw "The Robrix installer exited with code $($Process.ExitCode)"
+    }
+    Write-ProgressMessage "Installed $AppName $AppVersion"
+} finally {
+    if (Test-Path $TemporaryDirectory) {
+        Remove-Item -Recurse -Force $TemporaryDirectory
+    }
+}

--- a/packaging/distribution/robrix-installer.sh.in
+++ b/packaging/distribution/robrix-installer.sh.in
@@ -1,0 +1,298 @@
+#!/bin/sh
+
+set -eu
+
+APP_NAME="Robrix"
+APP_VERSION="@VERSION@"
+RELEASE_TAG="@TAG@"
+REPOSITORY="@REPOSITORY@"
+RELEASE_BASE_URL="${ROBRIX_DOWNLOAD_BASE_URL:-https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}}"
+DRY_RUN="${ROBRIX_INSTALLER_DRY_RUN:-0}"
+QUIET=0
+DOWNLOAD_ONLY=""
+TEMP_DIR=""
+MOUNT_DIR=""
+MOUNTED=0
+
+usage() {
+    cat <<EOF
+robrix-installer.sh
+
+Install Robrix ${APP_VERSION} from the official GitHub release.
+
+USAGE:
+    robrix-installer.sh [OPTIONS]
+
+OPTIONS:
+    --download-only DIR  Verify and save the native installer without running it
+    --dry-run            Print the selected artifact without downloading it
+    -q, --quiet          Suppress progress messages
+    -h, --help           Print this help
+
+ENVIRONMENT:
+    ROBRIX_INSTALL_DIR          macOS destination (default: /Applications or ~/Applications)
+    ROBRIX_DOWNLOAD_BASE_URL    Override the release download base URL
+    ROBRIX_GITHUB_TOKEN         Token for a private or draft GitHub release
+    ROBRIX_INSTALLER_DRY_RUN=1  Same as --dry-run
+    ROBRIX_ACCEPT_LICENSE=1     Accept the DMG license in noninteractive installs
+EOF
+}
+
+say() {
+    if [ "$QUIET" -ne 1 ]; then
+        printf '%s\n' "$*"
+    fi
+}
+
+die() {
+    printf 'robrix-installer: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ "$MOUNTED" -eq 1 ] && [ -n "$MOUNT_DIR" ]; then
+        hdiutil detach "$MOUNT_DIR" -quiet >/dev/null 2>&1 || true
+    fi
+    if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+        rm -rf "$TEMP_DIR"
+    fi
+}
+
+trap cleanup 0
+trap 'exit 1' 1 2 15
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --download-only)
+            [ "$#" -ge 2 ] || die "--download-only requires a directory"
+            DOWNLOAD_ONLY=$2
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -q|--quiet)
+            QUIET=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+raw_os="${ROBRIX_INSTALLER_OS:-$(uname -s)}"
+case "$raw_os" in
+    Darwin|darwin|macOS|macos)
+        target_os="macos"
+        ;;
+    Linux|linux)
+        target_os="linux"
+        ;;
+    *)
+        die "unsupported operating system: $raw_os"
+        ;;
+esac
+
+raw_arch="${ROBRIX_INSTALLER_ARCH:-$(uname -m)}"
+case "$raw_arch" in
+    arm64|aarch64)
+        target_arch="aarch64"
+        ;;
+    x86_64|amd64)
+        target_arch="x86_64"
+        ;;
+    *)
+        die "unsupported architecture: $raw_arch"
+        ;;
+esac
+
+linux_release="22.04"
+if [ "$target_os" = "linux" ] && [ -r /etc/os-release ]; then
+    linux_id=$(awk -F= '$1 == "ID" { gsub(/^"|"$/, "", $2); print $2; exit }' /etc/os-release)
+    linux_version=$(awk -F= '$1 == "VERSION_ID" { gsub(/^"|"$/, "", $2); print $2; exit }' /etc/os-release)
+    case "${linux_id}:${linux_version}" in
+        ubuntu:24.*)
+            linux_release="24.04"
+            ;;
+    esac
+fi
+if [ -n "${ROBRIX_LINUX_RELEASE:-}" ]; then
+    linux_release=$ROBRIX_LINUX_RELEASE
+fi
+
+case "${target_os}/${target_arch}/${linux_release}" in
+    macos/aarch64/*)
+        asset="@MACOS_AARCH64_ASSET@"
+        expected_sha256="@MACOS_AARCH64_SHA256@"
+        ;;
+    macos/x86_64/*)
+        asset="@MACOS_X86_64_ASSET@"
+        expected_sha256="@MACOS_X86_64_SHA256@"
+        ;;
+    linux/aarch64/24.04)
+        asset="@LINUX_24_AARCH64_ASSET@"
+        expected_sha256="@LINUX_24_AARCH64_SHA256@"
+        ;;
+    linux/x86_64/24.04)
+        asset="@LINUX_24_X86_64_ASSET@"
+        expected_sha256="@LINUX_24_X86_64_SHA256@"
+        ;;
+    linux/aarch64/*)
+        asset="@LINUX_22_AARCH64_ASSET@"
+        expected_sha256="@LINUX_22_AARCH64_SHA256@"
+        ;;
+    linux/x86_64/*)
+        asset="@LINUX_22_X86_64_ASSET@"
+        expected_sha256="@LINUX_22_X86_64_SHA256@"
+        ;;
+esac
+
+download_url="${RELEASE_BASE_URL}/${asset}"
+
+if [ "$DRY_RUN" = "1" ]; then
+    printf 'version=%s\n' "$APP_VERSION"
+    printf 'platform=%s\n' "$target_os"
+    printf 'architecture=%s\n' "$target_arch"
+    if [ "$target_os" = "linux" ]; then
+        printf 'linux_release=%s\n' "$linux_release"
+    fi
+    printf 'asset=%s\n' "$asset"
+    printf 'sha256=%s\n' "$expected_sha256"
+    printf 'url=%s\n' "$download_url"
+    exit 0
+fi
+
+download() {
+    source_url=$1
+    destination=$2
+
+    if command -v curl >/dev/null 2>&1; then
+        if [ -n "${ROBRIX_GITHUB_TOKEN:-}" ]; then
+            curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+                --header "Authorization: Bearer ${ROBRIX_GITHUB_TOKEN}" \
+                --output "$destination" "$source_url"
+        else
+            curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+                --output "$destination" "$source_url"
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if [ -n "${ROBRIX_GITHUB_TOKEN:-}" ]; then
+            wget --quiet --header="Authorization: Bearer ${ROBRIX_GITHUB_TOKEN}" \
+                --output-document="$destination" "$source_url"
+        else
+            wget --quiet --output-document="$destination" "$source_url"
+        fi
+    else
+        die "curl or wget is required"
+    fi
+}
+
+sha256_file() {
+    file=$1
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$file" | awk '{print $NF}'
+    else
+        die "sha256sum, shasum, or openssl is required to verify the download"
+    fi
+}
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/robrix-installer.XXXXXX")
+downloaded_file="${TEMP_DIR}/${asset}"
+say "Downloading ${APP_NAME} ${APP_VERSION} (${target_os}/${target_arch})..."
+download "$download_url" "$downloaded_file"
+
+actual_sha256=$(sha256_file "$downloaded_file")
+if [ "$actual_sha256" != "$expected_sha256" ]; then
+    die "checksum mismatch for ${asset}: expected ${expected_sha256}, got ${actual_sha256}"
+fi
+say "Verified SHA-256: ${actual_sha256}"
+
+if [ -n "$DOWNLOAD_ONLY" ]; then
+    mkdir -p "$DOWNLOAD_ONLY"
+    destination="${DOWNLOAD_ONLY%/}/${asset}"
+    cp "$downloaded_file" "$destination"
+    say "Saved ${destination}"
+    exit 0
+fi
+
+if [ "$target_os" = "macos" ]; then
+    command -v hdiutil >/dev/null 2>&1 || die "hdiutil is required on macOS"
+    MOUNT_DIR="${TEMP_DIR}/mount"
+    mkdir -p "$MOUNT_DIR"
+    if hdiutil imageinfo "$downloaded_file" |
+        grep -q 'Software License Agreement: true'; then
+        if [ "${ROBRIX_ACCEPT_LICENSE:-0}" = "1" ]; then
+            printf 'Y\n' |
+                hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_DIR" \
+                    "$downloaded_file" >/dev/null
+        elif [ -r /dev/tty ]; then
+            hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_DIR" \
+                "$downloaded_file" </dev/tty >/dev/null
+        else
+            die "the DMG license requires an interactive terminal; review it and set ROBRIX_ACCEPT_LICENSE=1 to accept"
+        fi
+    else
+        hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_DIR" \
+            "$downloaded_file" >/dev/null
+    fi
+    MOUNTED=1
+
+    source_app="${MOUNT_DIR}/Robrix.app"
+    if [ ! -d "$source_app" ]; then
+        source_app=$(find "$MOUNT_DIR" -type d -name 'Robrix.app' -print -quit)
+    fi
+    [ -n "$source_app" ] && [ -d "$source_app" ] || die "Robrix.app was not found in ${asset}"
+
+    if [ -n "${ROBRIX_INSTALL_DIR:-}" ]; then
+        install_dir=$ROBRIX_INSTALL_DIR
+    elif [ -d /Applications ] && [ -w /Applications ]; then
+        install_dir=/Applications
+    else
+        install_dir="${HOME:?HOME is required}/Applications"
+    fi
+
+    mkdir -p "$install_dir"
+    target_app="${install_dir%/}/Robrix.app"
+    staged_app="${install_dir%/}/.Robrix.app.install.$$"
+    backup_app="${install_dir%/}/.Robrix.app.backup.$$"
+
+    rm -rf "$staged_app" "$backup_app"
+    if command -v ditto >/dev/null 2>&1; then
+        ditto "$source_app" "$staged_app"
+    else
+        cp -R "$source_app" "$staged_app"
+    fi
+
+    if [ -e "$target_app" ]; then
+        mv "$target_app" "$backup_app"
+    fi
+    if mv "$staged_app" "$target_app"; then
+        rm -rf "$backup_app"
+    else
+        [ ! -e "$backup_app" ] || mv "$backup_app" "$target_app"
+        die "could not replace ${target_app}"
+    fi
+    say "Installed ${target_app}"
+else
+    command -v apt-get >/dev/null 2>&1 ||
+        die "the current Linux release is a .deb; Debian or Ubuntu with apt-get is required"
+
+    if [ "$(id -u)" -eq 0 ]; then
+        apt-get install -y "$downloaded_file"
+    else
+        command -v sudo >/dev/null 2>&1 ||
+            die "sudo is required to install the .deb package"
+        sudo apt-get install -y "$downloaded_file"
+    fi
+    say "Installed ${APP_NAME} ${APP_VERSION}"
+fi

--- a/packaging/distribution/testdata/v1.1.0-assets.json
+++ b/packaging/distribution/testdata/v1.1.0-assets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "latest.json",
+    "digest": "sha256:3eb351eaa9ec3dd95f08db966ebc90f1cedac4adebe269ae624c94eb54f36094",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/latest.json"
+  },
+  {
+    "name": "robrix-1.1.0-linux-aarch64-release.deb",
+    "digest": "sha256:6859904c837fac8b177e2c33374e3a797cff0f330727d32e1463ff6c898857b4",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/robrix-1.1.0-linux-aarch64-release.deb"
+  },
+  {
+    "name": "robrix-1.1.0-linux-x86_64-release.deb",
+    "digest": "sha256:8a94580a1b9d2b2e6947248ace9bb2fca51c5f1ab970b18b13cc257851921891",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/robrix-1.1.0-linux-x86_64-release.deb"
+  },
+  {
+    "name": "robrix-1.1.0-macos-aarch64-release.dmg",
+    "digest": "sha256:783375cd75c8fc3ad38ccc3ad70e8368faf83606ad4788b99118cf6af6404e7a",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/robrix-1.1.0-macos-aarch64-release.dmg"
+  },
+  {
+    "name": "robrix-1.1.0-macos-x86_64-release.dmg",
+    "digest": "sha256:cbfb903acbf3ba68cb1549878e0847b5d6d53318fec7d7bc1523808cc63889b2",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/robrix-1.1.0-macos-x86_64-release.dmg"
+  },
+  {
+    "name": "robrix-1.1.0-windows-x86_64-release.exe",
+    "digest": "sha256:82171be7936cc97965f02baf20cef2c820b5bd2890e80c39fe1e034480d047e2",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.1.0/robrix-1.1.0-windows-x86_64-release.exe"
+  }
+]

--- a/packaging/distribution/testdata/v1.2.0-assets.json
+++ b/packaging/distribution/testdata/v1.2.0-assets.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "robrix-1.2.0-macos-aarch64-release.dmg",
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-macos-aarch64-release.dmg"
+  },
+  {
+    "name": "robrix-1.2.0-macos-x86_64-release.dmg",
+    "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-macos-x86_64-release.dmg"
+  },
+  {
+    "name": "robrix-1.2.0-ubuntu-22.04-aarch64-release.deb",
+    "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-ubuntu-22.04-aarch64-release.deb"
+  },
+  {
+    "name": "robrix-1.2.0-ubuntu-22.04-x86_64-release.deb",
+    "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-ubuntu-22.04-x86_64-release.deb"
+  },
+  {
+    "name": "robrix-1.2.0-ubuntu-24.04-aarch64-release.deb",
+    "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-ubuntu-24.04-aarch64-release.deb"
+  },
+  {
+    "name": "robrix-1.2.0-ubuntu-24.04-x86_64-release.deb",
+    "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-ubuntu-24.04-x86_64-release.deb"
+  },
+  {
+    "name": "robrix-1.2.0-windows-x86_64-release.exe",
+    "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+    "browser_download_url": "https://github.com/Project-Robius-China/robrix2/releases/download/v1.2.0/robrix-1.2.0-windows-x86_64-release.exe"
+  }
+]

--- a/packaging/homebrew/robrix.rb.in
+++ b/packaging/homebrew/robrix.rb.in
@@ -1,0 +1,22 @@
+cask "robrix" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "@VERSION@"
+  sha256 arm:   "@MACOS_AARCH64_SHA256@",
+         intel: "@MACOS_X86_64_SHA256@"
+
+  url "https://github.com/@REPOSITORY@/releases/download/@TAG@/robrix-#{version}-macos-#{arch}-release.dmg"
+  name "Robrix"
+  desc "Multi-platform Matrix chat client built with Rust and Makepad"
+  homepage "https://github.com/@REPOSITORY@"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Robrix.app"
+end

--- a/packaging/npm/README.md.in
+++ b/packaging/npm/README.md.in
@@ -1,0 +1,17 @@
+# Robrix
+
+This package installs the native Robrix desktop application from the
+[`@TAG@` GitHub release](https://github.com/@REPOSITORY@/releases/tag/@TAG@).
+The downloaded DMG, DEB, or NSIS installer is verified with a release-pinned
+SHA-256 checksum before it runs.
+
+```sh
+npm install --global robrix
+```
+
+The package supports macOS on Apple Silicon and Intel, Debian/Ubuntu on arm64
+and x86-64, and Windows on x86-64 (including Windows on ARM emulation).
+
+Set `ROBRIX_NPM_SKIP_INSTALL=1` to install only the npm wrapper. You can then
+run `robrix-install` later. Run `robrix-install --dry-run` to inspect the
+artifact selected for the current machine without downloading or installing it.

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+if (process.env.ROBRIX_NPM_SKIP_INSTALL === "1") {
+  process.stdout.write("Skipping native Robrix installation (ROBRIX_NPM_SKIP_INSTALL=1).\n");
+  process.exit(0);
+}
+
+const requestedArgs = process.argv.slice(2);
+const dryRun = requestedArgs.includes("--dry-run");
+const downloadOnlyIndex = requestedArgs.indexOf("--download-only");
+const downloadDirectory =
+  downloadOnlyIndex >= 0 ? requestedArgs[downloadOnlyIndex + 1] : undefined;
+
+if (downloadOnlyIndex >= 0 && !downloadDirectory) {
+  process.stderr.write("robrix-install: --download-only requires a directory\n");
+  process.exit(2);
+}
+
+let command;
+let args;
+
+if (process.platform === "win32") {
+  command = "powershell.exe";
+  args = [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    path.join(__dirname, "robrix-installer.ps1"),
+  ];
+  if (dryRun) {
+    args.push("-DryRun");
+  }
+  if (downloadDirectory) {
+    args.push("-DownloadDirectory", downloadDirectory);
+  }
+} else if (process.platform === "darwin" || process.platform === "linux") {
+  command = "sh";
+  args = [path.join(__dirname, "robrix-installer.sh")];
+  if (dryRun) {
+    args.push("--dry-run");
+  }
+  if (downloadDirectory) {
+    args.push("--download-only", downloadDirectory);
+  }
+} else {
+  process.stderr.write(`robrix-install: unsupported platform ${process.platform}\n`);
+  process.exit(1);
+}
+
+const result = spawnSync(command, args, {
+  env: process.env,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  process.stderr.write(`robrix-install: ${result.error.message}\n`);
+  process.exit(1);
+}
+
+process.exit(result.status === null ? 1 : result.status);

--- a/packaging/npm/package.json.in
+++ b/packaging/npm/package.json.in
@@ -1,0 +1,40 @@
+{
+  "name": "robrix",
+  "version": "@VERSION@",
+  "description": "Native installer wrapper for the Robrix Matrix client",
+  "license": "MIT",
+  "homepage": "https://github.com/@REPOSITORY@",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/@REPOSITORY@.git"
+  },
+  "bugs": {
+    "url": "https://github.com/@REPOSITORY@/issues"
+  },
+  "bin": {
+    "robrix-install": "install.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "install.js",
+    "robrix-installer.sh",
+    "robrix-installer.ps1",
+    "README.md",
+    "LICENSE-MIT"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "arm64",
+    "x64"
+  ],
+  "preferGlobal": true
+}

--- a/packaging/winget/ProjectRobiusChina.Robrix.installer.yaml.in
+++ b/packaging/winget/ProjectRobiusChina.Robrix.installer.yaml.in
@@ -1,0 +1,27 @@
+# Created by the Robrix release workflow.
+PackageIdentifier: ProjectRobiusChina.Robrix
+PackageVersion: @VERSION@
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Protocols:
+  - robrix
+  - matrix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/@REPOSITORY@/releases/download/@TAG@/@WINDOWS_X86_64_ASSET@
+    InstallerSha256: @WINDOWS_X86_64_SHA256_UPPER@
+    AppsAndFeaturesEntries:
+      - DisplayName: Robrix
+        DisplayVersion: @VERSION@
+        Publisher: GOSIM Foundation
+        InstallerType: nullsoft
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/packaging/winget/ProjectRobiusChina.Robrix.locale.en-US.yaml.in
+++ b/packaging/winget/ProjectRobiusChina.Robrix.locale.en-US.yaml.in
@@ -1,0 +1,27 @@
+# Created by the Robrix release workflow.
+PackageIdentifier: ProjectRobiusChina.Robrix
+PackageVersion: @VERSION@
+PackageLocale: en-US
+Publisher: GOSIM Foundation
+PublisherUrl: https://github.com/Project-Robius-China
+PublisherSupportUrl: https://github.com/@REPOSITORY@/issues
+Author: Project Robius
+PackageName: Robrix
+PackageUrl: https://github.com/@REPOSITORY@
+License: MIT
+LicenseUrl: https://github.com/@REPOSITORY@/blob/@TAG@/LICENSE-MIT
+Copyright: Copyright 2023-2026, Project Robius
+ShortDescription: Multi-platform Matrix chat client built with Rust and Makepad.
+Description: >-
+  Robrix is a Matrix chat client written in Rust using the Makepad UI toolkit
+  and Project Robius application development framework.
+Moniker: robrix
+Tags:
+  - chat
+  - makepad
+  - matrix
+  - messaging
+  - rust
+ReleaseNotesUrl: https://github.com/@REPOSITORY@/releases/tag/@TAG@
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/packaging/winget/ProjectRobiusChina.Robrix.yaml.in
+++ b/packaging/winget/ProjectRobiusChina.Robrix.yaml.in
@@ -1,0 +1,6 @@
+# Created by the Robrix release workflow.
+PackageIdentifier: ProjectRobiusChina.Robrix
+PackageVersion: @VERSION@
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/generate-distribution-assets.sh
+++ b/scripts/generate-distribution-assets.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPOSITORY="Project-Robius-China/robrix2"
+TAG=""
+ASSETS_JSON=""
+OUTPUT_DIR=""
+
+usage() {
+    cat <<'EOF'
+generate-distribution-assets.sh
+
+Generate checksum-pinned Robrix installers and package-manager metadata.
+
+USAGE:
+    scripts/generate-distribution-assets.sh \
+        --tag v1.2.3 \
+        --assets-json release-assets.json \
+        --output dist/distribution \
+        [--repository owner/repository]
+
+The assets JSON can be either a GitHub release object or its .assets array.
+Each required desktop asset must include name, digest, and browser_download_url.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repository)
+            REPOSITORY=${2:?missing repository}
+            shift 2
+            ;;
+        --tag)
+            TAG=${2:?missing tag}
+            shift 2
+            ;;
+        --assets-json)
+            ASSETS_JSON=${2:?missing assets JSON path}
+            shift 2
+            ;;
+        --output)
+            OUTPUT_DIR=${2:?missing output directory}
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+[[ -n "$TAG" ]] || { echo "--tag is required" >&2; exit 2; }
+[[ "$TAG" == v* ]] || { echo "--tag must start with v" >&2; exit 2; }
+[[ -f "$ASSETS_JSON" ]] || { echo "--assets-json must name a readable file" >&2; exit 2; }
+[[ -n "$OUTPUT_DIR" ]] || { echo "--output is required" >&2; exit 2; }
+
+for command in jq npm sed zip; do
+    command -v "$command" >/dev/null 2>&1 ||
+        { echo "$command is required" >&2; exit 1; }
+done
+
+VERSION=${TAG#v}
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] ||
+    { echo "unsupported release version: $VERSION" >&2; exit 2; }
+[[ "$REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+    { echo "invalid GitHub repository: $REPOSITORY" >&2; exit 2; }
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+NORMALIZED_ASSETS="$OUTPUT_DIR/.release-assets.json"
+
+jq -e '
+    (if type == "array" then . else .assets end)
+    | if type == "array" then . else error("assets JSON must contain an array") end
+' "$ASSETS_JSON" > "$NORMALIZED_ASSETS"
+
+asset_record() {
+    local candidate
+    local record
+    for candidate in "$@"; do
+        if record=$(jq -ce --arg name "$candidate" '.[] | select(.name == $name)' "$NORMALIZED_ASSETS"); then
+            printf '%s\n' "$record"
+            return 0
+        fi
+    done
+    echo "missing release asset; expected one of: $*" >&2
+    return 1
+}
+
+record_name() {
+    jq -r '.name' <<<"$1"
+}
+
+record_url() {
+    local url
+    local expected_prefix="https://github.com/${REPOSITORY}/releases/download/${TAG}/"
+    url=$(jq -r '.browser_download_url // ""' <<<"$1")
+    [[ "$url" == "${expected_prefix}"* ]] ||
+        { echo "unexpected release asset URL: $url" >&2; return 1; }
+    printf '%s\n' "$url"
+}
+
+record_sha256() {
+    local digest
+    digest=$(jq -r '.digest // ""' <<<"$1")
+    [[ "$digest" =~ ^sha256:[0-9a-fA-F]{64}$ ]] ||
+        { echo "asset has no GitHub SHA-256 digest: $(record_name "$1")" >&2; return 1; }
+    printf '%s\n' "${digest#sha256:}" | tr '[:upper:]' '[:lower:]'
+}
+
+MACOS_AARCH64_RECORD=$(asset_record "robrix-${VERSION}-macos-aarch64-release.dmg")
+MACOS_X86_64_RECORD=$(asset_record "robrix-${VERSION}-macos-x86_64-release.dmg")
+WINDOWS_X86_64_RECORD=$(asset_record "robrix-${VERSION}-windows-x86_64-release.exe")
+
+LINUX_22_AARCH64_RECORD=$(asset_record \
+    "robrix-${VERSION}-ubuntu-22.04-aarch64-release.deb" \
+    "robrix-${VERSION}-linux-aarch64-release.deb")
+LINUX_22_X86_64_RECORD=$(asset_record \
+    "robrix-${VERSION}-ubuntu-22.04-x86_64-release.deb" \
+    "robrix-${VERSION}-linux-x86_64-release.deb")
+LINUX_24_AARCH64_RECORD=$(asset_record \
+    "robrix-${VERSION}-ubuntu-24.04-aarch64-release.deb" \
+    "robrix-${VERSION}-linux-aarch64-release.deb")
+LINUX_24_X86_64_RECORD=$(asset_record \
+    "robrix-${VERSION}-ubuntu-24.04-x86_64-release.deb" \
+    "robrix-${VERSION}-linux-x86_64-release.deb")
+
+MACOS_AARCH64_ASSET=$(record_name "$MACOS_AARCH64_RECORD")
+MACOS_AARCH64_URL=$(record_url "$MACOS_AARCH64_RECORD")
+MACOS_AARCH64_SHA256=$(record_sha256 "$MACOS_AARCH64_RECORD")
+MACOS_X86_64_ASSET=$(record_name "$MACOS_X86_64_RECORD")
+MACOS_X86_64_URL=$(record_url "$MACOS_X86_64_RECORD")
+MACOS_X86_64_SHA256=$(record_sha256 "$MACOS_X86_64_RECORD")
+WINDOWS_X86_64_ASSET=$(record_name "$WINDOWS_X86_64_RECORD")
+WINDOWS_X86_64_URL=$(record_url "$WINDOWS_X86_64_RECORD")
+WINDOWS_X86_64_SHA256=$(record_sha256 "$WINDOWS_X86_64_RECORD")
+
+LINUX_22_AARCH64_ASSET=$(record_name "$LINUX_22_AARCH64_RECORD")
+LINUX_22_AARCH64_URL=$(record_url "$LINUX_22_AARCH64_RECORD")
+LINUX_22_AARCH64_SHA256=$(record_sha256 "$LINUX_22_AARCH64_RECORD")
+LINUX_22_X86_64_ASSET=$(record_name "$LINUX_22_X86_64_RECORD")
+LINUX_22_X86_64_URL=$(record_url "$LINUX_22_X86_64_RECORD")
+LINUX_22_X86_64_SHA256=$(record_sha256 "$LINUX_22_X86_64_RECORD")
+LINUX_24_AARCH64_ASSET=$(record_name "$LINUX_24_AARCH64_RECORD")
+LINUX_24_AARCH64_URL=$(record_url "$LINUX_24_AARCH64_RECORD")
+LINUX_24_AARCH64_SHA256=$(record_sha256 "$LINUX_24_AARCH64_RECORD")
+LINUX_24_X86_64_ASSET=$(record_name "$LINUX_24_X86_64_RECORD")
+LINUX_24_X86_64_URL=$(record_url "$LINUX_24_X86_64_RECORD")
+LINUX_24_X86_64_SHA256=$(record_sha256 "$LINUX_24_X86_64_RECORD")
+
+replace_placeholder() {
+    local file=$1
+    local placeholder=$2
+    local value=$3
+    local escaped
+    local temporary="${file}.tmp"
+
+    escaped=$(printf '%s' "$value" | sed 's/[&|\\]/\\&/g')
+    sed "s|${placeholder}|${escaped}|g" "$file" > "$temporary"
+    mv "$temporary" "$file"
+}
+
+render_template() {
+    local template=$1
+    local destination=$2
+
+    cp "$template" "$destination"
+    replace_placeholder "$destination" "@VERSION@" "$VERSION"
+    replace_placeholder "$destination" "@TAG@" "$TAG"
+    replace_placeholder "$destination" "@REPOSITORY@" "$REPOSITORY"
+    replace_placeholder "$destination" "@MACOS_AARCH64_ASSET@" "$MACOS_AARCH64_ASSET"
+    replace_placeholder "$destination" "@MACOS_AARCH64_SHA256@" "$MACOS_AARCH64_SHA256"
+    replace_placeholder "$destination" "@MACOS_X86_64_ASSET@" "$MACOS_X86_64_ASSET"
+    replace_placeholder "$destination" "@MACOS_X86_64_SHA256@" "$MACOS_X86_64_SHA256"
+    replace_placeholder "$destination" "@WINDOWS_X86_64_ASSET@" "$WINDOWS_X86_64_ASSET"
+    replace_placeholder "$destination" "@WINDOWS_X86_64_SHA256@" "$WINDOWS_X86_64_SHA256"
+    replace_placeholder "$destination" "@WINDOWS_X86_64_SHA256_UPPER@" \
+        "$(printf '%s' "$WINDOWS_X86_64_SHA256" | tr '[:lower:]' '[:upper:]')"
+    replace_placeholder "$destination" "@LINUX_22_AARCH64_ASSET@" "$LINUX_22_AARCH64_ASSET"
+    replace_placeholder "$destination" "@LINUX_22_AARCH64_SHA256@" "$LINUX_22_AARCH64_SHA256"
+    replace_placeholder "$destination" "@LINUX_22_X86_64_ASSET@" "$LINUX_22_X86_64_ASSET"
+    replace_placeholder "$destination" "@LINUX_22_X86_64_SHA256@" "$LINUX_22_X86_64_SHA256"
+    replace_placeholder "$destination" "@LINUX_24_AARCH64_ASSET@" "$LINUX_24_AARCH64_ASSET"
+    replace_placeholder "$destination" "@LINUX_24_AARCH64_SHA256@" "$LINUX_24_AARCH64_SHA256"
+    replace_placeholder "$destination" "@LINUX_24_X86_64_ASSET@" "$LINUX_24_X86_64_ASSET"
+    replace_placeholder "$destination" "@LINUX_24_X86_64_SHA256@" "$LINUX_24_X86_64_SHA256"
+}
+
+SHELL_INSTALLER="$OUTPUT_DIR/robrix-installer.sh"
+POWERSHELL_INSTALLER="$OUTPUT_DIR/robrix-installer.ps1"
+render_template \
+    "$REPO_ROOT/packaging/distribution/robrix-installer.sh.in" \
+    "$SHELL_INSTALLER"
+render_template \
+    "$REPO_ROOT/packaging/distribution/robrix-installer.ps1.in" \
+    "$POWERSHELL_INSTALLER"
+chmod +x "$SHELL_INSTALLER"
+
+jq -r '
+    .[]
+    | select((.digest // "") | test("^sha256:[0-9a-fA-F]{64}$"))
+    | select(.name != "SHA256SUMS")
+    | select(.name != "robrix-installer.sh")
+    | select(.name != "robrix-installer.ps1")
+    | select(.name != "robrix-dist-manifest.json")
+    | select(.name | endswith("-npm-package.tgz") | not)
+    | select(.name | endswith("-winget-manifests.zip") | not)
+    | "\(.digest | sub("^sha256:"; "") | ascii_downcase)  \(.name)"
+' "$NORMALIZED_ASSETS" > "$OUTPUT_DIR/SHA256SUMS"
+
+jq -n \
+    --arg version "$VERSION" \
+    --arg tag "$TAG" \
+    --arg repository "$REPOSITORY" \
+    --arg macos_arm_asset "$MACOS_AARCH64_ASSET" \
+    --arg macos_arm_url "$MACOS_AARCH64_URL" \
+    --arg macos_arm_sha "$MACOS_AARCH64_SHA256" \
+    --arg macos_x64_asset "$MACOS_X86_64_ASSET" \
+    --arg macos_x64_url "$MACOS_X86_64_URL" \
+    --arg macos_x64_sha "$MACOS_X86_64_SHA256" \
+    --arg linux22_arm_asset "$LINUX_22_AARCH64_ASSET" \
+    --arg linux22_arm_url "$LINUX_22_AARCH64_URL" \
+    --arg linux22_arm_sha "$LINUX_22_AARCH64_SHA256" \
+    --arg linux22_x64_asset "$LINUX_22_X86_64_ASSET" \
+    --arg linux22_x64_url "$LINUX_22_X86_64_URL" \
+    --arg linux22_x64_sha "$LINUX_22_X86_64_SHA256" \
+    --arg linux24_arm_asset "$LINUX_24_AARCH64_ASSET" \
+    --arg linux24_arm_url "$LINUX_24_AARCH64_URL" \
+    --arg linux24_arm_sha "$LINUX_24_AARCH64_SHA256" \
+    --arg linux24_x64_asset "$LINUX_24_X86_64_ASSET" \
+    --arg linux24_x64_url "$LINUX_24_X86_64_URL" \
+    --arg linux24_x64_sha "$LINUX_24_X86_64_SHA256" \
+    --arg windows_x64_asset "$WINDOWS_X86_64_ASSET" \
+    --arg windows_x64_url "$WINDOWS_X86_64_URL" \
+    --arg windows_x64_sha "$WINDOWS_X86_64_SHA256" \
+    '{
+        schema_version: 1,
+        app: "robrix",
+        version: $version,
+        tag: $tag,
+        repository: $repository,
+        release_url: ("https://github.com/" + $repository + "/releases/tag/" + $tag),
+        platforms: {
+            macos: {
+                aarch64: { asset: $macos_arm_asset, url: $macos_arm_url, sha256: $macos_arm_sha },
+                x86_64: { asset: $macos_x64_asset, url: $macos_x64_url, sha256: $macos_x64_sha }
+            },
+            linux: {
+                ubuntu_22_04: {
+                    aarch64: { asset: $linux22_arm_asset, url: $linux22_arm_url, sha256: $linux22_arm_sha },
+                    x86_64: { asset: $linux22_x64_asset, url: $linux22_x64_url, sha256: $linux22_x64_sha }
+                },
+                ubuntu_24_04: {
+                    aarch64: { asset: $linux24_arm_asset, url: $linux24_arm_url, sha256: $linux24_arm_sha },
+                    x86_64: { asset: $linux24_x64_asset, url: $linux24_x64_url, sha256: $linux24_x64_sha }
+                }
+            },
+            windows: {
+                x86_64: { asset: $windows_x64_asset, url: $windows_x64_url, sha256: $windows_x64_sha }
+            }
+        }
+    }' > "$OUTPUT_DIR/robrix-dist-manifest.json"
+
+mkdir -p "$OUTPUT_DIR/Casks"
+render_template \
+    "$REPO_ROOT/packaging/homebrew/robrix.rb.in" \
+    "$OUTPUT_DIR/Casks/robrix.rb"
+
+NPM_PACKAGE_DIR="$OUTPUT_DIR/npm-package"
+mkdir -p "$NPM_PACKAGE_DIR"
+render_template "$REPO_ROOT/packaging/npm/package.json.in" "$NPM_PACKAGE_DIR/package.json"
+render_template "$REPO_ROOT/packaging/npm/README.md.in" "$NPM_PACKAGE_DIR/README.md"
+cp "$REPO_ROOT/packaging/npm/install.js" "$NPM_PACKAGE_DIR/install.js"
+cp "$REPO_ROOT/LICENSE-MIT" "$NPM_PACKAGE_DIR/LICENSE-MIT"
+cp "$SHELL_INSTALLER" "$NPM_PACKAGE_DIR/robrix-installer.sh"
+cp "$POWERSHELL_INSTALLER" "$NPM_PACKAGE_DIR/robrix-installer.ps1"
+chmod +x "$NPM_PACKAGE_DIR/install.js" "$NPM_PACKAGE_DIR/robrix-installer.sh"
+
+PACKED_NAME=$(
+    cd "$NPM_PACKAGE_DIR"
+    npm_config_cache="$OUTPUT_DIR/.npm-cache" \
+        npm pack --silent --pack-destination "$OUTPUT_DIR"
+)
+mv "$OUTPUT_DIR/$PACKED_NAME" "$OUTPUT_DIR/robrix-${VERSION}-npm-package.tgz"
+
+WINGET_DIR="$OUTPUT_DIR/winget/ProjectRobiusChina.Robrix/$VERSION"
+mkdir -p "$WINGET_DIR"
+render_template \
+    "$REPO_ROOT/packaging/winget/ProjectRobiusChina.Robrix.yaml.in" \
+    "$WINGET_DIR/ProjectRobiusChina.Robrix.yaml"
+render_template \
+    "$REPO_ROOT/packaging/winget/ProjectRobiusChina.Robrix.installer.yaml.in" \
+    "$WINGET_DIR/ProjectRobiusChina.Robrix.installer.yaml"
+render_template \
+    "$REPO_ROOT/packaging/winget/ProjectRobiusChina.Robrix.locale.en-US.yaml.in" \
+    "$WINGET_DIR/ProjectRobiusChina.Robrix.locale.en-US.yaml"
+
+(
+    cd "$OUTPUT_DIR/winget"
+    zip -qr "$OUTPUT_DIR/robrix-${VERSION}-winget-manifests.zip" .
+)
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+for generated_asset in \
+    "$SHELL_INSTALLER" \
+    "$POWERSHELL_INSTALLER" \
+    "$OUTPUT_DIR/robrix-dist-manifest.json" \
+    "$OUTPUT_DIR/robrix-${VERSION}-npm-package.tgz" \
+    "$OUTPUT_DIR/robrix-${VERSION}-winget-manifests.zip"; do
+    printf '%s  %s\n' \
+        "$(sha256_file "$generated_asset")" \
+        "$(basename "$generated_asset")" >> "$OUTPUT_DIR/SHA256SUMS"
+done
+LC_ALL=C sort -o "$OUTPUT_DIR/SHA256SUMS" "$OUTPUT_DIR/SHA256SUMS"
+
+rm -rf "$OUTPUT_DIR/.npm-cache"
+rm -f "$NORMALIZED_ASSETS"
+printf 'Generated Robrix %s distribution assets in %s\n' "$VERSION" "$OUTPUT_DIR"

--- a/scripts/test-distribution.sh
+++ b/scripts/test-distribution.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/robrix-distribution-test.XXXXXX")
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+"$SCRIPT_DIR/generate-distribution-assets.sh" \
+    --repository Project-Robius-China/robrix2 \
+    --tag v1.1.0 \
+    --assets-json "$REPO_ROOT/packaging/distribution/testdata/v1.1.0-assets.json" \
+    --output "$TEMP_DIR/output"
+
+OUTPUT="$TEMP_DIR/output"
+
+bash -n "$OUTPUT/robrix-installer.sh"
+jq -e '
+    .schema_version == 1
+    and .version == "1.1.0"
+    and .platforms.macos.aarch64.sha256 == "783375cd75c8fc3ad38ccc3ad70e8368faf83606ad4788b99118cf6af6404e7a"
+    and .platforms.windows.x86_64.sha256 == "82171be7936cc97965f02baf20cef2c820b5bd2890e80c39fe1e034480d047e2"
+' "$OUTPUT/robrix-dist-manifest.json" >/dev/null
+
+assert_selection() {
+    local expected_asset=$1
+    shift
+    local selection
+    selection=$(env ROBRIX_INSTALLER_DRY_RUN=1 "$@" sh "$OUTPUT/robrix-installer.sh")
+    grep -F "asset=${expected_asset}" <<<"$selection" >/dev/null
+}
+
+assert_selection \
+    "robrix-1.1.0-macos-aarch64-release.dmg" \
+    ROBRIX_INSTALLER_OS=darwin ROBRIX_INSTALLER_ARCH=arm64
+assert_selection \
+    "robrix-1.1.0-macos-x86_64-release.dmg" \
+    ROBRIX_INSTALLER_OS=darwin ROBRIX_INSTALLER_ARCH=x86_64
+assert_selection \
+    "robrix-1.1.0-linux-aarch64-release.deb" \
+    ROBRIX_INSTALLER_OS=linux ROBRIX_INSTALLER_ARCH=aarch64 ROBRIX_LINUX_RELEASE=22.04
+assert_selection \
+    "robrix-1.1.0-linux-x86_64-release.deb" \
+    ROBRIX_INSTALLER_OS=linux ROBRIX_INSTALLER_ARCH=x86_64 ROBRIX_LINUX_RELEASE=24.04
+
+DISTRO_OUTPUT="$TEMP_DIR/distro-output"
+"$SCRIPT_DIR/generate-distribution-assets.sh" \
+    --repository Project-Robius-China/robrix2 \
+    --tag v1.2.0 \
+    --assets-json "$REPO_ROOT/packaging/distribution/testdata/v1.2.0-assets.json" \
+    --output "$DISTRO_OUTPUT"
+
+distro_22_selection=$(
+    ROBRIX_INSTALLER_DRY_RUN=1 \
+    ROBRIX_INSTALLER_OS=linux \
+    ROBRIX_INSTALLER_ARCH=x86_64 \
+    ROBRIX_LINUX_RELEASE=22.04 \
+        sh "$DISTRO_OUTPUT/robrix-installer.sh"
+)
+grep -F 'asset=robrix-1.2.0-ubuntu-22.04-x86_64-release.deb' \
+    <<<"$distro_22_selection" >/dev/null
+
+distro_24_selection=$(
+    ROBRIX_INSTALLER_DRY_RUN=1 \
+    ROBRIX_INSTALLER_OS=linux \
+    ROBRIX_INSTALLER_ARCH=x86_64 \
+    ROBRIX_LINUX_RELEASE=24.04 \
+        sh "$DISTRO_OUTPUT/robrix-installer.sh"
+)
+grep -F 'asset=robrix-1.2.0-ubuntu-24.04-x86_64-release.deb' \
+    <<<"$distro_24_selection" >/dev/null
+
+ROBRIX_NPM_SKIP_INSTALL=1 node "$OUTPUT/npm-package/install.js" >/dev/null
+ruby -c "$OUTPUT/Casks/robrix.rb" >/dev/null
+ruby -c "$REPO_ROOT/Casks/robrix.rb" >/dev/null
+
+for manifest in "$OUTPUT"/winget/ProjectRobiusChina.Robrix/1.1.0/*.yaml; do
+    ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV.fetch(0)), aliases: false)' "$manifest"
+done
+
+if command -v pwsh >/dev/null 2>&1; then
+    ROBRIX_INSTALLER_DRY_RUN=1 ROBRIX_INSTALLER_ARCH=AMD64 \
+        pwsh -NoProfile -File "$OUTPUT/robrix-installer.ps1" |
+        grep -F 'asset=robrix-1.1.0-windows-x86_64-release.exe' >/dev/null
+fi
+
+if rg -n '@[A-Z0-9_]+@' \
+    "$OUTPUT/robrix-installer.sh" \
+    "$OUTPUT/robrix-installer.ps1" \
+    "$OUTPUT/Casks/robrix.rb" \
+    "$OUTPUT/npm-package" \
+    "$OUTPUT/winget"; then
+    echo "unresolved distribution template placeholder" >&2
+    exit 1
+fi
+
+tar -tzf "$OUTPUT/robrix-1.1.0-npm-package.tgz" |
+    grep -F 'package/robrix-installer.sh' >/dev/null
+unzip -Z1 "$OUTPUT/robrix-1.1.0-winget-manifests.zip" |
+    grep -F 'ProjectRobiusChina.Robrix.installer.yaml' >/dev/null
+grep -F '  robrix-installer.sh' "$OUTPUT/SHA256SUMS" >/dev/null
+grep -F '  robrix-1.1.0-npm-package.tgz' "$OUTPUT/SHA256SUMS" >/dev/null
+
+echo "Robrix distribution tests passed."


### PR DESCRIPTION
## Summary
- add checksum-pinned shell and PowerShell installers for native Robrix packages
- add Homebrew Cask, npm wrapper, Winget manifests, and release publication automation
- add distribution fixtures, cross-platform CI validation, and maintainer documentation

## Validation
- `./scripts/test-distribution.sh`
- ShellCheck
- Actionlint
- Homebrew style
- PowerShell syntax and artifact-selection checks
- `cargo check --locked`
- macOS DMG download, checksum, mount, installation, and code-signature verification

The registry channels retain explicit bootstrap requirements documented in `docs/DISTRIBUTION.md`.