### PR TITLE
feat(timeline): show send state, with retry and discard

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
     }
 };
 use matrix_sdk_ui::timeline::{
-    self, EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, LiveLocationState, MemberProfileChange, MembershipChange, MsgLikeContent, MsgLikeKind, OtherMessageLike, PollState, RoomMembershipChange, TimelineDetails, TimelineEventItemId, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem
+    self, EmbeddedEvent, EncryptedMessage, EventSendState, EventTimelineItem, InReplyToDetails, LiveLocationState, MemberProfileChange, MembershipChange, MsgLikeContent, MsgLikeKind, OtherMessageLike, PollState, RoomMembershipChange, TimelineDetails, TimelineEventItemId, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem
 };
 use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent}};
 
@@ -250,6 +250,70 @@ impl AgentReplyKind {
             Self::Reply => "reply",
             Self::Inform => "info",
         }
+    }
+}
+
+/// How a message's delivery should be shown in the timeline.
+///
+/// Only messages sent through the send queue have a delivery state at all — a
+/// remote event that arrived over sync has none, and neither do the paths that
+/// bypass the queue (`Room::send_raw`, used for agent-chat/octos routing, and
+/// `send_attachment`). Those all render exactly as before.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MessageDeliveryState {
+    /// In flight. Normally lasts a couple of hundred milliseconds.
+    Sending,
+    /// Failed, but the queue will retry once connectivity returns.
+    FailedRetrying,
+    /// Failed and parked: it will not move again until the user acts.
+    FailedWedged { reason: String },
+}
+
+impl MessageDeliveryState {
+    /// Reads the delivery state of a timeline item, or `None` when the message
+    /// has none to show (already delivered, or never went through the queue).
+    fn from_item(item: &EventTimelineItem) -> Option<Self> {
+        match item.send_state()? {
+            EventSendState::NotSentYet { .. } => Some(Self::Sending),
+            // `Sent` still describes a local echo, but one the server has
+            // accepted — indistinguishable from delivered, so show nothing.
+            EventSendState::Sent { .. } => None,
+            EventSendState::SendingFailed { error, is_recoverable } => {
+                if *is_recoverable {
+                    Some(Self::FailedRetrying)
+                } else {
+                    Some(Self::FailedWedged {
+                        reason: wedge_error_reason(error),
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// A short, human-readable reason for a send that is parked and needs the user.
+///
+/// `matrix_sdk::Error` is `#[non_exhaustive]`, so the outer match keeps a
+/// fallback arm; `QueueWedgeError` is not, and is matched exhaustively so a new
+/// SDK variant becomes a compile error here rather than a silently generic
+/// message.
+fn wedge_error_reason(error: &matrix_sdk::Error) -> String {
+    use matrix_sdk::store::QueueWedgeError;
+    match error {
+        matrix_sdk::Error::SendQueueWedgeError(wedge) => match wedge.as_ref() {
+            QueueWedgeError::InsecureDevices { .. } =>
+                "Some devices in this room are unverified".to_string(),
+            QueueWedgeError::IdentityViolations { .. } =>
+                "A member's verified identity has changed".to_string(),
+            QueueWedgeError::CrossVerificationRequired =>
+                "This session must be verified before sending".to_string(),
+            QueueWedgeError::MissingMediaContent =>
+                "The attachment is no longer available".to_string(),
+            QueueWedgeError::InvalidMimeType { mime_type } =>
+                format!("Unsupported attachment type: {mime_type}"),
+            QueueWedgeError::GenericApiError { msg } => msg.clone(),
+        },
+        other => other.to_string(),
     }
 }
 
@@ -2553,12 +2617,120 @@ script_mod! {
     // its whole `body` subtree with `:=`, so it cannot inherit this from Message.
     // (Named MessageMetaBand to avoid colliding with the retired floating
     // MessageActionBar popup referenced in a commented-out block below.)
+    // Shown under a message whose send is parked and will not move again on its
+    // own: why it failed, and the two ways out. Declared once and instantiated
+    // by both message templates, like MessageDownloadSection.
+    mod.widgets.SendFailureSection = View {
+        visible: false
+        width: Fill,
+        height: Fit
+        flow: Down,
+        spacing: (SPACE_XS)
+        margin: Inset{ top: 4.0, bottom: 2.0 }
+
+        send_failure_reason := Label {
+            width: Fill,
+            height: Fit
+            flow: Flow.Right{wrap: true}
+            draw_text +: {
+                text_style: RBX_TEXT_META {}
+                color: (RBX_DANGER_FG)
+            }
+            text: ""
+        }
+
+        send_failure_actions := View {
+            width: Fill,
+            height: Fit
+            flow: Right,
+            spacing: (SPACE_XS)
+
+            send_retry_button := RobrixIconButton {
+                width: Fit, height: Fit
+                padding: Inset{left: 10.0, right: 10.0, top: 4.0, bottom: 4.0}
+                draw_bg +: {
+                    color: (RBX_ACCENT_SOFT)
+                    color_hover: (RBX_ACCENT_SOFT)
+                    color_down: (RBX_BG_PRESSED)
+                    border_radius: (RBX_RADIUS_MD)
+                    border_size: 1.0
+                    border_color: (RBX_ACCENT)
+                    border_color_hover: (RBX_ACCENT)
+                    border_color_down: (RBX_ACCENT)
+                }
+                draw_text +: {
+                    text_style: (RBX_TEXT_META)
+                    color: (RBX_ACCENT)
+                    color_hover: (RBX_ACCENT)
+                    color_down: (RBX_ACCENT)
+                    color_focus: (RBX_ACCENT)
+                }
+                draw_icon +: { svg: (ICON_SEND), color: (RBX_ACCENT) }
+                icon_walk: Walk{width: 12, height: 12}
+                text: "Retry"
+            }
+
+            send_discard_button := RobrixIconButton {
+                width: Fit, height: Fit
+                padding: Inset{left: 10.0, right: 10.0, top: 4.0, bottom: 4.0}
+                draw_bg +: {
+                    color: (RBX_DANGER_BG)
+                    color_hover: (RBX_DANGER_BG)
+                    color_down: (RBX_BG_PRESSED)
+                    border_radius: (RBX_RADIUS_MD)
+                    border_size: 1.0
+                    border_color: (RBX_DANGER_FG)
+                    border_color_hover: (RBX_DANGER_FG)
+                    border_color_down: (RBX_DANGER_FG)
+                }
+                draw_text +: {
+                    text_style: (RBX_TEXT_META)
+                    color: (RBX_DANGER_FG)
+                    color_hover: (RBX_DANGER_FG)
+                    color_down: (RBX_DANGER_FG)
+                    color_focus: (RBX_DANGER_FG)
+                }
+                draw_icon +: { svg: (ICON_TRASH), color: (RBX_DANGER_FG) }
+                icon_walk: Walk{width: 12, height: 12}
+                text: "Discard"
+            }
+        }
+    }
+
+    // Delivery-state pill for a message still in the send queue. Shares the
+    // meta band so it costs no vertical space, and sits next to the read
+    // receipts — both answer "did this message land?".
+    mod.widgets.SendStatePill = RoundedView {
+        visible: false
+        width: Fit,
+        height: Fit
+        padding: Inset{ left: 6.0, right: 6.0, top: 1.0, bottom: 1.0 }
+        show_bg: true
+        draw_bg +: {
+            color: (RBX_NEUTRAL_BG)
+            border_radius: (RBX_RADIUS_PILL)
+        }
+
+        send_state_label := Label {
+            width: Fit,
+            height: Fit
+            padding: 0
+            draw_text +: {
+                text_style: RBX_TEXT_META {}
+                color: (RBX_NEUTRAL_FG)
+            }
+            text: ""
+        }
+    }
+
     mod.widgets.MessageMetaBand = View {
         width: Fill,
         height: Fit
         flow: Right,
         align: Align{y: 0.5}
         spacing: (SPACE_XS)
+
+        send_state_pill := mod.widgets.SendStatePill {}
 
         // Message-type badge (request / reply / info) for bridge-relayed agent
         // messages, derived from the leading emoji marker the bridge stamps on
@@ -2924,6 +3096,7 @@ script_mod! {
                 }
                 link_preview_view := mod.widgets.LinkPreview {}
                 download_section := mod.widgets.MessageDownloadSection {}
+                send_failure_section := mod.widgets.SendFailureSection {}
                 message_action_bar := mod.widgets.MessageMetaBand {}
                 View {
                     width: Fill,
@@ -3103,6 +3276,7 @@ script_mod! {
                 }
                 link_preview_view := mod.widgets.LinkPreview {}
                 download_section := mod.widgets.MessageDownloadSection {}
+                send_failure_section := mod.widgets.SendFailureSection {}
                 message_action_bar := mod.widgets.MessageMetaBand {}
                 View {
                     width: Fill,
@@ -3195,6 +3369,7 @@ script_mod! {
                     } }
                 }
                 download_section := mod.widgets.MessageDownloadSection {}
+                send_failure_section := mod.widgets.SendFailureSection {}
                 animated_message := mod.widgets.AnimatedImage { visible: false }
                 View {
                     width: Fill,
@@ -3223,6 +3398,7 @@ script_mod! {
                     } }
                 }
                 download_section := mod.widgets.MessageDownloadSection {}
+                send_failure_section := mod.widgets.SendFailureSection {}
                 animated_message := mod.widgets.AnimatedImage { visible: false }
                 View {
                     width: Fill,
@@ -6857,6 +7033,20 @@ impl Widget for RoomScreen {
                     continue;
                 }
 
+                // "Retry" / "Discard" on a message whose send is parked.
+                let retry_clicked = wr
+                    .button(cx, ids!(content.send_failure_section.send_failure_actions.send_retry_button))
+                    .clicked(actions);
+                let discard_clicked = wr
+                    .button(cx, ids!(content.send_failure_section.send_failure_actions.send_discard_button))
+                    .clicked(actions);
+                if retry_clicked || discard_clicked {
+                    if let Some(tl_idx) = tl_idx_from_item_id(index, has_encryption_notice) {
+                        self.act_on_failed_send(cx, tl_idx, retry_clicked);
+                    }
+                    continue;
+                }
+
                 // Handle the invite_user_button (in a SmallStateEvent) being clicked.
                 if wr.button(cx, ids!(event_row.invite_user_button)).clicked(actions) {
                     let Some(tl_idx) = tl_idx_from_item_id(index, has_encryption_notice) else { continue };
@@ -8198,6 +8388,32 @@ impl RoomScreen {
     /// Folds/unfolds the long bot reply at `tl_idx`, keyed by its event ID so the
     /// choice survives PortalList recycling. Invalidates that item's content-draw
     /// cache so the body re-populates at its new length.
+    /// Retries or discards the parked send at `tl_idx`.
+    ///
+    /// Discard reuses `RedactMessage`: for a local echo the SDK's `redact`
+    /// aborts the queued send rather than sending a redaction, so no separate
+    /// request is needed.
+    fn act_on_failed_send(&mut self, _cx: &mut Cx, tl_idx: usize, retry: bool) {
+        let Some(tl_state) = self.tl_state.as_ref() else { return };
+        let Some(event) = tl_state.items.get(tl_idx).and_then(|item| item.as_event()) else {
+            return;
+        };
+        let timeline_kind = tl_state.kind.clone();
+        if retry {
+            let Some(transaction_id) = event.transaction_id().map(|id| id.to_owned()) else {
+                log!("BUG: retry requested for an item with no transaction id.");
+                return;
+            };
+            submit_async_request(MatrixRequest::RetrySend { timeline_kind, transaction_id });
+        } else {
+            submit_async_request(MatrixRequest::RedactMessage {
+                timeline_kind,
+                timeline_event_id: event.identifier(),
+                reason: None,
+            });
+        }
+    }
+
     fn toggle_bot_body_expanded(&mut self, cx: &mut Cx, tl_idx: usize) {
         let Some(tl_state) = self.tl_state.as_mut() else { return };
         let Some(event_id) = tl_state
@@ -13203,6 +13419,7 @@ fn populate_message_view(
             show_copy_button,
         );
         item.as_message().set_band_metadata(cx, band_metadata);
+        populate_send_state(cx, &item, event_tl_item);
 
         let has_action_payload = event_raw_json_contains_any(
             event_tl_item,
@@ -13452,6 +13669,62 @@ fn populate_bot_badge_identity(cx: &mut Cx, item: &WidgetRef, sender_localpart: 
         script_apply_eval!(cx, label, {
             draw_text +: { color: (mod.widgets.RBX_NEUTRAL_FG) }
         });
+    }
+}
+
+/// Renders a message's delivery state: a pill in the meta band, plus the reason
+/// and the two recovery actions when the send is parked for good.
+///
+/// Every widget is written on every call, never only on the branch that needs
+/// it. These item widgets are recycled by the PortalList, so a pill left visible
+/// would reappear under an unrelated message.
+fn populate_send_state(cx: &mut Cx, item: &WidgetRef, event_tl_item: &EventTimelineItem) {
+    let state = MessageDeliveryState::from_item(event_tl_item);
+
+    let pill = item.view(cx, ids!(content.message_action_bar.send_state_pill));
+    let failure = item.view(cx, ids!(content.send_failure_section));
+
+    let (pill_text, pill_bg, pill_fg) = match &state {
+        Some(MessageDeliveryState::Sending) => (
+            "Sending",
+            crate::shared::design_tokens::RBX_NEUTRAL_BG,
+            crate::shared::design_tokens::RBX_NEUTRAL_FG,
+        ),
+        Some(MessageDeliveryState::FailedRetrying) => (
+            "Waiting to retry",
+            crate::shared::design_tokens::RBX_WARNING_BG,
+            crate::shared::design_tokens::RBX_WARNING_FG,
+        ),
+        Some(MessageDeliveryState::FailedWedged { .. }) => (
+            "Not sent",
+            crate::shared::design_tokens::RBX_DANGER_BG,
+            crate::shared::design_tokens::RBX_DANGER_FG,
+        ),
+        None => ("", crate::shared::design_tokens::RBX_NEUTRAL_BG, crate::shared::design_tokens::RBX_NEUTRAL_FG),
+    };
+
+    pill.set_visible(cx, state.is_some());
+    if state.is_some() {
+        item.label(cx, ids!(content.message_action_bar.send_state_pill.send_state_label))
+            .set_text(cx, pill_text);
+        let mut pill_view = pill;
+        script_apply_eval!(cx, pill_view, {
+            draw_bg +: { color: #(pill_bg) }
+        });
+        let mut pill_label =
+            item.label(cx, ids!(content.message_action_bar.send_state_pill.send_state_label));
+        script_apply_eval!(cx, pill_label, {
+            draw_text +: { color: #(pill_fg) }
+        });
+    }
+
+    match &state {
+        Some(MessageDeliveryState::FailedWedged { reason }) => {
+            failure.set_visible(cx, true);
+            item.label(cx, ids!(content.send_failure_section.send_failure_reason))
+                .set_text(cx, reason);
+        }
+        _ => failure.set_visible(cx, false),
     }
 }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -36,7 +36,7 @@ use matrix_sdk_ui::{
     RoomListService, Timeline, encryption_sync_service, room_list_service::{RoomListItem, RoomListLoadingState, SyncIndicator, filters}, sync_service::{self, SyncService}, timeline::{LatestEventValue, RoomExt, TimelineEventItemId, TimelineFocus, TimelineItem, TimelineReadReceiptTracking, TimelineDetails, default_event_filter}
 };
 use robius_open::Uri;
-use ruma::{OwnedRoomOrAliasId, RoomId, events::tag::Tags};
+use ruma::{OwnedRoomOrAliasId, OwnedTransactionId, RoomId, events::tag::Tags};
 use tokio::{
     runtime::Handle,
     sync::{broadcast, mpsc::{Sender, UnboundedReceiver, UnboundedSender}, oneshot, watch, Notify}, task::JoinHandle, time::error::Elapsed,
@@ -1614,6 +1614,14 @@ pub enum MatrixRequest {
         timeline_kind: TimelineKind,
         timeline_event_id: TimelineEventItemId,
         reason: Option<String>,
+    },
+    /// Retry a message whose send failed and was parked.
+    ///
+    /// Carries the transaction id rather than a `SendHandle`, because the handle
+    /// is not available on the UI thread — the worker looks the item back up.
+    RetrySend {
+        timeline_kind: TimelineKind,
+        transaction_id: OwnedTransactionId,
     },
     /// Pin or unpin the given event in the given room.
     #[doc(alias("unpin"))]
@@ -5643,6 +5651,47 @@ async fn matrix_worker_task(
                     }
                 });
             },
+
+            MatrixRequest::RetrySend { timeline_kind, transaction_id } => {
+                let Some(timeline) = get_timeline(&timeline_kind) else {
+                    log!("BUG: {timeline_kind} not found for retry send request");
+                    continue;
+                };
+
+                let _retry_task = Handle::current().spawn(async move {
+                    // Waking the queue is not enough on its own: the send loop
+                    // re-reads the room's `locally_enabled` flag, which the
+                    // failure switched off, and parks again. Turn it back on
+                    // first, then unwedge this specific message.
+                    timeline.room().client().send_queue().set_enabled(true).await;
+
+                    // `Timeline` has no lookup by transaction id, so find the
+                    // item and take its handle. The list is short and this only
+                    // runs on an explicit click.
+                    let handle = timeline.items().await.iter().find_map(|item| {
+                        let event = item.as_event()?;
+                        (event.transaction_id() == Some(&transaction_id))
+                            .then(|| event.local_echo_send_handle())
+                            .flatten()
+                    });
+                    let Some(handle) = handle else {
+                        log!("Could not find a local echo to retry in {timeline_kind}; \
+                              the send queue was re-enabled anyway.");
+                        return;
+                    };
+                    match handle.unwedge().await {
+                        Ok(()) => log!("Retrying a failed send in {timeline_kind}."),
+                        Err(e) => {
+                            error!("Failed to retry a send in {timeline_kind}; error: {e:?}");
+                            enqueue_popup_notification(
+                                format!("Could not retry sending the message. Error: {e}"),
+                                PopupKind::Error,
+                                None,
+                            );
+                        }
+                    }
+                });
+            }
 
             MatrixRequest::RedactMessage { timeline_kind, timeline_event_id, reason } => {
                 let Some(timeline) = get_timeline(&timeline_kind) else {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6490,6 +6490,30 @@ pub fn set_sync_service_desired_running(running: bool, reason: &'static str) {
     rt_handle.spawn(apply_sync_service_desired_state(reason));
 }
 
+/// Re-enables the client's send queue.
+///
+/// The SDK disables a room's send queue after *any* send error — recoverable or
+/// not (`send_queue/mod.rs`: "Disable the queue for this room after any kind of
+/// error happened") — and never re-enables it on its own: there is no
+/// `locally_enabled.store(true)` anywhere in the SDK. The only way back is this
+/// call, so without it a single failed send leaves that room's queue asleep for
+/// the rest of the process. Messages then pile up as local echoes that are never
+/// sent, and the timeline draws them exactly like delivered ones.
+///
+/// `SendQueue::set_enabled(true)` is client-wide: it flips the global flag, wakes
+/// every room the client already knows about, and respawns tasks for rooms that
+/// still hold unsent requests — including ones queued in a previous session.
+///
+/// Called whenever sync (re)starts, which is the app's own signal that it
+/// believes it can talk to the homeserver again.
+async fn reenable_send_queue(reason: &'static str) {
+    let Some(client) = get_client() else { return };
+    if !client.send_queue().is_enabled() {
+        log!("Re-enabling the send queue after it was disabled by a send error ({reason}).");
+    }
+    client.send_queue().set_enabled(true).await;
+}
+
 async fn apply_sync_service_desired_state(reason: &'static str) {
     let _guard = SYNC_SERVICE_LIFECYCLE_LOCK.lock().await;
     loop {
@@ -6506,6 +6530,9 @@ async fn apply_sync_service_desired_state(reason: &'static str) {
         if desired {
             log!("Starting Matrix sync service after lifecycle request ({reason}).");
             sync_service.start().await;
+            // Coming back online is exactly when a queue disabled by an earlier
+            // failure should get another chance.
+            reenable_send_queue(reason).await;
         } else {
             log!("Stopping Matrix sync service after lifecycle request ({reason}).");
             sync_service.stop().await;
@@ -8195,7 +8222,17 @@ fn handle_sync_service_state_subscriber(mut subscriber: Subscriber<sync_service:
                     log!("Ignoring sync service state update after token expiration.");
                     break;
                 }
-                other => Cx::post_action(RoomsListHeaderAction::StateUpdate(other)),
+                other => {
+                    // Reaching `Running` means the client believes it can talk to
+                    // the homeserver again — the moment to revive a send queue an
+                    // earlier failure switched off. The error branch above already
+                    // covers restarts we drive ourselves; this covers the SDK
+                    // recovering on its own.
+                    if matches!(other, sync_service::State::Running) {
+                        reenable_send_queue("sync service running").await;
+                    }
+                    Cx::post_action(RoomsListHeaderAction::StateUpdate(other))
+                }
             }
         }
     });


### PR DESCRIPTION
> **Stacked on #283** — base is `feat/message-send-state`, so this diff shows only the UI. GitHub retargets it to `main` once #283 merges.

A failed send looked exactly like a delivered one: same bubble, no marker, no way to act on it. #283 restored *delivery* after a recoverable failure; this makes the failure **visible**, and gives the unrecoverable case a way out.

## The indicator

A pill in the meta band, so it costs no vertical space and sits beside the read receipts — both answer "did this land?".

| state | pill | colour |
|---|---|---|
| `NotSentYet` | Sending | neutral |
| `SendingFailed { is_recoverable: true }` | Waiting to retry | warning |
| `SendingFailed { is_recoverable: false }` | Not sent | danger |

Neutral for `Sending` is deliberate: it normally lasts a couple of hundred milliseconds, and an amber pill blinking on every message would be worse than saying nothing. Delivered messages and remote events render exactly as before.

## The recovery

A parked send also gets the reason and two actions below the body.

**Retry is two steps, not one.** `unwedge()` on its own is a dead click: the send loop re-reads the room's `locally_enabled` flag — which the failure switched off — and parks again. The worker calls `set_enabled(true)` first, *then* unwedges.

The request carries the transaction id rather than a `SendHandle`, which is not available on the UI thread; the worker finds the item and takes its handle via `local_echo_send_handle()` — the `Option` API, not `handle()`, which panics when the handle is missing (`event_item/mod.rs:537`). If the item has since gone, the queue has still been re-enabled, so the click was not wasted.

**Discard** reuses `MatrixRequest::RedactMessage`. For a local echo the SDK's `redact` aborts the queued send rather than sending a redaction, so this needed no new plumbing.

## Scope

Only sends that go through the send queue have a state at all. `Room::send_raw` (agent-chat/octos routing, `sliding_sync.rs:5175/5232/5387`) and `send_attachment` bypass it and never produce an `EventSendState`, so those messages show nothing. That is a path difference in the SDK, not a gap here — worth knowing before someone reports "agent replies never show a status".

## Notes for reviewers

- `QueueWedgeError` is matched **exhaustively**, so a new SDK variant becomes a compile error here rather than silently degrading to a generic string. The outer `matrix_sdk::Error` *is* `#[non_exhaustive]` and keeps a fallback arm.
- Both widgets are written on **every** draw, never only on the branch that needs them — these item widgets are recycled, so a pill left visible would reappear under an unrelated message. (Two bugs of exactly this shape were fixed in #281.)
- All four message templates instantiate the failure section; `CondensedMessage` and the image variants re-declare their subtree and cannot inherit it.
- The buttons spell out every text state including `color_focus`, since an unset focus colour is what turned the fold toggle white in #281.

## Testing

`cargo test --lib --features agent_chat` — 589 pass. `typos src/` clean. Ran the app and confirmed no `RBX_*` property fails to resolve in the log. Failure states were exercised by dropping the network: the pill moves Sending → Waiting to retry → Not sent, Retry delivers the message once connectivity is back, and Discard removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)