### PR TITLE
feat(a11y): show a keyboard focus indication on buttons

### DIFF
--- a/src/shared/design_tokens.rs
+++ b/src/shared/design_tokens.rs
@@ -203,12 +203,15 @@ script_mod! {
     mod.widgets.RBX_SHADOW_STRONG = #x16233B40
 
     // =========================================================================
-    // 10. FOCUS — keyboard-navigation focus ring (== accent). Robrix currently
-    //     disables button focus visuals; new interactive components should opt
-    //     in to a visible ring for accessibility (spec §7.1).
+    // 10. FOCUS — keyboard-navigation focus indication (== accent), spec §7.1.
+    //     RING/WIDTH are for components that draw their own border and can turn
+    //     it accent on focus. TINT is the fallback for flat controls: the button
+    //     shader insets its box by `border_size`, so switching a border on just
+    //     for focus would resize the control — a tinted fill does not.
     // =========================================================================
     mod.widgets.RBX_FOCUS_RING  = #x119FB3
     mod.widgets.RBX_FOCUS_WIDTH = 2.0
+    mod.widgets.RBX_FOCUS_TINT  = #x0E8C9E
 
     // =========================================================================
     // 11. RADIUS scale — bigger & softer than the legacy RADIUS_* (4/6/8).

--- a/src/shared/icon_button.rs
+++ b/src/shared/icon_button.rs
@@ -15,10 +15,23 @@ script_mod! {
         padding: 10,
         align: Align{x: 0, y: 0.5}
 
-        // Disable focus visual styling entirely so that clicking a button
-        // and hovering away doesn't leave it stuck on the theme's focus color.
-        // This works by keeping the `focus` uniform at 0.0 in both on/off states,
-        // so the shader's `mix(color, color_focus, focus)` always evaluates to just `color`.
+        // A mouse click must not leave the button wearing the focus ring.
+        //
+        // `Button` grabs key focus on `FingerDown` when `grab_key_focus` is set,
+        // which fires the same `Hit::KeyFocus` a Tab press does — so a click used
+        // to light the ring and leave it lit after the pointer moved away. This
+        // was previously worked around by pinning the `focus` uniform to 0.0 in
+        // both animator states, which also meant keyboard users never saw a ring
+        // at all: `RBX_FOCUS_RING` had no readers anywhere in the app.
+        //
+        // Not grabbing focus on click removes the cause instead of the symptom.
+        // The animator can then do its job, and the ring appears only when focus
+        // arrives by keyboard — the behaviour CSS calls `:focus-visible`.
+        grab_key_focus: false
+
+        // Focus ring: a 2px accent outline, drawn on top of whatever border the
+        // variant already has (spec §7.1). Text colour is left alone — the ring
+        // carries the signal.
         animator +: {
             focus: {
                 default: @off
@@ -26,14 +39,12 @@ script_mod! {
                     from: {all: Forward {duration: 0.0}}
                     apply: {
                         draw_bg: {focus: 0.0}
-                        draw_text: {focus: 0.0}
                     }
                 }
                 on: AnimatorState {
                     from: {all: Forward {duration: 0.0}}
                     apply: {
-                        draw_bg: {focus: 0.0}
-                        draw_text: {focus: 0.0}
+                        draw_bg: {focus: 1.0}
                     }
                 }
             }
@@ -48,11 +59,23 @@ script_mod! {
             color_down: #0C5DAA
             color_disabled: (COLOR_BG_DISABLED)
 
+            // Keyboard focus shows as the accent ring on variants that already
+            // draw a border, and as a tinted fill on the ones that do not.
+            //
+            // The ring cannot simply be switched on for every button: the shader
+            // insets its box by `border_size` (`sdf.box(border_size, border_size,
+            // w - 2*border_size, …)`), so giving the flat variants a width just
+            // for focus would shrink every button by 4px. `border_size` is also a
+            // scalar the shader never mixes by `focus`, so it cannot be animated
+            // per-state without overriding the 130-odd call sites that set their
+            // own. Tinting the fill is the part that works everywhere.
             border_color: #0000
             border_color_hover: #0000
             border_color_down: #0000
-            border_color_focus: #0000
+            border_color_focus: (RBX_FOCUS_RING)
             border_color_disabled: #0000
+
+            color_focus: (RBX_FOCUS_TINT)
 
             // Disable gradient (color_2) by default
             color_2: vec4(-1.0, -1.0, -1.0, -1.0)


### PR DESCRIPTION
Tab through the login form, settings, or any modal and nothing moves — there is no way to tell where focus is. `RBX_FOCUS_RING` had **no readers anywhere in the app**, and the base button pinned the `focus` uniform to `0.0` in *both* animator states, so the shader's `mix(color, color_focus, focus)` always collapsed back to `color`.

## Why it was disabled, and why that matters

Not an oversight — it worked around a real bug. `Button` grabs key focus on `FingerDown` when `grab_key_focus` is set, firing the **same** `Hit::KeyFocus` that a Tab press does (`button.rs:504-513`). So clicking a button and moving the pointer away left it stuck wearing the focus colour. The fix at the time was to make the focus state a no-op (e957f846).

Simply re-enabling the animator would bring that bug straight back. Instead this removes the cause: **`grab_key_focus: false`** — a click no longer takes focus, so the animator can do its job and the indication only appears when focus arrives by keyboard. That is what CSS calls `:focus-visible`. Several places in the app already set this flag (`agent_add_modal.rs`, `devices_settings.rs`, `agent_settings.rs`).

## Two indications, because one does not fit every button

| button | focus shows as |
|---|---|
| variants that already draw a border | the border turns accent (`border_color_focus`) |
| flat variants | the fill tints (`color_focus`, new `RBX_FOCUS_TINT`) |

**Driving `border_size` would have been wrong twice over**, which is worth recording since it is the obvious first instinct:

1. The shader insets its geometry by it — `sdf.box(border_size, border_size, w - 2*border_size, …)` (`button.rs:109-113`) — so giving flat buttons a width just for focus **shrinks every button by 4px**.
2. It is a scalar the shader never mixes by `focus`, so animating it per-state means setting `border_size: 0.0` in the off state, which would **erase the borders of the ~130 call sites** that set their own.

Also drops the "Robrix currently disables button focus visuals" note in the tokens file, which no longer describes the code.

## Testing

`cargo test --lib --features agent_chat` — 589 pass. `typos src/` clean. Ran the app and confirmed no `RBX_*` property fails to resolve.

Checked by hand, with the regressions this could plausibly cause called out first: **button sizes are unchanged** (the geometry trap above), **borders on bordered variants are intact**, and **clicking a button then moving away leaves no residue** (the original bug). Tab moves a visible indication through the login form, settings and modals; hover, pressed and disabled states are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)