### PR TITLE
fix(security): escape audio/video captions and mimetypes to prevent HTML injection

### DIFF
--- a/src/home/room_screen/populate.rs
+++ b/src/home/room_screen/populate.rs
@@ -1359,7 +1359,7 @@ pub(super) fn populate_audio_message_content(
                 .unwrap_or_default(),
             info.mimetype
                 .as_ref()
-                .map(|m| format!("  {m},"))
+                .map(|m| format!("  {},", htmlize::escape_text(m)))
                 .unwrap_or_default(),
             info.size
                 .map(|bytes| format!("  ({}),", ByteSize::b(bytes.into())))
@@ -1369,7 +1369,8 @@ pub(super) fn populate_audio_message_content(
     let caption = audio.formatted_caption()
         .filter(|fb| fb.format == MessageFormat::Html)
         .map(|fb| format!("<br><i>{}</i>", fb.body))
-        .or_else(|| audio.caption().map(|c| format!("<br><i>{c}</i>")))
+        // Escape caption to prevent HTML injection
+        .or_else(|| audio.caption().map(|c| format!("<br><i>{}</i>", htmlize::escape_text(c))))
         .unwrap_or_default();
 
     message_content_widget.show_html(
@@ -1417,7 +1418,7 @@ pub(super) fn populate_video_message_content(
                 .unwrap_or_default(),
             info.mimetype
                 .as_ref()
-                .map(|m| format!("  {m},"))
+                .map(|m| format!("  {},", htmlize::escape_text(m)))
                 .unwrap_or_default(),
             info.size
                 .map(|bytes| format!("  ({}),", ByteSize::b(bytes.into())))
@@ -1430,7 +1431,8 @@ pub(super) fn populate_video_message_content(
     let caption = video.formatted_caption()
         .filter(|fb| fb.format == MessageFormat::Html)
         .map(|fb| format!("<br><i>{}</i>", fb.body))
-        .or_else(|| video.caption().map(|c| format!("<br><i>{c}</i>")))
+        // Escape caption to prevent HTML injection
+        .or_else(|| video.caption().map(|c| format!("<br><i>{}</i>", htmlize::escape_text(c))))
         .unwrap_or_default();
 
     // TODO: add an video to play the video file


### PR DESCRIPTION
## Summary

Ports two upstream robrix Sentinel **HIGH** security fixes (`795b6fa7`, `2cdba6d1`) that robrix2 only partially had.

File-message captions were already escaped (`populate_file_message_content`), but four spots in `src/home/room_screen/populate.rs` interpolated untrusted event content into HTML rendered via `show_html()` without escaping:

- audio caption plain-text fallback (`populate_audio_message_content`)
- video caption plain-text fallback (`populate_video_message_content`)
- `info.mimetype` for audio messages
- `info.mimetype` for video messages

A malicious room member could inject arbitrary HTML into other users' clients via an audio/video message caption or crafted mimetype. Fix wraps each in `htmlize::escape_text()`, matching the existing file-message treatment.

Intentionally-HTML formatted captions (`MessageFormat::Html` branch) are left as-is, same as upstream.

## Testing

- `cargo check` passes.
- ⏳ **Awaiting user manual testing before merge**: send an audio/video message with caption `<b>bold</b><script>alert(1)</script>` and confirm it renders as literal text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)