### PR TITLE
refactor(ui): finish the primary-colour migration to the accent teal

### DIFF
--- a/src/home/light_themed_dock.rs
+++ b/src/home/light_themed_dock.rs
@@ -144,7 +144,7 @@ script_mod! {
         draw_bg +: {
             // Unselected tabs: subtle neutral surface. Selected tab: teal accent
             // (RBX_ACCENT) — the unified UI selection color, replacing the legacy
-            // bright blue COLOR_ACTIVE_PRIMARY.
+            // COLOR_ACTIVE_PRIMARY (the accent teal).
             color: (RBX_BG_SURFACE_SUBTLE)
             color_hover: (RBX_BG_HOVER)
             color_active: (RBX_ACCENT)

--- a/src/shared/design_tokens.rs
+++ b/src/shared/design_tokens.rs
@@ -24,13 +24,15 @@
 //! - `RBX_FOCUS_*`   keyboard-nav focus ring
 //! - `RBX_TEXT_*`    type-scale `TextStyle` presets
 //!
-//! ## Primary color migration
-//! The legacy primary is the bright blue `COLOR_ACTIVE_PRIMARY` (#0F88FE) in
-//! `styles.rs`, used across ~80 existing call sites. The new visual language uses
-//! the teal `RBX_ACCENT` (#119FB3) as the single primary/CTA/focus color. New UI
-//! MUST use `RBX_ACCENT`; legacy blue is deprecated and migrated per surface as
-//! §5 refactors land (see spec §3 "Primary 迁移"). `RBX_LEGACY_BLUE` names the old
-//! value only so migrations can reference it explicitly.
+//! ## Primary color migration — done
+//! The teal `RBX_ACCENT` (#119FB3) is the single primary/CTA/focus color, and
+//! `COLOR_ACTIVE_PRIMARY` in `styles.rs` now resolves to it, so the ~40 remaining
+//! call sites moved together rather than a screen at a time — every one of them
+//! means "primary", "active" or "focus", and staging them would only have grown
+//! the stretch where blue and teal sat side by side. New UI should still name
+//! `RBX_ACCENT` directly; `COLOR_ACTIVE_PRIMARY` survives as a compatibility
+//! alias for the call sites that have not been renamed yet.
+//! `RBX_LEGACY_BLUE` records the retired #0F88FE and now has no users.
 //!
 //! Tokens are registered into the global `mod.widgets.*` namespace (so any other
 //! `script_mod!` block can read them via `(RBX_TOKEN)` after `use mod.widgets.*`).

--- a/src/shared/icon_button.rs
+++ b/src/shared/icon_button.rs
@@ -5,7 +5,7 @@ script_mod! {
     use mod.widgets.*
 
     // The base Robrix button widget.
-    // Uses COLOR_ACTIVE_PRIMARY (blue) background with white text by default.
+    // Uses COLOR_ACTIVE_PRIMARY (the accent teal) background with white text by default.
     // See also the preset variants below:
     //   RobrixPositiveIconButton, RobrixNegativeIconButton, RobrixNeutralIconButton.
     mod.widgets.RobrixIconButton = Button {

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -196,7 +196,11 @@ script_mod! {
     mod.widgets.COLOR_BG_DANGER_RED = #FFF0F0
     mod.widgets.COLOR_FG_DISABLED = #B3B3B3
     mod.widgets.COLOR_BG_DISABLED = #E0E0E0
-    mod.widgets.COLOR_INFO_BLUE = #0f88fe
+    // Informational accent — it only ever shared a value with the retired legacy
+    // primary. Now the system's own info blue (literal mirroring RBX_INFO_FG;
+    // see the registration-order note further down), so it stays blue while the
+    // primary moves to teal.
+    mod.widgets.COLOR_INFO_BLUE = #1E6FBF
     mod.widgets.COLOR_WARNING_YELLOW = #fcdb03
     mod.widgets.COLOR_TEXT_WARNING_NOT_FOUND = #953800
 
@@ -222,9 +226,18 @@ script_mod! {
     mod.widgets.COLOR_SECONDARY = #E3E3E3
     mod.widgets.COLOR_SECONDARY_DARKER = #C8C8C8
 
-    mod.widgets.COLOR_ACTIVE_PRIMARY = #0f88fe
+    // The primary/CTA/focus colour. Was the legacy bright blue `#0f88fe`; now the
+    // accent teal, completing the migration design_tokens.rs describes. Every one
+    // of the ~40 call sites means "primary", "active" or "focus", which is
+    // exactly what the accent is defined to be, so they all move together —
+    // migrating a screen at a time would have left blue and teal side by side for
+    // as long as the migration ran.
+    // Literals mirroring RBX_ACCENT / RBX_ACCENT_HOVER: this file is registered
+    // before design_tokens.rs, so `RBX_*` is not resolvable here (see the note on
+    // COLOR_PRIMARY_DARKER above).
+    mod.widgets.COLOR_ACTIVE_PRIMARY = #119FB3
 
-    mod.widgets.COLOR_ACTIVE_PRIMARY_DARKER = #106fcc
+    mod.widgets.COLOR_ACTIVE_PRIMARY_DARKER = #0E8C9E
 
     mod.widgets.COLOR_BG_PREVIEW = #F0F5FF
 
@@ -391,10 +404,11 @@ script_mod! {
 
 /// #FFFFFF
 pub const COLOR_PRIMARY:               Vec4 = vec4(1.0, 1.0, 1.0, 1.0);
-/// #0F88FE
-pub const COLOR_ACTIVE_PRIMARY:        Vec4 = vec4(0.059, 0.533, 0.996, 1.0);
-/// #106FCC
-pub const COLOR_ACTIVE_PRIMARY_DARKER: Vec4 = vec4(0.063, 0.435, 0.682, 1.0);
+/// The primary/CTA/focus colour, now the accent teal (was the legacy `#0F88FE`).
+/// The Rust side has no registration-order constraint, so it names the tokens
+/// directly and stays tied to the DSL literals above by construction.
+pub const COLOR_ACTIVE_PRIMARY:        Vec4 = crate::shared::design_tokens::RBX_ACCENT;
+pub const COLOR_ACTIVE_PRIMARY_DARKER: Vec4 = crate::shared::design_tokens::RBX_ACCENT_HOVER;
 /// #138808
 pub const COLOR_FG_ACCEPT_GREEN:       Vec4 = vec4(0.074, 0.533, 0.031, 1.0);
 /// #F0FFF0


### PR DESCRIPTION
`design_tokens.rs` has described the teal `RBX_ACCENT` as "the single primary/CTA/focus color" for a while, with the legacy blue `#0F88FE` deprecated and slated to migrate "per surface as §5 refactors land". About 40 call sites were still on the blue — which is why login could show a teal primary button stacked directly on a bright blue one.

## Why all at once, not per surface

Doing this a screen at a time would only have lengthened the stretch where the two colours sit side by side, and **that mismatch is the bug**. Staging it makes the symptom last longer, not shorter.

Two conditions made a single move safe, and I checked both before touching anything:

- **Every one of the ~40 sites means "primary", "active" or "focus"** — `color`, `color_active`, `border_color_active`, `border_color_focus`, `mark_color_active`, `progress_color`. That is precisely what the accent is defined to be, so no site wanted to stay blue.
- **`RBX_LEGACY_BLUE` had no users at all**, so nothing depended on the old value.

## The change

```
COLOR_ACTIVE_PRIMARY        #0f88fe -> #119FB3   (RBX_ACCENT)
COLOR_ACTIVE_PRIMARY_DARKER #106fcc -> #0E8C9E   (RBX_ACCENT_HOVER)
```

**Not one call site is edited.** All ~40 follow the alias, so they cannot drift apart or be half-migrated, and reverting is the same two lines.

## One deliberate exception

`COLOR_INFO_BLUE` happened to share the retired value, but it marks an informational badge in the space lobby — not a primary action. It moves to the system's own info blue (`#1E6FBF`, mirroring `RBX_INFO_FG`) so it **stays blue** instead of being swept along with the primary.

## Note for reviewers

The DSL side keeps literals rather than naming `RBX_*`. `shared/mod.rs` registers `styles` **before** `design_tokens`, so a token reference there resolves to nothing and silently falls back to grey at runtime — `cargo check` cannot see it. (That exact mistake produced grey day-dividers earlier in #276 and is now recorded in a comment beside each literal.) The Rust consts have no ordering constraint and name the tokens directly, which keeps the two sides tied together.

Comments in `icon_button.rs` and `light_themed_dock.rs` that described the colour as blue are updated, as is the migration note in `design_tokens.rs`.

## Testing

`cargo test --lib --features agent_chat` — 586 pass. Ran the app and walked the affected surfaces: login, settings, room settings, invite and bot-binding modals, TSP wallet/DID modals, add-room, space lobby, the dock tab highlight, progress bar, mention autocomplete, and input focus rings — all now teal, with the space-lobby info badge still blue. Confirmed from the app log that no `RBX_*` property fails to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)