### PR TITLE
fix(directory): resolve DirectoryGhostIconButton so its buttons render

### DIFF
--- a/src/home/directory_screen.rs
+++ b/src/home/directory_screen.rs
@@ -195,7 +195,7 @@ script_mod! {
             align: Align{y: 0.5}
             spacing: (SPACE_SM)
 
-            back_button := DirectoryGhostIconButton {
+            back_button := mod.widgets.DirectoryGhostIconButton {
                 padding: (SPACE_SM)
                 draw_icon.svg: (ICON_ARROW_BACK)
                 icon_walk: Walk{width: 18, height: 18}
@@ -276,7 +276,7 @@ script_mod! {
                 }
             }
 
-            clear_button := DirectoryGhostIconButton {
+            clear_button := mod.widgets.DirectoryGhostIconButton {
                 visible: false
                 padding: Inset{top: 7, bottom: 7, left: 7, right: 7}
                 draw_icon.svg: (ICON_CLOSE)


### PR DESCRIPTION
## Problem

`src/home/directory_screen.rs` logged six errors on **every** app startup, present since 118d18d5 (unrelated to any recent change):

```
[E] src/home/directory_screen.rs:198:54 - variable DirectoryGhostIconButton not found in scope
[E] src/home/directory_screen.rs:200:31 - field draw_icon not found in type-check and has no default
[E] src/home/directory_screen.rs:200:31 - cannot assign field svg on NotFound (not an object)
```

…repeated once for `back_button` (line 198) and once for `clear_button` (line 279).

## Cause

`DirectoryGhostIconButton` is registered at line 44 of the same `script_mod!` block that uses it, but both call sites referenced it bare.

`use mod.widgets.*` is a **snapshot** of what earlier-registered modules put in `mod.widgets` — it does not see entries the *current* block adds later. So both references resolved to `NotFound`, and the header back affordance and the search field's clear button lost their icons.

The 2nd and 3rd error in each triple are downstream noise: once the widget is `NotFound`, every property set on it fails too.

## Fix

Reference the widget as `mod.widgets.DirectoryGhostIconButton`, matching the convention used everywhere else in the codebase — `welcome_screen.rs` (`mod.widgets.HomeSectionTitle`, `mod.widgets.HomeQuickActionButton`), `main_desktop_ui.rs`, `app_settings.rs`.

Two lines changed, no logic touched.

## Verification

- `cargo build` clean.
- `cargo run` through full startup and session restore: all six error lines gone. The only remaining `[E]` is a pre-existing makepad font-resource warning (`IBMPlexSans-Text.ttf`), unrelated to this file.
- The `field draw_icon not found in type-check` error disappearing confirms `draw_icon.svg` now binds to a real field on a real widget type.

Worth an eyeball on review: open **Public rooms** from the compass in the rooms-list header, check the back arrow renders, then type in the search box and check the ✕ clear button renders.