### PR TITLE
fix(send): revive the send queue after a failed send

### DIFF
--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6490,6 +6490,30 @@ pub fn set_sync_service_desired_running(running: bool, reason: &'static str) {
     rt_handle.spawn(apply_sync_service_desired_state(reason));
 }
 
+/// Re-enables the client's send queue.
+///
+/// The SDK disables a room's send queue after *any* send error — recoverable or
+/// not (`send_queue/mod.rs`: "Disable the queue for this room after any kind of
+/// error happened") — and never re-enables it on its own: there is no
+/// `locally_enabled.store(true)` anywhere in the SDK. The only way back is this
+/// call, so without it a single failed send leaves that room's queue asleep for
+/// the rest of the process. Messages then pile up as local echoes that are never
+/// sent, and the timeline draws them exactly like delivered ones.
+///
+/// `SendQueue::set_enabled(true)` is client-wide: it flips the global flag, wakes
+/// every room the client already knows about, and respawns tasks for rooms that
+/// still hold unsent requests — including ones queued in a previous session.
+///
+/// Called whenever sync (re)starts, which is the app's own signal that it
+/// believes it can talk to the homeserver again.
+async fn reenable_send_queue(reason: &'static str) {
+    let Some(client) = get_client() else { return };
+    if !client.send_queue().is_enabled() {
+        log!("Re-enabling the send queue after it was disabled by a send error ({reason}).");
+    }
+    client.send_queue().set_enabled(true).await;
+}
+
 async fn apply_sync_service_desired_state(reason: &'static str) {
     let _guard = SYNC_SERVICE_LIFECYCLE_LOCK.lock().await;
     loop {
@@ -6506,6 +6530,9 @@ async fn apply_sync_service_desired_state(reason: &'static str) {
         if desired {
             log!("Starting Matrix sync service after lifecycle request ({reason}).");
             sync_service.start().await;
+            // Coming back online is exactly when a queue disabled by an earlier
+            // failure should get another chance.
+            reenable_send_queue(reason).await;
         } else {
             log!("Stopping Matrix sync service after lifecycle request ({reason}).");
             sync_service.stop().await;
@@ -8195,7 +8222,17 @@ fn handle_sync_service_state_subscriber(mut subscriber: Subscriber<sync_service:
                     log!("Ignoring sync service state update after token expiration.");
                     break;
                 }
-                other => Cx::post_action(RoomsListHeaderAction::StateUpdate(other)),
+                other => {
+                    // Reaching `Running` means the client believes it can talk to
+                    // the homeserver again — the moment to revive a send queue an
+                    // earlier failure switched off. The error branch above already
+                    // covers restarts we drive ourselves; this covers the SDK
+                    // recovering on its own.
+                    if matches!(other, sync_service::State::Running) {
+                        reenable_send_queue("sync service running").await;
+                    }
+                    Cx::post_action(RoomsListHeaderAction::StateUpdate(other))
+                }
             }
         }
     });


### PR DESCRIPTION
**One failed send silently stops a room from ever sending again.** Found while researching how to show send state in the timeline — the missing UI turned out to be the symptom, not the disease.

## The chain

Each step verified against the pinned SDK checkout (`matrix-rust-sdk-…/9ca2c26`):

| | |
|---|---|
| A send error disables that room's queue — **any** error, recoverable or not | `send_queue/mod.rs:873`. The store happens *before* the `is_recoverable` branch; the comment reads "Disable the queue for this room after any kind of error happened" |
| The queue loop then parks on the flag | `:637` — `if !locally_enabled { notified().await; continue; }` |
| Nothing in the SDK ever sets it back | `locally_enabled.store(true)` appears **zero** times in the checkout |
| The only way out | `SendQueue::set_enabled(true)` (`:273`) / `RoomSendQueue::set_enabled` (`:1072`) |
| robrix2 never called it | zero hits for `send_queue` in `src/` (the three `set_enabled` matches are unrelated button state in `join_leave_room_modal.rs`) |

The queue is on by default (`SendQueueData::new(true)`, `client/builder/mod.rs:606`) and ordinary messages go through it (`timeline.send`, `sliding_sync.rs:5246`), so one network blip is enough. From then on every message in that room becomes a local echo that is never sent — and the timeline draws local echoes exactly like delivered messages, so **nothing looks wrong**.

## The fix

Re-enable the queue at the two points where the app decides it can reach the homeserver again:

- **after `sync_service.start()`** in `apply_sync_service_desired_state` — this also covers the automatic restart the state subscriber's error branch performs (`:8211` routes through the same function)
- **when the sync service state reaches `Running`** — for recoveries the SDK makes on its own without us restarting it

`SendQueue::set_enabled(true)` is client-wide and does the whole job in one call: flips the global flag, wakes every room already known, and respawns tasks for rooms still holding unsent requests — including ones queued in an earlier session. It is idempotent, so calling it on every sync start is harmless; the `is_enabled()` check only decides whether to log.

## Notes for reviewers

- `sync_service::State::Running` is a real variant (`sync_service.rs:67`) — checked, because a wrong name in `matches!` would compile fine and silently never fire.
- Only the *recoverable* half of the problem is addressed here: delivery resumes. A send that failed unrecoverably stays wedged until the user acts, which needs UI that does not exist yet.

## Follow-up (not in this PR)

Making failure **visible** — a sending/failed indicator, the error reason, and retry/discard actions. Worth knowing for that work: `SendHandle::unwedge()` alone is a no-op click, because the loop re-reads `locally_enabled` and parks again; retry has to be `set_enabled(true)` **then** `unwedge()`. Also, `Room::send_raw` (agent-chat/octos routing) and `send_attachment` bypass the queue entirely and never produce an `EventSendState`, so no send-state UI can cover them.

## Testing

`cargo test --lib --features agent_chat` — 589 pass. Ran the app and confirmed from the log that the path is actually taken: `Initial sync service state is Idle` → `Starting Matrix sync service…` → `Received a sync service state update: Running`. The `Re-enabling the send queue…` line only prints when the queue really was off, so a clean session stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)