### PR TITLE
feat: agent-chat thread-session support — /thread popup, Agent Ops panel, operations docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,18 @@ For users who want to connect [Hermes Agent](https://github.com/NousResearch/Her
 
 ---
 
+## Robrix + agent-chat (HAgency)
+
+For maintainers and developers testing local coding agents, owner-scoped approvals, Matrix Threads, and multi-agent workflows:
+
+| Guide | Goal |
+|-------|------|
+| [Robrix × agent-chat demo guide](robrix-with-agentchat/README.md) | Reproduce the original local software-factory demo and inspect its artifacts. |
+| [Current known issues and roadmap](robrix-with-agentchat/current-known-issues-and-roadmap.md) | Track release blockers, productization gaps, completed fixes, and the recommended PR order. |
+| [Historical Agent Operations model experiment](robrix-with-agentchat/agent-ops-client-contract-v1-proposal.md) | Review the non-canonical R3 design experiment; it is test-only and does not define agent-chat's V1 wire contract. |
+
+---
+
 ## Palpo and Octos Deployment Files
 
 The [`palpo-and-octos-deploy/`](../palpo-and-octos-deploy/) directory (at the repository root) holds the runnable lightweight-mode deployment — see its [README](../palpo-and-octos-deploy/README.md) for the 3-step Quickstart.

--- a/docs/agent-system-planes.md
+++ b/docs/agent-system-planes.md
@@ -1,0 +1,165 @@
+# The three planes of the agent system
+
+Written because the distinction is easy to lose, and losing it produces real
+design errors. The first draft of `specs/task-agent-ops-panel.spec.md` put
+approval buttons and worktree paths into a Matrix client screen; that was
+caught by agent-chat's privacy requirement, not by good judgement. This
+document exists so the next person does not have to rediscover the boundary the
+same way.
+
+Anyone about to extend the Agent Operations Panel, or to build a "see all the
+agents" view, should read this first.
+
+## Plane 1 — Matrix: the shared collaboration surface
+
+agent-chat bridges each operator's local agents into Matrix as puppet accounts
+(`@ac_<name>:…`). A room therefore contains agents belonging to several
+different operators, alongside the humans.
+
+**Robrix2 already renders this plane.** The room list, the member list, the
+threads, the messages — that *is* the cross-operator view of who is present and
+what is being discussed. It needs no additional panel, and it is governed by
+Matrix's own access model: you see what the rooms you are in contain.
+
+What lives here: conversation, task threads, agent presence, approval requests
+addressed to their owner.
+
+## Plane 2 — Router: one backend's private control plane
+
+Each agent-chat backend owns the execution state of *its own* agents: topic
+sessions, the dispatch ledger, workspace and resource leases, worktrees, task
+bindings. See `agent-chat/docs/router-layer-design.md`.
+
+This plane is inherently single-operator and privileged. It knows local
+filesystem layout, which worktree holds uncommitted work, which dispatch ended
+in `outcome_unknown` on this machine. One backend has no view of another
+operator's backend, and should not.
+
+What lives here: everything about *how* work executed, on *this* host.
+
+## Plane 3 — Operations panel: a window onto plane 2
+
+The Agent Operations Panel is an operator console for **one** backend. It is
+not a fleet view and not a management surface for other people's agents.
+
+If the canonical contract is released and the client runtime is built, its
+authority must come from a scoped client session issued per client: separate
+credentials, proof of possession, replay protection, an explicit
+owner/DM/project/agent scope, and immediate revocation. The panel must read a
+backend-generated projection; it must never derive execution state itself,
+and the projection must be filtered before it leaves the backend — no absolute
+paths, no approval content, nothing outside the granted scope.
+
+Today Robrix2 establishes no such session, has no Agent Operations transport,
+and renders only the fail-closed contract status screen. The development
+manifest is a gate input, not evidence that authentication or runtime wiring is
+available.
+
+## Why plane 2 cannot simply be widened into a global view
+
+The two planes have **opposite** disclosure properties:
+
+| | Plane 1 (Matrix) | Plane 2 (Router) |
+| --- | --- | --- |
+| Audience | every member of the room | the operator of that one backend |
+| Content | conversation and task threads | local execution internals |
+| Access model | Matrix room membership | future scoped client session, per backend |
+| Failure of confinement | a message reaches the wrong room | one machine's internals reach everyone |
+
+Publishing plane 2 onto plane 1 as-is would expose each operator's local
+execution state — paths, dirty workspaces, failure details — to every member of
+a shared room. That is why any future router access requires a scoped client
+session rather than something a Matrix client gains merely by being logged in.
+
+## If a cross-operator fleet view is wanted, it is a fourth thing
+
+"See every agent that everyone has connected" is a legitimate goal, but it is
+not this panel with a wider scope. It inverts the direction of data flow:
+
+- **The panel pulls**: a client authenticates to one backend and reads that
+  backend's private projection.
+- **A fleet view would push**: each backend publishes a deliberately public,
+  privacy-filtered summary into Matrix — as state events in a shared room —
+  and any client aggregates what it can already see.
+
+The push design is the better fit for the goal, for three reasons. Each
+operator decides what leaves their machine, because publishing is an explicit
+act rather than a permission granted to a reader. Matrix's existing access
+model does the authorization, so no cross-operator client credential has to be
+invented. And it degrades correctly: an operator who publishes nothing is
+simply absent from the view rather than a hole in someone's permission model.
+
+Nothing in the current design implements this. It would need its own event
+schema, its own decision record, and its own answer to "what is safe to publish
+about a machine you do not control".
+
+## Consuming agent-chat's client contract
+
+agent-chat has supplied a development manifest for the canonical client
+contract. Robrix2 vendors that manifest under
+`specs/fixtures/agent-ops-client-v1/manifest.json`. Local, non-canonical design
+fixtures live separately under
+`specs/fixtures/agent-ops-client-v1-proposal/`; they can never satisfy the
+runtime gate.
+
+The manifest currently reads:
+
+```json
+{ "release_status": "development", "source_commit": null }
+```
+
+That development status is deliberate, but it does not prove that a consumable
+contract or runtime exists. **Robrix2 must stay fail-closed against exactly
+this condition** — a manifest whose `release_status` is not a released value,
+or whose `source_commit` is null, describes a moving target. Consuming it would
+mean building a client against artifacts that can change underneath it, which
+is how a client and a server silently drift apart.
+
+The order is therefore: agent-chat releases the complete canonical set and
+binds it to a real commit → Robrix2 vendors the manifest and every artifact →
+the build verifies their exact paths and bytes → the contract becomes ready →
+the client runtime is built and validated. Not before.
+
+### How the gate enforces this
+
+Robrix2 vendors agent-chat's manifest at
+`specs/fixtures/agent-ops-client-v1/manifest.json` and **compiles it in**
+(`include_str!`). The gate in `src/agent_ops/state.rs` judges that embedded
+copy together with the artifact bytes compiled into the same build. It reports
+the contract ready only when all of these are true:
+
+- the manifest names this contract and is marked `released`;
+- `source_commit` is a complete 40- or 64-character Git object ID;
+- the manifest contains the complete V1 artifact set with safe, unique paths
+  and valid SHA-256 values;
+- the compiled artifact set exactly matches the manifest and every byte digest
+  matches.
+
+Anything else is a distinct, named closed state with a localized explanation
+shown in the panel.
+
+Embedding rather than reading at runtime means the gate's answer is a fact
+pinned by Robrix2's own commit: no filesystem lookup, no environment
+dependence, and no network call (the panel is forbidden any transport, and
+tests enforce that).
+
+**To make the contract ready** once agent-chat has released and committed: copy
+the released `manifest.json` and every listed canonical artifact, then register
+each file with `include_bytes!` in `src/agent_ops/state.rs`. The reviewed diff
+therefore contains both the producer binding and the exact consumer bytes.
+Changing only `release_status`, a hash string, or a local flag cannot open the
+gate.
+
+Contract readiness is deliberately not called “connected”: it proves only that
+Robrix2 has pinned the protocol material. Authentication, transport, snapshot
+loading, mutations, and the four operational views are still separate runtime
+work and must pass a real canary before the UI can claim connectivity.
+
+## References
+
+- `specs/task-agent-ops-panel.spec.md` — this repository's panel contract
+- `agent-chat/docs/AGENT-OPS-CLIENT.md` — the client contract
+- `agent-chat/knowledge/decisions/adr-012-scoped-agent-ops-client-access.md`
+- `agent-chat/knowledge/requirements/req-agent-ops-client-access.md`
+- `agent-chat/docs/router-layer-design.md` — plane 2's internals
+- `agent-chat/knowledge/decisions/adr-011-backend-owned-ephemeral-runner-sessions.md`

--- a/docs/robrix-with-agentchat/README.md
+++ b/docs/robrix-with-agentchat/README.md
@@ -6,6 +6,10 @@
 >
 > 本文档从**环境搭建**到**使用方法**,用我们真实跑通的案例(让 agent 把一个 hello
 > 种子做成一个最小 Makepad 2.0 计数器 app)作为示例,配实测截图。
+>
+> **注意：** 本文记录的是早期 demo 搭建路径，部分“零代码改动”和宽松 audit 配置
+> 已不再代表当前生产安全基线。当前能力、发布缺陷与安全门以
+> [当前已知问题与后续路线](current-known-issues-and-roadmap.md)为准。
 
 ---
 
@@ -23,7 +27,9 @@
 10. [附录:文件清单 / 命令速查](#10-附录文件清单--命令速查)
 
 后续产品化需求见：[软件工厂需求文档](software-factory-requirements.md)。
-中午验收切片见：[软件工厂 MVP 文档](software-factory-mvp.md)。
+中期验收切片见：[软件工厂 MVP 文档](software-factory-mvp.md)。
+截至 2026-07-24 的发布缺陷、产品化缺口与后续 PR 顺序见：
+[当前已知问题与后续路线](current-known-issues-and-roadmap.md)。
 
 ---
 

--- a/docs/robrix-with-agentchat/agent-ops-client-contract-v1-proposal.md
+++ b/docs/robrix-with-agentchat/agent-ops-client-contract-v1-proposal.md
@@ -1,0 +1,284 @@
+# Robrix2 Agent Operations 展示模型实验 R3（非 V1 合同）
+
+状态：**Historical Design Experiment / 非 canonical / 不可用于生产接线**  
+实验 schema：`io.robrix.agent_ops.proposal.r3`  
+日期：2026-08-05
+
+agent-chat 拥有 canonical 合同命名空间 `io.agentchat.agent_ops.v1`。本文档只保留
+Robrix2 早期展示与安全设计思考，不得定义、覆盖或伪装成该 canonical wire
+contract。对应 Rust 类型只在 `cfg(test)` 下编译。
+
+## 文档语义
+
+| 类别 | 含义 |
+|---|---|
+| Current Fact | 两个仓库中已能核实的当前事实，不因本提案而改变 |
+| Current Gate Requirement | Robrix2 当前必须执行的安全门控，已经落地并可测试 |
+| Proposed Future Contract | 未来跨仓库协议草案；只有进入 agent-chat Accepted ADR/REQ、canonical artifacts 和实现后才有约束力 |
+
+除明确标为 Current Fact 或 Current Gate Requirement 的内容外，第 3–8 节中的“必须/不得”
+都表示 **Proposed Future Contract**，不能被解释为 agent-chat 已支持这些字段或端点。
+
+## 1. Current Fact：为什么不能直接接 Dashboard router
+
+agent-chat 当前接受的线程会话需求与 ADR 规定：V1 router 读端点留在本地 Dashboard 的
+认证边界内；Robrix2 若要访问，必须先有单独获批的客户端认证合同。当前
+`/api/router/*` 使用 backend-wide `API_TOKEN`，把它交给桌面客户端等于交出 operator
+权限。
+
+当前两个仓库还存在实际线格式和状态机差异：
+
+- Robrix2 proposal 使用 `schema + scope/projection/stream + seq +
+  attention/tasks/queue/worktrees` 的 UI 投影；
+- agent-chat Dashboard 当前返回 `schemaVersion + lowWatermark/highWatermark +
+  sessions/tasks/dispatches/resources/attention`；
+- 当前 Dashboard event endpoint 返回带 watermarks、gap 与 events 数组的 EventPage；旧原型
+  曾使用不同的失效 envelope。当前 proposal fixture 使用 `schema + projection/epoch + seq`，
+  两者都不是已接受的客户端合同；
+- 清理 dirty 的真实对象是 `resource_id`，不是 session/worktree 标识；
+- `outcome_unknown` 不能靠再次 cancel 解决，而要进入结果检查与显式消歧流程。
+
+## 2. Current Gate Requirement：Robrix2 保持 fail closed
+
+在 agent-chat 的 canonical 合同被发布、绑定并由 Robrix2 校验前，Agent Operations 面板：
+
+- 只显示“合同未就绪”，不展示真实 operational rows；
+- 不发网络请求、不轮询、不注册 command transport；
+- 不采集、保存或迁移 Dashboard token、router bearer、bridge secret 或其他后台凭据；
+- 不提供 mutation、approve 或 deny 按钮；
+- proposal model 和 fixtures 只在 `cfg(test)` 下编译，不导出为生产 API，
+  也不被运行时 panel 引用。
+
+## 3. 拟议的安全、认证与传输边界
+
+### 3.1 权威、部署与数据面
+
+1. Robrix2 是展示与请求客户端，不是 session、task、dispatch、lease 或审批的授权源。
+2. 审批仍只在既有 owner-DM 审批链中完成。Agent Operations 不构造 approve/deny；最多
+   提供跳转入口。
+3. V1 operational client 仅支持 Robrix2 与 agent-chat **同机桌面部署**。远程桌面和移动端
+   数据面不在 V1 范围内，必须另定传输合同。
+4. Matrix 作为认证控制面，只承载 bootstrap、低体积失效/撤销通知和 audit correlation；
+   snapshot、inspection 和 command 走 scoped loopback HTTP 数据面。
+5. loopback 只允许明确的 `127.0.0.1` 或 `[::1]` endpoint，禁止重定向，并冻结 Host、
+   Origin/CORS、audience 与服务端身份校验规则。含 capability 的响应必须
+   `Cache-Control: no-store`，不得进入访问日志、telemetry、代理缓存或崩溃报告。
+6. 任何失败都不能降级到 Dashboard `API_TOKEN`、未加密 Matrix 消息、公共房间或在 DM
+   timeline 中永久保存数据面 capability。
+
+### 3.2 精确授权 scope
+
+一个 session capability 只授权一个 scope：
+
+```text
+scope = owner_mxid + owner_dm_room_id + project_room_id + stable_agent_id
+```
+
+snapshot 顶层必须携带相同的 `scope_id` 和展开后的 scope。全局面板只能在客户端安全拼接
+多个独立 scope 的快照，不能把一个 scope 的 capability 用于另一个 scope。若未来需要后台
+聚合，必须另设带显式成员列表的 aggregate scope，不能隐式扩大权限。
+
+“DM”不是安全谓词。正式 ADR 必须冻结：owner MXID 权威来源、exact room ID、允许成员集合、
+完整 `event.sender` 比较、设备 ID/key、cross-sign verification、`was_encrypted` 与 crypto
+verification state。当前 bridge ingestion 没有提供完整设备/加密证明，因此这是 agent-chat
+的前置实现变更。成员变化、关闭加密、binding 重配、设备 blocked/deleted/unverified、logout、
+project/agent 删除或 backend key rotation 时都必须提升 client-auth revocation epoch 并拒绝旧请求。
+
+### 3.3 Bootstrap 与 proof-of-possession
+
+正式 ADR 必须把 bootstrap 写成可测试 wire protocol，而不只是流程叙述：
+
+1. Robrix2 在绑定的 encrypted owner DM 发送专用 control event（建议
+   `io.agentchat.agent_ops.client_session.request.v1`），包含合同版本、请求 scope、
+   `client_nonce`、一次性 ephemeral public key 和客户端支持的 PoP profile；不能复用普通
+   chat message ingestion。
+2. agent-chat 在验证 sender/room/scope/device/E2EE 后签发 server-owned
+   `client_session_id`，不得信任客户端自报 session id。响应 grant 绑定 owner、room、
+   project、agent、Matrix device、client key、audience、scope、expiry、唯一 jti、
+   server challenge 与 client-auth revocation epoch。
+3. grant 同时提供精确 loopback exchange endpoint 和可验证的服务端 key/certificate
+   fingerprint。敏感 grant payload 必须使用经安全评审的标准 profile 密封给 ephemeral key；
+   不得自创加密格式。
+4. exchange 请求必须以 ephemeral private key 对 `grant_jti + client_nonce + server_challenge +
+   HTTP method/path + canonical body digest + audience` 做 sender-constrained/DPoP 类证明。
+   仅持有 bearer grant、能读取 DM 或能抢占本地端口都不足以兑换。
+5. grant 原子消费一次。换得的短期 session capability 只驻留内存；每次后续 HTTP 请求都
+   携带新 nonce 的 sender-constrained proof。服务端在每次请求中重查 scope、expiry 和
+   client-auth revocation epoch，而不是把 Matrix revoke 通知当作授权判断。
+
+具体算法、canonicalization、key confirmation、nonce/replay cache、时钟偏差、endpoint
+discovery 和 key rotation 必须经 threat model 与安全评审后进入 Accepted ADR；本提案不选择
+自定义密码算法。
+
+### 3.4 重放、幂等与撤销
+
+- 每个 mutation 携带全局唯一 `request_id`。agent-chat 对**解析后的规范字段**计算 semantic
+  digest，不依赖 JSON 字段顺序；同 id 同 digest 返回原结果，同 id 不同 digest 返回
+  `idempotency_conflict`。
+- backend-issued opaque action capability 绑定 scope、projection、stream epoch、client
+  session、auth fence、action kind、target entity/version、resource generation、allowed
+  resolutions、expiry 和 jti。它不必是自包含签名 token，也可由后台散列存储，但验证语义相同。
+- capability 验证、实体 CAS、业务 mutation、idempotency result 写入和 capability 消费必须
+  在同一事务中提交。result retention 必须长于重试窗口，以覆盖“已提交但响应丢失”。
+- Matrix `event_id` 持久去重；撤销状态由服务端持久 fence 强制执行，不能只依赖客户端删 token。
+
+## 4. 拟议的只读投影与失效流
+
+每份 snapshot 只对应一个授权 scope，并至少包含：
+
+- `schema: "io.robrix.agent_ops.proposal.r3"`；
+- `scope` 与 `scope_id`；
+- `projection_id`：稳定标识该 projection；
+- `stream_epoch`：持久 UUID，数据库恢复/替换或无法保证序列连续时必须更换；
+- `auth_fence_generation`：客户端认证撤销代次，区别于现有 dispatch/runner fence；
+- `seq`：仅在同 `scope_id + projection_id + stream_epoch + auth_fence_generation` 内单调递增；
+- `attention/tasks/queue/worktrees` 和 backend-issued `available_actions`。
+
+`seq`、version、generation 与 Unix 时间戳在线上均为 JSON safe integer
+（`0..=2^53-1`）；`expires_at_unix_ms` 明确使用 Unix epoch 毫秒。scope、epoch 或 fence
+变化时 Robrix2 清空全部可操作数据并重新 bootstrap，不能把低序号猜成回滚。
+
+投影字段语义：
+
+- `attention` 只含后台明确标记需要人处理的条目；
+- `tasks` 携带标题、stable agent id、后台状态、运行时间和完整 Matrix thread reference；
+- `queue` 是后台生成的阻塞链，不允许客户端从 lease/event 自行推导；
+- `worktrees` 使用 `resource_id`、entity version、`dirty_generation`、安全 label 与 branch，
+  不含真实路径；
+- 每个 `available_action` 使用统一 `target { entity_kind, entity_id, entity_version }`、可选
+  `resource_precondition { resource_id, dirty_generation }`、expiry 和 opaque capability；
+- `resolve_outcome` 还必须显式携带 `allowed_resolutions`。客户端只显示该集合，不从 task
+  状态猜测；non-task dispatch 只能收到 `continue`。
+
+Matrix event 只发失效通知，携带同一 scope/projection/epoch/fence 和新 `seq`。Robrix2 收到
+更高序列后重新请求完整 snapshot，不在本地合并 router 状态。schema、scope、epoch、fence、
+序列或解析任一不匹配时停止展示可操作数据并重新同步。
+
+`snapshot_seq` 只是视图基线，不是 mutation 授权。dispatch/resource/task 或 action-relevant
+aggregate 必须有持久 entity version；任何影响展示字段、动作资格或 CAS 的事务都必须 bump。
+资源 dirty 状态变化必须 bump `dirty_generation`。当前 agent-chat 没有完整的 entity-version
+投影，这是 Accepted 前的后台实现工作。
+
+## 5. 拟议的隐私合同
+
+### 5.1 后台规范性过滤
+
+agent-chat 必须在数据离开后台前，从所有可展示字符串和结构化字段删除：绝对路径、
+home-relative 路径、worktree 实际目录、bearer/secret、环境变量值、命令输出凭据、审批正文、
+可用于构造审批副作用的字段，以及其他 owner scope 的任务/资源/房间信息。
+
+### 5.2 客户端纵深防御
+
+Robrix2 对完整 projection 做路径启发式检查；失败时拒绝整份 projection。该检查不能可靠识别
+所有编码、Unicode 绕过或 secret，因此不替代后台过滤，也不声称是通用 secret detector。
+
+## 6. 拟议的命令 envelope 与事务语义
+
+每个后台 mutation 使用同一公共 envelope：
+
+```text
+schema
+request_id
+client_session_id                 # backend 签发
+scope_id
+projection_id
+stream_epoch
+auth_fence_generation
+snapshot_seq
+action_capability
+target { entity_kind, entity_id, entity_version }
+resource_precondition? { resource_id, dirty_generation }
+```
+
+capability 已绑定的字段仍在请求中显式回传，便于审计和 semantic digest。服务端必须在同一事务
+比较 capability binding、请求字段和当前数据库状态，并重查 session/resource/task 级业务条件；
+任一不匹配返回稳定错误并要求刷新，不允许客户端自动改变参数重试。
+
+- `cancel_dispatch`：只在 snapshot 明确提供时请求；`outcome_unknown` 不再提供 cancel。
+- `mark_resource_inspected`：只清相同 generation 的非 quarantine dirty。若资源由
+  outcome_unknown dispatch 隔离，返回 `inspection_required`。
+- `begin_outcome_inspection`：本身是幂等 mutation，必须使用公共 envelope；响应丢失后同一
+  request 可安全取得同一结果。
+- `open_thread`：纯客户端导航，不是 mutation。
+
+删除 worktree/branch、启动或恢复 runner、approve 与 deny 不在 V1。
+
+## 7. 拟议的 `outcome_unknown` 恢复闭环
+
+1. snapshot 为 dispatch 提供 `begin_outcome_inspection` action，并绑定 dispatch version 与
+   `resource_id + dirty_generation`。
+2. 成功 response 返回 scope/projection/epoch/fence、server session id、`inspection_id`、
+   一次性 `inspection_token`、`expires_at_unix_ms`、dispatch target、`task_id`（可空）、
+   `terminal_reason`、隐私过滤后的 resource context，以及新的 `resolve_outcome` action。
+3. resolution action 显式列出 `allowed_resolutions`。task dispatch 可按后台状态授权下列集合；
+   non-task dispatch 只授权 `continue`。
+
+| resolution | 必填字段 | 后台语义 |
+|---|---|---|
+| `continue` | inspection id/token、operator note、recovery instruction | 消费 inspection，清同 generation quarantine，创建或复用经验证的 queued replacement dispatch；绝不重放原 started dispatch |
+| `accept_completed` | inspection id/token、operator note | 消费 inspection，清同 generation quarantine，将关联 task 接受为完成；non-task 不允许 |
+| `keep_blocked` | inspection id/token、operator note | 消费 inspection，清同 generation quarantine，使关联 task 保持 blocked；non-task 不允许 |
+
+4. resolution request 使用公共 envelope，并显式回传 inspection id/token、resource
+   precondition 和选择。`continue` 的 recovery instruction 必须非空；另两种携带该字段必须
+   被严格反序列化拒绝；三种 operator note 都必须非空。
+5. agent-chat 原子验证 token 未过期/未消费、所选 resolution 在 capability 的允许集合中、
+   dispatch 仍为 outcome_unknown、workspace generation 未变、同 session 无其他 active runner，
+   再提交 resolution。客户端不能只靠 dispatch version 替代这些事务内检查。
+6. 成功 response 字段冻结为 `resolution`、`task_id`、可选 `replacement_dispatch_id` 和
+   `idempotent_request_replay`。这里的 replay 只表示同 request digest 返回既存结果，绝不表示
+   重放原 started dispatch。状态仍以新 snapshot 为准。
+
+`inspection_token` 和 action capability 只驻留内存，不进日志、AppState 或 Matrix timeline。
+三个本地 resolution fixtures 是互斥案例，各自使用独立的一次性 token/capability。
+
+## 8. 拟议合同的 canonical artifacts 与发布门槛
+
+Robrix2 仓库中的 `specs/fixtures/agent-ops-client-v1-proposal/` 是
+**Non-canonical proposal fixtures**，只示例字段并做本地类型回归，不构成已接受线格式。
+`specs/fixtures/agent-ops-client-v1/` 专门保留给 agent-chat 发布的 canonical manifest
+与未来逐字节 vendored artifacts，两类材料不得混放。
+
+Accepted 合同必须由 agent-chat 发布以下 canonical artifacts：
+
+| Artifact | 最低内容 |
+|---|---|
+| `manifest.json` | 合同版本、agent-chat source commit、digest algorithm、每个 artifact 的 SHA-256 |
+| control-plane fixtures | bootstrap request、grant、exchange、session、invalidation、revoke 的正反案例 |
+| projection fixtures | snapshot、scope/epoch/fence mismatch、隐私拒绝案例 |
+| mutation fixtures | begin inspection、cancel、mark inspected、resolve 的 request/success/error |
+| security/error fixtures | expired/consumed capability、idempotent replay/conflict、wrong target/version/generation、非法 resolution |
+| machine schema | 所有 envelope、safe integer、长度限制、enum 与 stable error code 定义 |
+
+agent-chat 合入前还必须：
+
+1. 接受正式 requirement/ADR 和 threat model；
+2. 实现上述认证 bridge 证据、projection/version、命令事务闭环与稳定错误码；
+3. capability 存储/散列、key rotation、revocation、canonical digest 和 retention 通过安全评审；
+4. 测试证明无路径/secret 泄露、无第二审批入口，并提供完整 thread reference。
+
+Robrix2 接线前必须：
+
+1. 按 agent-chat canonical manifest 同步或生成模型并验证 digest；
+2. 通过既有 Matrix async worker 通道和独立 scoped data-plane worker 接线，不从 UI 线程
+   spawn 原始 tokio task；
+3. 先把 wire DTO 转换成经全部不变量验证的 trusted model；未知 action 不进入 UI；
+4. schema/scope/epoch/fence/gap/auth/privacy 任一失败时 fail closed；
+5. feature on/off、i18n、导航、端到端和安全回归全部通过。
+
+## 9. 真实开发时间
+
+当前 gate task（状态页、旧凭据清理、proposal 与测试）的预算仍是约 **3 个工程日**。它不等于
+未来完整 operational client 的工期。
+
+未来完整合同包含新的设备信任、PoP、服务端身份、撤销、projection/CAS 与 inspection 闭环，
+建议先安排 **2–3 个工程日的 Matrix device/PoP 技术 spike**，再按风险预算：
+
+- agent-chat requirement/ADR、threat model 与安全评审：4–6 工程日；
+- agent-chat bootstrap/session、projection、命令闭环与 canonical tests：9–14 工程日；
+- Robrix2 四视图、worker 接线、导航、状态与测试：5–8 工程日；
+- 跨仓库集成、安全回归与验收：4–7 工程日。
+
+总量约 **22–35 个工程日**。两端并行且首轮冻结时，真实日历周期约 **4–6 周**；单人串行或
+合同反复时应更长。合同交付周期必须从“Accepted ADR/REQ + threat model + canonical manifest
+冻结”开始计算，不能从当前 Dashboard 原型开始计算。

--- a/docs/robrix-with-agentchat/current-known-issues-and-roadmap.md
+++ b/docs/robrix-with-agentchat/current-known-issues-and-roadmap.md
@@ -1,0 +1,238 @@
+# Robrix2 × agent-chat：当前已知问题与后续路线
+
+> **状态日期：** 2026-07-24  
+> **范围：** Robrix2、agent-chat backend/Matrix bridge/runtime，以及共同组成的 coding-agent workflow。  
+> **代码基线：** Robrix2 `origin/main`（`08d92357`）；agent-chat `github/master`（`ad45f67`）；Project Board 本地预览提交 `3102a5f`。  
+> **发布口径：** 首个完整 HAgency 版本包含严格 `@agent` 唤醒、owner 专属审批、安全 onboarding、四角色 workflow 状态和带 `agent_chat` feature 的 Robrix2 产物；Room aliases、iOS、加密项目房和自然语言模型调度不默认纳入首版。
+
+## 状态总览
+
+| 分类 | 优先级 | 仓库 | 是否阻塞首版 | 当前证据 | 下一步 |
+|---|---:|---|---|---|---|
+| rich reply 可绕过严格 `@agent` | P0 | agent-chat | 是 | bridge 会从 `reply_to` 推断 Agent | strict mention PR |
+| Robrix2 本机时钟提前禁用审批 | P1 | Robrix2 | 否 | UI 用墙钟硬拦截 | approval clock PR |
+| 审批失败对 owner 静默 | P0 | agent-chat | 是 | 4xx 只写日志 | approval status PR |
+| Owner onboarding 仍依赖人工步骤 | P0 | 两侧 | 是 | 自动建房不能证明人类 owner | onboarding + invite UI |
+| 生产 trust/command ACL 默认不 fail-closed | P0 | agent-chat | 是 | trust 默认 audit；ACL 全空会允许命令 | startup preflight/doctor |
+| workflow 状态依赖 skill 自律 | P0 | agent-chat | 是 | demo 状态不进入 backend task/run | binding + durable run |
+| Project Board 未发 PR | P1 | agent-chat | 否 | 本地实现和定向测试完成 | 独立推送 PR |
+| dispatch queue/lease 不持久 | P1 | agent-chat | 否 | 进程内状态 | scheduler persistence |
+| HAgency 发行产物未显式启用 feature | P0 | Robrix2 | 是 | Cargo 默认 feature 为空 | release/CI PR |
+
+P0/P1/P2 只表示优先级；下文用四个互斥状态区分“真 bug、已实现能力的缺口、未来能力、已修复事项”。
+
+## A. 已确认的当前 bug 或验收缺口
+
+### A1. 无显式 `@agent` 的 rich reply 仍会唤醒 Agent
+
+**优先级：P0；归属：agent-chat。**
+
+普通项目房消息在没有明确 `@agent` 时不会唤醒 Agent；但用户用 Matrix rich reply 回复 Agent 消息时，
+[`inferReplyMention()`](https://github.com/ZhangHanDong/agent-chat/blob/ad45f67/bridge-matrix.js#L2362-L2404)
+会从被回复消息的 `from`、唯一 mention 或 `to` 推断 Agent，并加入 `effectiveMentions`。
+
+该逻辑只在同 group、可信 `reply_to` 且目标唯一时生效，但仍违反当前验收条件：
+
+> 公共项目房只有明确 `@` 具体 Agent 才允许其执行命令和发言。
+
+修复要求：
+
+- 默认关闭 group reply inference；兼容模式只能显式 opt-in。
+- Agent/人类 DM 不受此规则限制。
+- 覆盖顶层消息、Thread reply、rich reply 和歧义目标测试。
+
+[mention-only PR #7](https://github.com/ZhangHanDong/agent-chat/pull/7) 已修复普通顶层消息，但没有移除这一旧逻辑。
+
+### A2. Robrix2 使用本机墙钟硬性禁用审批
+
+**优先级：P1；归属：Robrix2。**
+
+Robrix2 使用本机时间与 `expires_at` 比较，并在点击时硬性拦截过期请求，见
+[`src/home/room_screen.rs`](../../src/home/room_screen.rs)。本机时钟偏快时，backend 仍认为有效的请求可能被 UI 提前拒绝。
+
+修复应使用 Matrix event/server timestamp 估算偏移，或让客户端过期只作提示并把 verdict 交给 backend 最终裁决。服务端 TTL、单次消费和完整字段校验不能放宽。
+
+## B. 已实现能力的可靠性或产品化缺口
+
+### B1. 审批终态与失败原因对 owner 不可见
+
+**优先级：P0；归属：agent-chat。**
+
+Claude 与 Codex 的成功链路已经跑通；但 verdict 被 backend 以 400/401/403/404/409/410 拒绝时，
+[`onApprovalVerdict()`](https://github.com/ZhangHanDong/agent-chat/blob/ad45f67/bridge-matrix.js#L3091-L3112)
+只记录事件和日志，不会在 owner approval room 显示 expired、sender/room/digest mismatch 或 not pending。
+
+应从 backend 持久化 approval record 构造幂等的 `com.agentchat.approval.status.v1`：
+
+- 私密 approval room 显示详细终态；公共项目房只显示脱敏终态。
+- 路由不得信任 verdict payload 自带的 agent/project/room。
+- 404 或记录缺失时不得向 payload 指定房间发送状态。
+- Robrix2 只把可信 bridge sender 的结构化事件渲染为系统状态。
+- 状态发送失败不得改变服务端 fail-closed 结果。
+
+### B2. Owner onboarding 尚未成为安全的默认产品路径
+
+**优先级：P0；归属：两侧。**
+
+权威关系是：
+
+```text
+(project room, exact agent)
+    → 邀请该 Agent 的 event.sender 完整 MXID
+    → 该 Agent 在该项目房的 owner
+```
+
+`!bindroom` 只建立 room → group 映射。由 bridge 自动建房或邀请 Agent，不能证明某个人类开发者是 owner。生产验收还要求邀请者属于 `MATRIX_TRUSTED_INVITER_MXIDS`；否则 enforce 模式拒绝加入，audit 模式即使加入也不会建立可信 owner binding。
+
+下一步：
+
+- agent-chat 提供 backend-only group 或 `--no-auto-room`。
+- Robrix2 显示准确 Agent MXID、目标房间和预期 owner，由登录的人类账号确认并发送邀请。
+- doctor 校验 `(room, agent) → owner`、Agent membership 和 approval room ready。
+- 禁止通过任意请求 payload 直接写 owner。
+
+### B3. 生产 trust 与管理命令 ACL 仍需 fail-closed 启动门
+
+**优先级：P0；归属：agent-chat。**
+
+当前 `MATRIX_TRUST_MODE` 默认是 `audit`；`MATRIX_OPERATOR_MXIDS` 与 `MATRIX_ADMIN_MXIDS` 同时为空时，命令 ACL 为兼容旧部署而允许命令。项目房和审批房虽然禁止 `!ctl`/`!agentctl`，普通 Agent DM 仍可能暴露终端控制路径。
+
+首版生产模式必须：
+
+- `MATRIX_TRUST_MODE=enforce`。
+- `MATRIX_TRUSTED_INVITER_MXIDS` 非空。
+- `MATRIX_OPERATOR_MXIDS`/`MATRIX_ADMIN_MXIDS` 按职责配置，不能同时为空。
+- startup preflight 或 doctor 在配置缺失时拒绝生产启动。
+- 保留本地开发模式时必须双重显式开启并显示醒目警告。
+
+### B4. 现有 workflow 的状态上报不可靠
+
+**优先级：P0；归属：agent-chat。**
+
+四角色 demo 可以运行，但 Robrix2 的 `/workflow-*` 只是文本补全；角色主要由 Agent 名字和 skill 约定决定；状态写入 `.agentchat-demo/state.json`，Project Board 不读取它。Agent 离线、会话中断或 relay 异常时，“主动汇报”没有系统保证。
+
+首版需要版本化 workflow binding 和持久化 run：
+
+```text
+definition/version + project/thread
+    → run/phase/role/assignee/worktree
+    → blocked/approval/review verdict
+    → durable transition
+    → Project Board + 原 Thread 状态
+```
+
+写权限必须明确：
+
+- 启动/取消由 owner/operator 的完整 MXID 授权。
+- phase transition 只接受绑定角色的 Agent token。
+- 使用合法迁移表、幂等键、版本/CAS 和 append-only audit。
+- backend 是权威状态源；Robrix2 只展示并提交经确认的操作。
+
+### B5. Project Board 本地实现完成，尚未交付
+
+**优先级：P1；归属：agent-chat。**
+
+本地 `feat/project-board` 比 `github/master` 领先提交 `3102a5f`，尚未推送同名远端分支，也没有 PR。GitHub/AtomGit、worktree、spec、本地/远程 issue、PR/CR、tasks/graphs/activity 等定向测试为 16/16，完整测试套件仍待在干净环境运行。
+
+v1 边界：
+
+- `workflow_bindings.json` 需手工准备，没有 operator ACL CRUD/UI。
+- 不读取 `.agentchat-demo/state.json`。
+- task 缺少明确 project ID，多 group Agent 可能产生重复投影。
+- 看板只读，不负责发布 issue 或创建 PR/CR。
+- spec tests 是声明映射数量，不是实际执行或覆盖率。
+
+现有提交可以先独立推送和发 PR；workflow binding 与 durable run 分开提交。
+
+### B6. Agent Pool 的 queue/lease 不持久
+
+**优先级：P1；归属：agent-chat。**
+
+`/api/pool`、`/api/dispatch`、role/capability、lease 和 provision plan 已存在，但 queue/lease 是进程内状态，backend 重启后不能可靠恢复。
+
+持久化时，owner 必须从认证主体派生，不能接受调用方自由填写或生产环境 default owner；随后再补 restart recovery 和 planning API。
+
+### B7. 完整 HAgency 发行产物尚无明确构建门
+
+**优先级：P0；归属：Robrix2 Release/CI。**
+
+Cargo `agent_chat` feature 默认关闭，见 [`Cargo.toml`](../../Cargo.toml)；当前
+[release workflow](../../.github/workflows/release.yml) 没有明确为 HAgency artifact 启用它。
+
+应新增独立 release/CI PR，构建带 `agent_chat` 的目标产物，并对实际 artifact 验证 Preferences、workflow 命令、approval card 和 Thread，而不只验证默认 feature 的开发构建。
+
+## C. 后续能力与一般 backlog
+
+以下未纳入当前首版，不应登记为现有能力回归：
+
+### C1. Robrix2 自然语言模型调度
+
+目标流程是把“medium 实现、strong Claude 复审、Codex 终审”转换为结构化计划，展示 runtime/model/project/worktree/permission，用户确认后再调用持久化 scheduler。当前尚未接入 Robrix2。
+
+单个 agent-chat backend 只能调度注册在自身实例中的 Agent，不能管理同房其他开发者的本地 Agent。
+
+### C2. 加密项目房的 Agent Thread
+
+[Thread continuity PR #9](https://github.com/ZhangHanDong/agent-chat/pull/9) 已覆盖非加密 group 房间的 thread context、Matrix relation、delivery journal、重启恢复和多 Agent 多跳。
+
+普通加密项目房的 Agent 出站尚不走 crypto client；approval DM 使用独立 E2EE 路径。旧消息缺少 delivery metadata 时降级为顶层回复属于兼容策略。
+
+### C3. Room aliases
+
+[Issue #266](https://github.com/Project-Robius-China/robrix2/issues/266) 仍 OPEN。`feat/room-aliases` 已推送但无 PR，独立 worktree 还有未提交、未贯通的 generation/reconcile 竞态修复。它不属于当前 HAgency 首版，完成接线、编译、alias gate 测试和用户验收后应独立发 PR。
+
+### C4. Robrix2 常规 backlog
+
+| 条目 | 分类/归因 | 状态与后续 |
+|---|---|---|
+| [跨 homeserver 401 storm](https://github.com/Project-Robius-China/robrix2/issues/157) | 调查中，尚未归因 | 记录准确 URL、homeserver、errcode、token 所属账号、频率和停止条件；区分客户端 token 路由与 Palpo/federation |
+| [SSO provider 硬编码](../../issues/006-sso-provider-list-is-hardcoded.md) | 已确认客户端缺口 | 动态读取 Matrix login capabilities 和真实 provider ID |
+| [typing subscription 生命周期竞态](../../issues/007-room-timeline-typing-subscription-race.md) | 已确认客户端缺口 | 对 room registry 延迟排队/重试，收紧 timeline attach/detach |
+| [idle sliding-sync 循环](https://github.com/Project-Robius-China/robrix2/issues/30) | 调查中 | 定位空闲请求来源与停止条件 |
+| [4 个 ignored bot 测试](../../issues/011-upstream-bot-test-failures.md) | 未裁决 | 分别判断测试过时或用户行为回归 |
+| [Settings dropdown 箭头](../../issues/002-settings-dropdown-arrow-visual-artifact.md) | 已确认低优先级 UI bug | 后续修复 |
+| Dock splitter/多窗格恢复 | 未来增强 | 崩坏路径已绕过；不再调用 `Dock.load_state()` |
+| 历史已离房 tab 数据清理 | 产品化清理 | 新离房行为已修；增加一次性迁移 |
+
+最近 v1.1 release 的 Android、Windows、macOS 和 Linux job 成功，iOS packaging 失败：
+[GitHub Actions run 29935273011](https://github.com/Project-Robius-China/robrix2/actions/runs/29935273011)。
+当前 run 没有足够日志证明具体根因。iOS 不属于本次首版；若未来承诺 iOS artifact，再单独完成签名、IPA/TestFlight 和真机持久化验收。
+
+## D. 已修复，不再作为当前 bug
+
+- Robrix2 邀请实时出现，无需重启。
+- 普通顶层消息无 `@agent` 不再唤醒；仅剩 A1 的 rich reply 例外。
+- Owner 专属审批、完整 `event.sender` MXID、agent/project/request/digest/TTL/单次消费校验。
+- 审批者为空或绑定歧义时 fail-closed，不回退给管理员。
+- 公共房只显示脱敏 waiting；详细请求进入 owner approval room。
+- 项目房/审批房的 `!ctl`、`!agentctl` 不能绕过审批。
+- Claude auto-mode channel；Codex PermissionRequest hook、显式 TRUST 和 TTL timeout 联动。
+- Claude/Codex 默认 coding-agent 沙箱。
+- OTK 对账、crypto store/device identity 和延迟 room key 恢复。
+- Claude 与 Codex 的加密 owner approval 成功闭环。
+- 非加密 group Thread continuity、delivery journal 和 bridge 重启恢复。
+- Dashboard `/msg/:id?view=...` capability link。
+- [Owner approval PR #8](https://github.com/ZhangHanDong/agent-chat/pull/8) 与 [Thread continuity PR #9](https://github.com/ZhangHanDong/agent-chat/pull/9) 已合并。
+
+2026-07-24 重新执行的 agent-chat 定向验证覆盖 7 个测试文件，131/131 通过；Project Board 4 个定向测试文件 16/16 通过。
+
+## 建议的 PR 顺序
+
+1. **agent-chat Project Board**：先交付现有独立提交并跑完整测试。
+2. **agent-chat strict mention**：默认关闭无显式 `@agent` 的 reply inference。
+3. **agent-chat approval status**：私密详细终态、公共脱敏终态。
+4. **agent-chat production preflight**：enforce trust、trusted inviter、operator/admin ACL。
+5. **agent-chat owner-safe onboarding**：backend-only group/no-auto-room 与 doctor。
+6. **Robrix2 owner invite UI**：完整 MXID 预览与人类确认。
+7. **Robrix2 approval clock**：消除本机墙钟硬拦截。
+8. **agent-chat versioned workflow binding**：operator ACL 和角色/能力映射。
+9. **agent-chat durable workflow run**：状态机、CAS、audit、Thread anchor。
+10. **workflow skill/status integration**：写入 backend 并自动投影到 Thread/Board。
+11. **Robrix2 HAgency release/CI**：显式启用并验收 `agent_chat` artifact。
+12. **agent-chat dispatch persistence**：认证 owner、queue/lease 和重启恢复。
+13. **Robrix2 Room aliases**：完成竞态修复后独立提交。
+14. **Robrix2 model dispatch preview**：scheduler 稳定后再接入。
+
+## 维护规则
+
+每个条目必须记录状态分类、优先级、权威来源和关闭证据。安全或恢复类问题需要 fix commit/PR、自动化测试和必要的 Palpo 在环验证；未实现的产品目标不能登记为回归 bug。Robrix2 始终只负责展示和提交操作，owner、approval、workflow 与 dispatch 权限必须由服务端基于认证身份、完整 MXID 和持久化记录判定。

--- a/docs/robrix-with-agentchat/matrix-project-space-roadmap.md
+++ b/docs/robrix-with-agentchat/matrix-project-space-roadmap.md
@@ -1,0 +1,237 @@
+# Robrix2 Matrix Project Space Roadmap
+
+> - **状态：** Proposed roadmap，尚不是 Accepted spec，也不代表交付日期承诺
+> - **日期：** 2026-08-06
+> - **Robrix2 代码基线：** `9f70cd66392ba51e81e0cfcc77770649d2fb5c9a`
+> - **产品依据：** [PRD — HAFleet as a digital-labour resource plane](prd-hafleet-pdu-v0.2.md)
+> - **范围：** Robrix2 的 Matrix Space 生命周期、Project Space 导航与项目绑定；不包含 HAFleet 的资源调度实现
+
+## 1. 路线图结论
+
+Robrix2 当前的 Matrix Space 能力是“读侧成熟，写侧残缺”：用户可以发现、浏览、搜索、加入和离开 Space，
+可以邀请成员，也可以在 Space 内新建房间；但还不能创建 Space、把已有房间加入 Space、从 Space 移除房间，
+顶层 Space 邀请也不会进入现有可见邀请列表。
+
+HAgency 的目标不是把 Space 继续当作一个只读房间目录，而是把它作为客户项目平面的稳定入口：
+
+- **Matrix Space = Project**：面向客户的项目容器和导航根。
+- **Child room = Team/Process Surface**：PRD、SE、模块 Spec、测试、Release、MO、PDT、销售、客服、HR、CFO 等协作面。
+- **Thread 或持久化任务 = Work Item**：具体问题、需求、决策或交付单元。
+- **HAFleet = Resource Plane**：提供数字员工、能力、成本、健康和派工状态，不拥有客户的项目流程。
+
+因此，Space 邀请是第一个必须修复的用户阻断点，但不是 Project Space 产品闭环。创建、挂载、移除、
+稳定层级和 `ProjectRef` 绑定都应进入同一条路线图。
+
+## 2. 已确认的当前基线
+
+| 能力 | 当前状态 | 代码证据或说明 |
+|---|---|---|
+| 已加入 Space 的发现和增量同步 | 已实现 | [`space_service_sync.rs`](../../src/space_service_sync.rs) 订阅 SDK 的 joined-space service |
+| 嵌套 Space/room 层级浏览 | 已实现 | Space Lobby、桌面侧栏和移动端 Spaces 标签已经接入 |
+| Space 内搜索和导航 | 已实现 | Lobby 搜索会保留匹配项的祖先路径 |
+| 加入子房间、离开 Space | 已实现 | 离开 Space 可级联离开其已加入的房间 |
+| 邀请成员加入当前 Space | 已实现 | [`space_lobby.rs`](../../src/home/space_lobby.rs) 可打开成员邀请入口 |
+| 在当前 Space 内新建房间 | 部分实现 | 新房间创建后调用 `attach_room_to_space()` 写入 Space 关系 |
+| 顶层 Space 邀请可见 | 缺失，P0 | 普通房间列表过滤 Space；Space service 只订阅已加入 Space |
+| 创建 Space | 缺失，P0 | 创建房间请求没有设置 `m.space` room type/creation content |
+| 把已有房间加入 Space | 缺失，P0 | 当前关系写入只出现在“新建房间后挂载”路径 |
+| 从 Space 移除房间 | 缺失，P0 | 没有撤销 `m.space.child` 关系的请求和 UI |
+| 规范子房间顺序 | 有缺陷，P1 | Lobby 丢弃 SDK 顺序，重新按“Space 优先、名称排序”排列 |
+| 侧边栏稳定顺序 | 有缺陷，P1 | 部分重建路径来自 `HashMap`，顺序可能漂移 |
+| 上次选中 Space 持久化 | 缺失，P1 | `selected_tab` 使用 `#[serde(skip)]`，启动后回到 Home |
+| Space 深链接 | 部分实现，P1 | Add/Explore 可解析；时间线内点击 Space room ID 的导航尚未贯通 |
+| Space 未读角标 | 缺失，P2 | 当前 Space 未读数量固定为 0 |
+| Space 专项 spec/自动化测试 | 缺失，P0 | 只有其他任务附带的 SpaceLobby 场景，没有完整能力合同 |
+
+这张表描述的是上述代码基线，不用于推断团队路线图意图，也不把未来目标登记成当前回归 bug。
+
+## 3. 产品与安全边界
+
+### 3.1 Space 是项目导航与绑定载体，不是权限证明
+
+`m.space.child` 和 `m.space.parent` 表达层级关系，不自动授予以下权限：
+
+- 项目成员身份或房间成员身份；
+- room power level；
+- HAFleet 派工、预算、成本或审批权限；
+- Agent Operations 的 owner-DM 权限；
+- E2EE 密钥访问权限。
+
+Robrix2 可以展示关系和提交 Matrix 操作，但最终权限由 homeserver、房间状态和对应服务端的认证主体判定。
+
+### 3.2 Project 身份不能只从名称或层级推导
+
+目标 `ProjectRef` 至少需要：
+
+- 稳定 `project_id`；
+- 可选但规范化的 `space_room_id`；
+- binding version；
+- 带类型的 child-room bindings；
+- classification、revocation 和 audit 信息。
+
+不得用 Space 名称、房间名称或当前树位置临时推断规范项目身份。共享房间、嵌套 Space、关系撤销和迁移
+都必须有明确语义。
+
+### 3.3 Matrix 写操作必须走既有异步边界
+
+未来的创建 Space、挂载和移除操作必须通过 `submit_async_request(MatrixRequest::*)` 进入 Matrix worker，
+由后台执行 SDK/API 调用并把结构化结果送回 UI。UI 不直接启动 Tokio 任务，也不把本地乐观状态当作服务端终态。
+
+## 4. 分阶段路线
+
+阶段编号表示依赖顺序，不表示自然月或合同交付期。每个阶段开始实现前，应拆成独立 task spec，继承
+[`specs/project.spec.md`](../../specs/project.spec.md)，并通过 `agent-spec parse` 与
+`agent-spec lint --min-score 0.7`。
+
+### Phase 0 — 合同、模型与测试基线（P0）
+
+**目标：** 在增加写能力前，先确定 Project Space 生命周期和安全语义。
+
+交付物：
+
+1. `task-space-invitations.spec.md`：Space 邀请发现、接受、拒绝和实时更新。
+2. `task-space-lifecycle.spec.md`：创建 Space、挂载已有房间、移除房间和失败恢复。
+3. `task-space-hierarchy-integrity.spec.md`：循环、重复边、规范排序和稳定导航。
+4. Project Space/`ProjectRef` ADR/REQ：修订或取代 room-as-project 的旧假设。
+5. 明确桌面、移动端、i18n、权限不足、网络失败、重启恢复和无障碍验收矩阵。
+
+退出条件：
+
+- Space 邀请和 Space lifecycle 的状态模型、动作结果及错误语义无歧义。
+- 明确 `m.space.child` 与 `m.space.parent` 的写入顺序、幂等策略和部分失败补偿。
+- 明确关系变化不会自动改变成员、power level、E2EE 或 HAFleet 权限。
+- 核心模型和图算法可以脱离 Makepad Widget 做单元测试。
+
+### Phase 1 — 让 Project Space 可到达（P0）
+
+**目标：** 用户收到邀请或链接后，能够在 Robrix2 中发现并进入 Project Space。
+
+范围：
+
+- 为邀请模型增加明确 room type/`is_space` 分类，不再让 Space 邀请依赖被过滤的普通房间列表。
+- 桌面和移动端统一展示 Space 邀请，支持接受、拒绝、处理中和失败状态。
+- 支持同步期间实时到达、应用重启后恢复、重复事件去重和邀请撤销。
+- 打通时间线中的 `matrix.to`/Matrix URI 到 Space Lobby 的导航。
+- 未加入 Space 的预览不得泄漏无权读取的成员或子房间信息。
+
+关键验收：
+
+- 用户无需重启即可看到新 Space 邀请。
+- 接受后邀请条目消失且 Space 只出现一次；拒绝或邀请撤销后不残留幽灵条目。
+- 无权限、网络失败和服务端拒绝都有可理解、可翻译的错误状态。
+- Add/Explore、时间线链接和邀请卡最终进入同一个 Space 导航结果。
+
+### Phase 2 — 完成 Space 生命周期（P0）
+
+**目标：** 客户可以直接在 Robrix2 中建立和维护 Project Space 结构。
+
+范围：
+
+- 创建 `RoomType::Space` 的 Space，配置名称、topic、avatar、可见性和初始权限。
+- 将已有房间或子 Space 加入当前 Space。
+- 从 Space 中移除房间或子 Space；默认只解除关系，不离开、不删除目标房间。
+- 保留“在 Space 中新建房间”，但统一复用同一套关系写入状态机。
+- 在 UI 中根据 power level 禁用无权操作，并由服务端做最终授权。
+- 对双向关系写入提供明确结果：成功、部分成功、权限不足、关系已存在、目标不可见和重试后终态。
+
+关系一致性要求：
+
+1. 父 Space 的 `m.space.child` 是层级展示的必要写入。
+2. 子房间的 `m.space.parent` 仅在有权限且产品合同要求时写入。
+3. 第二次写入失败不得把第一次已经成功的写入伪装成“完全失败”。
+4. 重试必须幂等；UI 必须重新读取服务端状态，而不是只修改本地树。
+5. 移除关系不得隐式退房、删除房间、删除历史消息或撤销成员权限。
+
+关键验收：
+
+- 创建的 Space 能被 Robrix2 和另一标准 Matrix 客户端识别为 Space。
+- 已有房间可挂载、重复挂载不产生错误重复项、移除后可重新挂载。
+- 对父有权限但对子无权限，以及对子有权限但对父无权限的情况都有确定结果。
+- 写入成功后，侧边栏、Lobby 和房间过滤视图最终收敛到同一服务端状态。
+
+### Phase 3 — 层级完整性与日常可用性（P1）
+
+**目标：** Space 树在复杂项目、重启和长期使用下保持稳定。
+
+范围：
+
+- Robrix2 自己的递归遍历增加 visited set、最大深度或等价的循环保护。
+- 保留 Matrix SDK 给出的规范 child order；没有 order 时使用确定性 fallback。
+- 侧边栏使用稳定、有定义的排序，正确处理 Insert/Set/Remove/Reset 等增量变化。
+- 持久化上次选中的 Space，并在 Space 已退出或不可见时安全回退到 Home。
+- 为 Space 增加聚合未读和 mention 语义；明确是否递归包含子 Space。
+- 清理 stale relation、孤立 parent、重复边和关系撤销后的缓存状态。
+
+关键验收：
+
+- 人工构造 A → B → A、自环和重复边时，不出现无限递归、栈溢出或重复渲染。
+- 同一服务端状态跨启动、搜索清空和增量刷新后保持相同顺序。
+- selected Space、其 Dock 布局和当前房间恢复一致；目标失效时不会打开错误项目。
+- 未读计数与既定聚合规则一致，不因环或共享房间重复计数。
+
+### Phase 4 — Project Space 产品绑定（P1，跨 Robrix2/HAFleet）
+
+**目标：** Space 从通用 Matrix 容器升级为 HAgency 的规范项目入口，同时保持项目平面与资源平面解耦。
+
+范围：
+
+- 建立 versioned `ProjectRef`，绑定 `project_id` 与 `space_room_id`。
+- 支持 typed room bindings，例如 `prd`、`architecture`、`module_spec`、`testing`、`release`、
+  `marketing`、`pdt`、`sales`、`support`、`hr` 和 `cfo`。
+- 明确一个房间被多个 Space 引用、嵌套 Space、房间迁移和撤销的处理方式。
+- Robrix2 在 Project Space 中展示 HAFleet 的 Agent、assignment、cost 和 health 投影。
+- HAFleet 的请求必须携带稳定 `project_id`；Space/room/thread 只作为受验证的绑定和追踪上下文。
+- Project Space 中的阶段、验收和项目决策仍归客户 Matrix 流程所有，HAFleet 不成为项目工作流引擎。
+
+退出条件：
+
+- `ProjectRef`/typed bindings 的 ADR、REQ、schema 和 canonical fixtures 已 Accepted。
+- room-as-project 兼容模式有明确迁移和退役条件。
+- 解除或变更 Space 关系不会静默改变项目身份、成本归属或授权。
+- Robrix2 与 HAFleet 对同一绑定版本、撤销状态和错误语义达成一致。
+
+## 5. 建议交付切片
+
+| 切片 | 包含阶段 | 用户价值 | 是否可独立发布 |
+|---|---|---|---|
+| **A. Space Access** | Phase 0 + Phase 1 | 能看到邀请，并从邀请或链接进入现有 Project Space | 可以；解决最直接阻断点 |
+| **B. Space Management** | Phase 2 + Phase 3 核心项 | 能创建和维护真实项目结构，层级在长期使用中稳定 | 可以；是 Robrix2 Project Space MVP |
+| **C. HAgency Project Binding** | Phase 4 | 项目身份、团队房间与 HAFleet 派工/成本投影形成规范关联 | 需跨仓合同后发布 |
+
+切片 A 不能被描述为“Project Space 已完成”；只有切片 B 通过后，Robrix2 才具备客户自主管理 Project Space
+的完整基础。切片 C 不应反向阻塞纯 Matrix Space 管理能力，但其身份和授权合同必须在接入 HAFleet 前完成。
+
+## 6. 测试与验收策略
+
+### 自动化测试
+
+- **纯模型测试：** 邀请分类、动作状态、错误映射、排序 fallback、图遍历和循环保护。
+- **Matrix 集成测试：** 创建 Space、挂载/移除、双向关系、power level、邀请到达、重启和幂等重试。
+- **持久化测试：** selected Space、失效回退、Dock 状态和账户隔离。
+- **契约 fixtures：** ProjectRef、typed bindings、binding revocation 和未知版本拒绝。
+
+### 手工验收
+
+- 桌面和移动端分别覆盖邀请、创建、挂载、移除、搜索、深链接和错误恢复。
+- 至少使用两个不同权限的 Matrix 账号验证授权边界。
+- 至少与一个标准 Matrix 客户端交叉验证所创建 Space 和关系事件。
+- 检查中文和英文文案、长 Space 名称、空状态、加载状态和窄屏布局。
+
+## 7. 明确非目标
+
+本路线图不包含：
+
+- 通过 Space 层级自动授予 HAFleet、审批或 Agent Operations 权限；
+- 让 HAFleet 接管客户的 PRD → Spec → Testing → Acceptance 流程；
+- 根据房间名称自动认定房间类型或项目身份；
+- 移除 Space 关系时自动删除、退房或清理工作成果；
+- 在没有独立租户与数据隔离合同前实现跨客户 Project Space 资源市场；
+- 把 Space 管理与 Agent Operations 的独立客户端认证问题合并成同一协议。
+
+## 8. 维护规则
+
+- 每个阶段必须链接到对应 task spec、实现 PR、自动化测试和用户验收记录。
+- “当前缺陷”“产品目标”“治理依赖”使用不同状态，不得互相替代。
+- 路线图基线变化时更新代码 SHA、状态表和已完成证据，不根据提交沉默推断产品意图。
+- 任何新增 UI 文案必须同步检查 `resources/i18n/en.json` 和 `resources/i18n/zh-CN.json`。
+- 未经用户测试，不提交代码、不创建 PR。

--- a/docs/robrix-with-agentchat/prd-hafleet-pdu-v0.2.md
+++ b/docs/robrix-with-agentchat/prd-hafleet-pdu-v0.2.md
@@ -1,0 +1,899 @@
+# PRD — HAFleet as a digital-labour resource plane
+
+Version: 0.2
+Status: revised draft for review
+Date: 2026-08-06
+
+## Evidence baseline
+
+Current-state evidence and target governance are two different baselines:
+
+- **Implementation baseline:** `agent-chat` `github/master@6dfe0a9960eeb7c0a728464750ca313958d929a3`
+  (2026-08-04). Statements labelled `[implementation-baseline]` describe only this commit.
+- Deployment data is not part of that Git baseline. Any observation from `data/agents.json` must be
+  identified as a dated deployment sample, not as a product invariant.
+- **Target-governance review checkout:** the following files have `status: Accepted` in the review
+  checkout but are not present in the implementation baseline and were uncommitted at review time:
+  `adr-011-backend-owned-ephemeral-runner-sessions.md`,
+  `req-thread-scoped-agent-sessions.md`, `adr-012-agent-operations-client-access.md` and
+  `req-agent-ops-client-access.md`. Statements labelled `[target-governance]` are proposed target
+  constraints, not released implementation facts. Immutable commit SHAs must be recorded before
+  this PRD can move from Draft to Accepted.
+
+Current facts, current limitations, product decisions and target requirements are deliberately
+separated below. Authentication middleware is treated as evidence of caller identity, not as proof
+of domain ownership.
+
+---
+
+## 1. Release decision summary
+
+### Target product statement
+
+**HAFleet will be the resource plane and workforce manager for digital coding agents.** It will
+connect agents wherever they run, record their identity and qualification, classify their role and
+skills, manage capacity and commercial resources, accept scoped staffing requests from Matrix
+Project Spaces, and return auditable assignments, execution state, usage and cost.
+
+HAFleet is analogous to a digital-employee outsourcing house or PDU. The analogy defines its
+responsibility for hiring, qualification, staffing, capacity, health, cost, performance evidence and
+development. It does not make HAFleet the owner of the customer's product lifecycle.
+
+### Release boundary
+
+| release class | included | meaning |
+|---|---|---|
+| **Internal technical preview** | Phase 0–2 | assignment and staffing foundation; not yet a priceable PDU product |
+| **PDU MVP beta** | Phase 0–3 code complete | durable staffing, roster, utilisation and cost accrual are available for a controlled pilot; no commercial SLA yet |
+| **Commercial GA** | PDU MVP beta + controlled baseline period | price/invoice reconciliation, approved targets and operational/commercial SLAs are complete |
+| **Later product waves** | Phase 4–5 | scoped team knowledge and evidence-based workforce assessment |
+| **Explicitly out of PDU MVP** | autonomous HR sourcing, cross-organisation capacity market, multi-customer deployment, customer project workflow engine | requires separate product and isolation decisions |
+
+Phases are implementation waves, not claims that every intermediate wave is a complete product.
+The PDU MVP beta cannot begin its pilot until the Phase 0–3 release gates in §9 pass. Commercial GA
+requires the additional pilot and reconciliation gates in §9.
+
+---
+
+## 2. Product boundary and ownership
+
+### 2.1 Customer project plane
+
+The customer decides how to run a project, divide the product process into phases, approve work and
+accept delivery. These decisions are made through Matrix and surfaced by Robrix2/HAgency.
+
+The target normative information model is:
+
+- **Matrix Space = Project**: stable customer-facing project container and navigation root.
+- **Child room = team or process surface**: PDT, PRD, architecture/SE, module spec/development,
+  testing, release, marketing, sales or service.
+- **Thread or durable task = Work Item**: a concrete discussion, request or unit of delivery.
+- Room membership, power level and E2EE remain independent. A Space hierarchy is not automatically
+  an authorisation boundary.
+
+The PDU MVP beta may support a `room-as-project compatibility mode`, but every assignment must still carry a
+stable `project_id` and an optional `project_space_id`. The compatibility mode must not become the
+canonical data model.
+
+At the implementation baseline, Accepted ADR-009 and REQ-PROJECT-BOARD define an HAFleet group as
+the project-room/membership boundary. Phase 0 must accept an amending or superseding ADR and update
+REQ-PROJECT-BOARD before `Matrix Space = Project` becomes normative. The migration must define
+group compatibility, typed child-room bindings, nested/shared rooms, revocation, membership and
+E2EE behaviour.
+
+### 2.2 HAFleet resource plane
+
+HAFleet owns:
+
+- agent identity, connector and runtime offers;
+- roles, skills, qualification evidence and eligibility;
+- commercial resources such as seats, quota buckets and API billing sources;
+- staffing assignments and capacity reservations;
+- fleet health, resource usage, cost allocation and performance evidence;
+- the operator/PDU-manager console.
+
+HAFleet may publish resource status and delivery claims into Matrix. Those messages are projections,
+not the authoritative project phase or acceptance decision.
+
+### 2.3 Cross-plane objects
+
+| object | system of record | purpose |
+|---|---|---|
+| `ProjectRef` and `ProjectWorkItem` | Matrix/Robrix2; anchored by authoritative Matrix events and versioned bindings | project identity, work intent, deliverables and acceptance criteria |
+| `AssignmentRequest` | Matrix/Robrix2 creates `request_id` and authoritative source event; HAFleet stores a digest-pinned received copy | asks HAFleet for one qualified allocation under explicit scope |
+| `StaffingAssignment` | HAFleet creates `assignment_id` | records who/what was assigned, why and under which commercial policy |
+| `ExecutionDispatch` and `ResourceLease` | durable router | controls runner creation, fencing, capacity and at-most-once execution |
+| `DeliveryAcceptanceObservation` | Matrix/Robrix2 creates the authoritative event; HAFleet stores a verified projection | records accepted or rework outcome; HAFleet cannot originate it |
+
+```mermaid
+flowchart LR
+  subgraph CUSTOMER["Customer plane — Matrix / Robrix2"]
+    SPACE[Project Space]
+    ROOMS[PRD · Spec · Dev · Test · Release rooms]
+    WORK[Work Item + acceptance criteria]
+    ACCEPT[Acceptance / rework decision]
+    SPACE --> ROOMS --> WORK
+  end
+
+  subgraph FLEET["Resource plane — HAFleet"]
+    PROFILE[Qualified agent profiles]
+    ASSIGN[Staffing assignment]
+    HOLD[Durable HAFleet resource hold]
+    CAP[Capacity policy and reconciliation]
+    LEDGER[Usage · cost · performance evidence]
+    PROFILE --> ASSIGN --> HOLD --> CAP --> LEDGER
+  end
+
+  subgraph EXEC["Single execution truth — durable router"]
+    TASK[Durable task]
+    LEASE[Fenced resource lease]
+    RUNNER[Ephemeral runner]
+    USAGE[Usage observation]
+    TASK --> LEASE --> RUNNER --> USAGE
+  end
+
+  WORK -->|AssignmentRequest| ASSIGN
+  ASSIGN -->|task/dispatch intent| TASK
+  HOLD <-->|fail-closed claim/commit saga| LEASE
+  RUNNER -->|delivery claim| ACCEPT
+  USAGE --> LEDGER
+  ACCEPT -->|accepted / rework evidence| LEDGER
+  LEDGER -->|status · usage · cost| SPACE
+```
+
+---
+
+## 3. Users and authorisation
+
+| user | need | authorisation boundary |
+|---|---|---|
+| **PDU manager** | staffing, cost, utilisation and performance evidence | fleet-wide read; commercial and profile policy write |
+| **Fleet operator** | onboard, start, stop, diagnose and intervene | operational write; no customer acceptance authority |
+| **Project requester** | request qualified capacity and see assignment state | scoped to the Project Space/work item |
+| **Project approver** | approve execution where required and accept delivery | Matrix membership/power policy plus approval contract |
+| **Agent/runner** | read its assignment, authorised knowledge and tools | assignment-scoped capability; never a fleet-wide operator token |
+
+PDU-manager and fleet-operator permissions must be distinct even if one person holds both roles in a
+single-customer deployment. `requireBridgeSecret`, agent tokens and loopback/API tokens authenticate
+callers; domain authorisation additionally requires project binding, full MXID, assignment scope and
+the relevant Matrix membership/power policy.
+
+---
+
+## 4. Scope
+
+### 4.1 In scope for the PDU MVP
+
+- Connect, identify and qualify supported local coding agents.
+- Classify agents by role, skills, service tier, runtime and eligibility.
+- Represent shared plan seats, API billing sources, quotas and availability without treating a
+  credential home as the commercial resource itself.
+- Accept idempotent, project-scoped assignment requests.
+- Use the durable router as the only execution truth.
+- Persist staffing, capacity, usage and cost events through restart.
+- Present a workforce roster and a thin, read-only project lens.
+- Attribute cost and accepted outcomes to assignment and project.
+- Default transcript/memory export to off or an approved local destination.
+
+### 4.2 Deployment constraint
+
+The PDU MVP is **single-customer / single-fleet**. It may contain multiple projects, and project
+isolation is still required. It must not be deployed as a shared multi-customer service until tenant,
+identity, knowledge, cost and retention isolation are specified and tested.
+
+The product target supports local and remote resources. The initial durable thread-runner contract
+supports only the runtime/runner combinations explicitly accepted by that contract. A remote agent
+or framework is shown as `unsupported_for_assignment` until its transport, workspace, approval and
+data-boundary semantics are accepted; it is not silently treated as equivalent to a local runner.
+
+### 4.3 Out of scope for the PDU MVP
+
+- Customer-owned PRD/spec/release workflow automation and acceptance authority.
+- Autonomous sourcing or replacement of agents.
+- Cross-organisation capacity exchange.
+- Multi-customer deployment.
+- Causal claims that a guidance change improved performance; the first version reports evidence and
+  correlation only.
+
+Credential material is not a HAFleet business object, but credential binding and security are in
+scope. Plan login state should remain in its credential home. API-key mode currently requires the
+backend to receive and inject secrets, so encrypted storage, redaction, rotation, access control and
+audit are mandatory implementation concerns.
+
+---
+
+## 5. Verified current state
+
+The table describes `agent-chat@6dfe0a9`; it does not imply that the mechanism satisfies the target
+contracts.
+
+| function | verified current fact | proven limitation |
+|---|---|---|
+| Connect | Five framework manifests and HAFleet ACP launch paths exist; ACP onboarding provisions an agent token, registers a profile and performs sustained health sampling | supported/launchable status differs by adapter; qualification is largely transport liveness |
+| Classify | `lib/matrix-agent.js` defines six roles and three ordered tiers and can infer some roles from canonical names | onboarding paths do not explicitly populate role/capability; explicit roles are not fully validated; a skill dimension is absent and capability tier implies a fixed runtime/model mapping |
+| Dispatch | `/api/dispatch`, selection, queue tickets and renewable leases exist | no first-party production caller was found; queue and leases are process-local; `[target-governance]` this path conflicts with the proposed durable thread router if treated as a second execution truth |
+| Monitor | agent task, ACTIVE/IDLE streaks, health, logs, alerts and supervisor signals exist | room/role/tier/task lease context is private and not durably queryable; current streak duration is not historical utilisation |
+| Assess | supervisor events support intervention and incident history | incident signals do not equal accepted outcome quality or long-term performance |
+| Learn | Letta integration and governed knowledge artifacts exist | hook migration is partial; knowledge is not assignment-scoped or served through the MCP surface; default remote endpoint creates a privacy hazard |
+| Cost | an unrelated LLM usage field exists | there is no per-assignment workforce usage, price book, seat accounting or cost-allocation pipeline |
+| Project lens | the project page already renders separate specifications, issues and change requests with richer rows at this baseline | the bridge models one group to one room and has no canonical Project Space/project-room binding |
+
+Dispatch is not described as “0% by construction.” Some agents can enter the legacy pool through
+name-derived roles. The accurate product gap is that onboarding does not create an explicit,
+validated qualification; no production requester drives the legacy dispatch API; and the legacy
+queue/lease cannot provide durable execution guarantees.
+
+At this baseline, nine ADRs and four requirements have Accepted status. Guidance, standards canon
+and contextual documents are useful knowledge assets, but are not counted as Accepted ADR/REQ
+artifacts.
+
+---
+
+## 6. Requirements
+
+Priorities describe business necessity. Delivery phase describes dependency order; the two are not
+interchangeable.
+
+`R0` is a newly introduced foundation requirement. Existing R1–R20 identifiers are retained to
+avoid silently changing external references; any downstream tracker must explicitly add R0.
+
+### 6.1 Contract and privacy foundation
+
+#### R0 — One assignment contract and one execution truth (P0)
+
+HAFleet must accept an immutable, idempotent `AssignmentRequest` and create a durable
+`StaffingAssignment`. Execution must be delegated to the target durable router; the legacy
+`/api/dispatch` may be removed or retained only as an adapter into that router.
+
+The existing Agent Operations owner-DM contract does **not** authorise project staffing requests.
+Phase 0 must establish a separate Project Assignment Requester ADR/REQ. It binds requester and
+device/event provenance, ProjectRef/binding version, room/work item, allowed command, expiry, nonce,
+payload digest and revocation. Matrix-to-HAFleet delivery uses a durable inbox/outbox and replay
+protection.
+
+An assignment request contains at least:
+
+- client-generated `request_id`, `project_id`, optional `project_space_id`;
+- `room_id`, `thread_root_event_id`, `work_item_id`, existing durable `task_id`, authoritative source
+  event/digest and requester full MXID;
+- required and preferred roles/skills/service tier;
+- compatible frameworks/runtimes and local/remote constraint;
+- backend-pre-registered opaque references for repository, workspace, tools and write scope, plus
+  data classification;
+- priority, deadline, budget and estimated effort;
+- deliverables, acceptance criteria and status destination;
+- schema version and payload digest.
+
+HAFleet generates `assignment_id` only after request validation. PDU MVP requests exactly one
+allocation (`quantity = 1`). Multi-person demand later uses an explicit assignment group with child
+assignments; it is not represented by one ambiguous lifecycle. Cancel and reassign are separate
+idempotent commands/events, not mutable fields on the request.
+
+The layers have separate state machines:
+
+| layer | canonical states and invariants |
+|---|---|
+| Request reception | `received → validation_rejected or validated`; validation includes requester authority, binding version, durable task and confirmed Matrix anchor |
+| Staffing assignment | `queued → staffed → executing → delivered → acceptance_pending → completed or rework_requested`; `cancelled` may occur before execution; `failed` records a known terminal failure; `outcome_unknown` blocks reassignment until inspection/resolution; `rework_requested` closes this assignment and creates a separately authorised successor request/assignment |
+| Execution dispatch | `created → started → completed / failed / cancelled_before_start / outcome_unknown`; at-most-once applies to one `dispatch_id/generation`, never to the whole assignment |
+| Resource hold/lease | `prepared → claimed → committed → released / expired / compensated`; expiry is a capacity event, not an assignment outcome |
+| Delivery acceptance | authoritative Matrix event: `accepted` or `rework_requested`; HAFleet stores a source-event/digest-pinned observation and cannot originate or silently revoke it |
+
+For PDU MVP the cardinality is:
+
+`1 AssignmentRequest → 1 StaffingAssignment → 1 durable task → 1..N dispatch generations`
+
+The first dispatch requires a pre-existing durable task and durably confirmed Matrix anchor. A
+started dispatch is never replayed. Recovery after `outcome_unknown` first completes the required
+inspection/resolution flow; `continue` creates a distinct successor dispatch with a higher fence and
+predecessor reference. Dirty workspace/resource evidence cannot be bypassed by cancel or reassign.
+A short-lived capacity lease remains subordinate to these objects and cannot replace their
+lifecycles.
+
+*Acceptance A-R0-1:* repeating the same `request_id` and digest produces the same assignment; a
+different digest is rejected as a conflict.
+
+*Acceptance A-R0-2:* a dedicated requester contract validates full MXID, device/event provenance,
+ProjectRef/binding version, membership/power policy, nonce/expiry and request digest; a desktop
+client never receives or submits a fleet operator token.
+
+*Acceptance A-R0-3:* `assignment_id → task_id → dispatch_id/generation` and the confirmed Matrix
+anchor are durable and uniquely queryable before execution begins.
+
+*Acceptance A-R0-4:* restart between every runtime transition preserves state; the same started
+dispatch generation is never replayed, while a resolved recovery uses a new dispatch and higher
+fence.
+
+*Acceptance A-R0-5:* stale runners can report only delivery claims; they cannot create acceptance
+evidence, advance project state or bypass outcome inspection.
+
+*Acceptance A-R0-6:* a verified Matrix acceptance/rework event references the assignment, task,
+delivery digest, actor and binding version and is idempotently projected into HAFleet.
+
+#### R20 — Memory and transcripts stay local by default (P0)
+
+Subconscious/memory export is disabled by default or points to an approved local endpoint. Any
+off-host destination requires explicit project-level opt-in, shows the endpoint and data classes,
+and defines redaction, retention, deletion/export and audit behaviour. “Self-hosted” is not treated
+as proof of safety.
+
+*Acceptance A-R20-1:* a clean installation sends no prompt or transcript off-host.
+
+*Acceptance A-R20-2:* enabling export requires an authorised project decision and records actor,
+destination, scope, time and retention policy.
+
+*Acceptance A-R20-3:* export uses an allow-list of permitted data classes and fails closed when
+classification is unknown; size/attachment limits, audit sampling and deletion/export behaviour are
+verifiable. Secret scanning is defence in depth, not a guarantee that arbitrary transcripts can be
+made safe by redaction.
+
+### 6.2 Connect, classify and qualify
+
+#### R1 — Every employee receives an explicit classified profile (P0)
+
+Every onboarding path records `primary_role`, `skills`, `service_tier`, `runtime_offer` and
+`eligibility`. A missing classification produces `unassigned`, with the dispatch consequence
+visible; name-derived role is migration assistance, not authoritative qualification.
+
+*Acceptance A-R1-1:* supported onboarding commands accept profile inputs or a versioned profile
+file, and the resulting profile is queryable.
+
+*Acceptance A-R1-2:* an unassigned agent may be healthy but is ineligible for staffing.
+
+#### R2 — Classification values are validated and extensible (P0)
+
+Canonical MVP roles may use the existing six-role vocabulary, but role, skill and tier are separate
+fields. Unknown canonical roles are rejected; custom roles require a namespaced taxonomy entry.
+Skills carry level, evidence, verification time and optional expiry.
+
+*Acceptance A-R2-1:* invalid roles and skills return a 400 with the accepted taxonomy/version.
+
+*Acceptance A-R2-2:* existing off-vocabulary records are migrated or shown as
+`classification_invalid`; no invisible seventh pool cell is created.
+
+#### R3 — A profile can evolve without replacing employee identity (P1)
+
+Role, skills, service tier, runtime offer and eligibility can be revised independently. Every change
+is versioned and audited. Identity, authorised knowledge references and historical performance
+remain linked without incorrectly carrying customer-private material to another project.
+
+*Acceptance A-R3-1:* reclassification preserves `agent_id` and historical assignments.
+
+*Acceptance A-R3-2:* an active assignment continues under its pinned qualification version unless
+explicitly reassigned.
+
+#### R4 — Hiring verifies eligibility and job competence (P0)
+
+Process liveness, transport/tool operation and job competence are distinct evidence. Qualification
+runs a versioned test appropriate to the advertised skill/runtime and records the result. An
+ACP→MCP→reply check proves transport/toolchain operation; it does not by itself certify coding,
+testing or review skill.
+
+*Acceptance A-R4-1:* an agent can be `onboarded_unqualified`, `qualified` or
+`qualification_expired`. Only qualified offers enter staffing.
+
+*Acceptance A-R4-2:* evidence records test version, environment, result and validity period.
+
+#### R5 — The dashboard shows what the host can connect (P1)
+
+A detection endpoint reports framework presence, version, transport, launchability, credential
+binding state, setup requirements, permission summary and qualification support without returning a
+secret. Connection readiness and assignment eligibility are orthogonal fields, not one precedence
+ordered enum.
+
+*Acceptance A-R5-1:* `connection_state` is one of
+`ready | needs_auth | needs_setup | absent`; `assignment_eligibility` is independently
+`eligible | trial | non_launchable | unsupported`, with a stable reason/contract reference. An
+unsupported adapter cannot render as assignment-ready merely because it is installed and
+authenticated.
+
+*Acceptance A-R5-2:* detection responses and UI text have i18n keys; translated labels do not clip
+or lose the reason for an unavailable state.
+
+#### R6 — Trial and unsupported adapters are explicit (P2)
+
+Adapter status distinguishes `production`, `trial`, `non_launchable` and
+`unsupported_for_assignment`, with a human-readable reason and the contract it lacks.
+
+*Acceptance A-R6-1:* `codex` and `codex-acp` are not displayed as interchangeable peers while one
+remains a trial/non-launchable transport.
+
+The following state axes remain independent in APIs, scheduling and UI:
+
+| axis | examples | answers |
+|---|---|---|
+| classification | `unassigned`, `classification_invalid`, valid taxonomy version | what work profile is declared? |
+| qualification | `onboarded_unqualified`, `qualified`, `qualification_expired` | is there current evidence? |
+| connection | `ready`, `needs_auth`, `needs_setup`, `absent` | can the connector operate? |
+| assignment eligibility | `eligible`, `trial`, `non_launchable`, `unsupported` | may this offer receive this assignment? |
+| capacity | `available`, `reserved`, `busy`, `throttled` | can the qualified offer take work now? |
+| health | `healthy`, `degraded`, `unhealthy`, `unknown` | is the runtime functioning? |
+
+No single enum or colour may collapse these axes; combinations and reasons remain inspectable.
+
+### 6.3 Commercial resources and scheduling
+
+#### R7 — Usage and capacity observations are durable (P0)
+
+Building on R0's Phase 2 assignment/event ledger, HAFleet persists append-only capacity intervals
+and per-execution usage observations. The records survive restart and contain
+project/assignment/dispatch/agent/runtime/seat/workspace references, timestamps, observation
+category, confidence and end reason.
+
+Usage provenance is `reported`, `measured` or `unknown`. Tokens are recorded only where the provider
+reports them; busy time is measured independently and is never converted into token cost without a
+valid rate source.
+
+*Acceptance A-R7-1:* a completed, failed or cancelled dispatch and a released, expired or
+compensated resource hold/lease leave queryable history after restart.
+
+*Acceptance A-R7-2:* duplicate framework callbacks do not duplicate usage or cost.
+
+*Acceptance A-R7-3:* missing provider usage is rendered as `unknown` with measured busy time, never
+as zero.
+
+#### R8 — Seats and billing sources are independent resources (P0)
+
+`Seat` is not stored as a string property that makes an agent the owner of capacity. The model
+contains:
+
+- `Seat`: provider, plan type, quota buckets, concurrency, status and observation confidence;
+- `SeatBinding`: runtime offer/execution environment, seat, host/OS identity, credential-home
+  fingerprint and validity interval;
+- `BillingSource`: API account or commercial plan, currency and policy reference;
+- `PriceBook`: provider/model rates, effective interval and version;
+- `BudgetReservation`: assignment/project budget reserved and consumed.
+
+A credential-home fingerprint is a deployment-keyed HMAC with key identifier and rotation policy;
+it is neither a raw path nor a globally correlatable hash and never exposes the credential. API-key
+mode nevertheless uses a secret and must follow the security controls in §4.
+
+*Acceptance A-R8-1 (Phase 1):* agents sharing a seat consume one shared quota/concurrency model and are not
+double-counted.
+
+*Acceptance A-R8-2 (Phase 2):* HAFleet-owned agent/seat/budget holds and router-owned workspace/named-resource
+leases use a durable fail-closed `prepare → claim → commit | compensate` saga with idempotency,
+expiry, fences and restart reconciliation. Cross-store atomicity is not claimed; provider quota is
+an external observation and cannot be locally locked.
+
+*Acceptance A-R8-3 (Phase 1):* the deployment records whether the commercial plan permits the intended
+automation/sharing use.
+
+#### R9 — Scheduling is policy-driven, not tier-hardcoded (P1)
+
+Eligibility is checked before optimisation. Mandatory skills, runtime, data, workspace and approval
+constraints cannot be traded for cost. PDU MVP uses a stable lexicographic policy:
+`security/qualification → observable quota → budget → configured cost-or-headroom preference →
+stable tie-break`. Ordered service tier is not assumed to imply substitutability across unrelated
+skills. More complex weighted optimisation is deferred until measurement supports it.
+
+*Acceptance A-R9-1 (Phase 2):* every assignment result names the eligibility and optimisation policy version
+and explains the selected offer or queue reason.
+
+*Acceptance A-R9-2 (Phase 3):* plan scheduling accounts for every relevant quota bucket and preserves a
+configured safety headroom; unknown quota does not masquerade as full capacity.
+
+#### R10 — Throttled is distinct from unhealthy (P1)
+
+Provider/quota exhaustion produces `throttled`, with reset time and confidence when known. It is
+excluded from eligible capacity but remains operationally healthy unless independent health evidence
+says otherwise.
+
+*Acceptance A-R10-1:* timeout, health failure and quota exhaustion produce different states and
+alerts.
+
+*Acceptance A-R10-2:* reset reconciles capacity without requiring agent re-registration.
+
+#### R11 — Cost is traceable to assignment and project (P0)
+
+The primary allocation keys are `assignment_id`, `project_id` and cost centre. Space, room and thread
+are trace context. PDU MVP uses one deployment currency, integer micros, explicit rounding, a static
+versioned price book and a declared plan-allocation policy. API usage categories include provider,
+model, input/output/cache/reasoning units where reported. Amount stages are `estimated`, `accrued`
+(usage × policy/rate) and `invoiced`; `observed` describes usage evidence, not money.
+
+Corrections use reversal/superseding events. A billing period can be closed only under an explicit
+policy. Budget reservations declare hard-limit or warning semantics and define unknown-price,
+overage, cancellation and release behaviour. Currency conversion and multi-currency accounting are
+out of the PDU MVP.
+
+*Acceptance A-R11-1:* every non-zero or unknown accrued cost can be traced to usage evidence,
+rate/policy version, rounding rule and assignment.
+
+*Acceptance A-R11-2:* room/project/agent/seat views aggregate the same ledger without silently
+mixing `reported`, `measured` and `unknown`.
+
+*Acceptance A-R11-3:* plan cost is allocated by a declared policy; “paid already” is not recorded as
+zero marginal accounting cost.
+
+*Acceptance A-R11-4:* provider invoices reconcile to accrued records with explicit coverage,
+variance, correction and closed-period handling before Commercial GA.
+
+### 6.4 Workforce console
+
+#### R12 — The console is a workforce roster (P0)
+
+The dashboard home for PDU managers and operators is organised around the workforce. Each agent row
+shows identity, role/skills summary, qualification, runtime, availability, current assignment,
+project, work item, elapsed time, health, quota state, utilisation and cost coverage.
+
+An unavailable value is `—` with a reason such as `usage_unknown`, `not_yet_measured` or
+`project_unbound`; it is never silently zero. Management and operational actions follow separate
+RBAC. New labels and reason strings require i18n keys and layout verification.
+
+*Acceptance A-R12-1 (Phase 2):* a manager can answer who is working, for which project/work item,
+since when, under which runtime/seat binding and with what current health/availability; unavailable
+history/cost is explained.
+
+*Acceptance A-R12-2 (Phase 3):* the same row adds historical utilisation, quota confidence and
+accrued-cost coverage reconciled to R7/R11.
+
+*Acceptance A-R12-3:* an operator action cannot perform customer approval or delivery acceptance.
+
+#### R13 — Utilisation is derived from durable intervals (P0)
+
+Utilisation is derived from durable intervals, not current ACTIVE/IDLE streaks. The model separates:
+
+- assigned/reserved time;
+- runner busy time and productive execution time where observable;
+- idle, offline, maintenance and throttled time;
+- agent utilisation and seat utilisation.
+
+The denominator uses declared availability, maintenance and quota policy. It is shown alongside SLA,
+queue time and safety headroom rather than treated as the only optimisation target.
+
+*Acceptance A-R13-1:* the UI states numerator, denominator, timezone and period.
+
+*Acceptance A-R13-2:* a restart or released lease does not change historical results.
+
+*Acceptance A-R13-3:* agent, role, seat, assignment and project aggregations reconcile to the same
+interval ledger.
+
+#### R14 — The project lens is thin and Space-aware (P1)
+
+HAFleet presents an internal, read-only resource lens: assignments, agent-opened issues/change
+requests, dirty worktrees, blocked work, spec drift, usage and cost. It links into the authoritative
+Matrix Project Space for project discussion and decisions.
+
+`ProjectRef` contains a stable `project_id`, optional Matrix `space_room_id`, binding version and
+typed child-room bindings. The PDU MVP beta may configure these bindings manually; HAFleet never infers authority
+from names or Space hierarchy alone. The feature cannot become normative until the Phase 0
+ADR-009/REQ-PROJECT-BOARD amendment is Accepted.
+
+*Acceptance A-R14-1:* multiple rooms aggregate as one project without merging membership or E2EE
+policy.
+
+*Acceptance A-R14-2:* issue and change-request rows retain provider, identifier, state, link and
+check detail already available at the implementation baseline.
+
+*Acceptance A-R14-3:* the page deep-links to Matrix and does not implement project acceptance.
+
+### 6.5 Knowledge and workforce development
+
+#### R15 — Performance is evidence-based and outcome-aware (P1)
+
+Supervisor incidents remain operational evidence, not a quality score. R0 already records the basic
+verified acceptance/rework observation needed for attribution; R15 adds the analytical performance
+record joining assignment, acceptance/rework outcome, cost, duration, task class/complexity, external wait,
+restart/incident history and pinned profile/model/guidance versions.
+
+*Acceptance A-R15-1:* scorecards show sample size, confidence and missing data.
+
+*Acceptance A-R15-2:* `cost per accepted outcome` and `time to accepted outcome` are stratified by
+task class/complexity; agents are not directly ranked across unrelated roles.
+
+*Acceptance A-R15-3:* external wait and project-caused blocks are separated from agent-caused
+blocks.
+
+#### R16 — Team knowledge is served through assignment scope (P1)
+
+Knowledge objects carry project, audience, classification, Accepted status, version/supersedes,
+digest, provenance, owner and retention. An agent receives an assignment-scoped capability to list
+or read only the permitted artifact manifest/content. It cannot enumerate the entire repository or
+another project's knowledge.
+
+*Acceptance A-R16-1:* local and remote agents receive the same authorised project manifest without
+requiring the repository tree to exist on the runner host.
+
+*Acceptance A-R16-2:* owner-DM, unrelated-project and unaccepted proposal content are denied and
+audited.
+
+*Acceptance A-R16-3:* session start uses targeted retrieval and a context budget rather than
+injecting every Accepted artifact.
+
+#### R17 — Private lessons can be proposed as governed knowledge (P1)
+
+Agents submit idempotent, project-scoped proposals through a restricted backend command. The command
+validates path/type, schema and agent-spec lint. Human/PDT promotion produces a versioned Accepted
+artifact; an agent never receives arbitrary repository write access.
+
+*Acceptance A-R17-1:* proposal, review, rejection and promotion are auditable and preserve
+provenance.
+
+*Acceptance A-R17-2:* only promoted artifacts become eligible for R16 delivery.
+
+#### R18 — Employee profiles are portable without leaking customer memory (P1)
+
+Portable data includes generic identity, non-customer-specific qualification evidence and public
+configuration history. Project transcripts, owner-DM content, customer knowledge and acceptance
+records remain within their project/retention boundary. Export/import is encrypted, schema-versioned
+and audited.
+
+*Acceptance A-R18-1:* host/framework/model migration preserves generic identity and approved
+qualification history.
+
+*Acceptance A-R18-2:* exporting a profile cannot export project-private content without a separate
+authorised project export.
+
+#### R19 — Improvement evidence closes the loop without claiming causality (P2)
+
+Guidance/knowledge/profile changes are versioned and linked to subsequent assignments. Reports show
+before/after evidence with task mix, sample size and confounders. The product does not label a change
+as causal improvement without a separately designed evaluation.
+
+*Acceptance A-R19-1:* a reviewer can reproduce which configuration and guidance version served each
+assignment and compare stratified outcomes.
+
+---
+
+## 7. Data and event model
+
+| entity/event | system of record and responsibility | requirements |
+|---|---|---|
+| `ProjectRef` | Matrix/Robrix2 authority; project ID, Space ID, versioned typed room bindings, classification, revocation | R0, R14, R16 |
+| `ProjectWorkItem` | Matrix/Robrix2 authority; source event, task/anchor, criteria digest, data class and binding version | R0, R14 |
+| `AssignmentRequesterGrant` | project-requester authority, device/event provenance, commands, nonce/expiry and revocation | R0 |
+| `AssignmentRequest` / received copy | client request ID and source event; HAFleet digest-pinned received copy, demand, budget, deliverables and idempotency | R0 |
+| `StaffingAssignment` | HAFleet assignment ID, lifecycle, selected offer, policy/qualification versions and task mapping | R0, R9, R15 |
+| durable `Task` / `ExecutionDispatch` | router-owned task, confirmed Matrix anchor, dispatch generation, predecessor and outcome inspection | R0 |
+| `ResourceHold` / `ResourceLease` | HAFleet hold and router lease joined by saga ID, fence, expiry and compensation state | R0, R8 |
+| `WorkspaceResourceRef` | router-owned opaque workspace/named-resource identity and lease policy | R0, R8 |
+| `DeliveryClaim` | runner-originated artifact/status claim with dispatch generation and digest; never acceptance | R0 |
+| `DeliveryAcceptanceObservation` | verified Matrix event, actor/power evidence, assignment/task/delivery digest, accepted/rework and version | R0, R11, R15 |
+| `AgentProfile` / `RuntimeOffer` | identity, role, skills, service tier, runtime, environment, eligibility and versions | R1–R4, R18 |
+| `TaxonomyVersion` / `SchedulerPolicy` | accepted vocabulary, deterministic eligibility/selection policy and tie-break | R2, R9 |
+| `QualificationEvidence` | test/version/environment/result/expiry | R4 |
+| `Seat` / `SeatBinding` | commercial capacity and time-bounded runtime/environment binding | R8–R10 |
+| `BillingSource` / `PriceBook` | plan/API policy, provider/model/unit rates, currency, rounding and effective time | R8, R11 |
+| `QuotaObservation` | provider bucket, consumed/remaining/reset, provenance and confidence | R9, R10, R13 |
+| `BudgetReservation` / `CostCentre` | assignment/project hard-or-soft budget and allocation dimension | R8, R11 |
+| capacity/activity interval event | reservation, busy/idle/offline/maintenance/throttled start/end/reason | R7, R13 |
+| `UsageObservation` | provider units or measured time, provenance and callback idempotency | R7 |
+| `CostRecord` | estimated/accrued/invoiced micros, rate/policy, reversal and allocation keys | R11 |
+| `PerformanceEvidence` | acceptance/rework, task class, waits, incidents and pinned versions | R15, R19 |
+| `KnowledgeArtifact` / access capability | project/audience/classification/status/provenance/retention and scoped access | R16–R18 |
+| profile export/import audit | schema, encryption/key reference, scope, actor and tombstone/retention action | R18 |
+| transcript-export decision/event | project opt-in, actor, endpoint, allow-listed data class, retention and audit | R20 |
+
+The operational and accounting ledgers are append-only at the domain-event level. Corrections use
+reversal/superseding events, not silent mutation. Privacy deletion uses policy-governed
+tombstone/pseudonymisation and key destruction while retaining the minimum legally required audit
+evidence; raw private content is not retained merely because the ledger is append-only.
+
+---
+
+## 8. Metrics
+
+Metrics become release gates only when their baseline, target, owner and approval date are recorded.
+`TBD` is an explicit decision debt, not an implied target.
+
+| metric | formula and unit | window / inclusion rules | source | owner | availability / target decision |
+|---|---|---|---|---|---|
+| Eligible staffing SLA | eligible validated requests staffed within SLA ÷ eligible non-cancelled requests, % | rolling 7d/30d; invalid, unauthorised and pre-SLA requester cancellation reported separately | assignment ledger | PDU manager | measurable Phase 2; target after pilot |
+| Staffing queue latency | `staffed_at - validated_at`, p50/p95 seconds | by role/skill/service tier; show queue reason | assignment ledger | Fleet operator | measurable Phase 2; target after pilot |
+| Time to qualified | `qualified_at - onboarding_started_at`, p50/p95 minutes | setup/auth/user wait broken out | onboarding and qualification events | Fleet operator | measurable Phase 1; target before beta |
+| Agent utilisation | policy-defined busy or assigned interval ÷ declared available interval, % | 7d/30d; maintenance/throttled denominator policy version shown | interval ledger | PDU manager | measurable Phase 3; target after pilot |
+| Seat utilisation/headroom | consumed/reserved observable capacity ÷ usable capacity, % plus confidence | by quota bucket/window; unknown is excluded and counted as coverage gap | quota and lease observations | PDU manager | measurable Phase 3; target after pilot |
+| Cost coverage | assignments with known accrued cost policy and evidence ÷ cost-bearing assignments, % | reported/measured/unknown coverage shown separately | usage and cost ledgers | CFO/PDU manager | measurable Phase 3; GA target TBD |
+| Cost per accepted outcome | allocated accrued micros ÷ verified accepted outcomes, deployment currency/outcome | 30d; task-class stratification is Phase 5, so beta result is descriptive only | cost ledger + acceptance observations | CFO/PDU manager | basic Phase 3; decision-grade Phase 5 |
+| Accepted throughput / rework | count of verified accepted and rework events; rework ÷ delivered, % | 7d/30d; external/project waits separate when Phase 5 evidence exists | acceptance observations | Project/PDU manager | basic Phase 2; enriched Phase 5 |
+| Repeat-incident rate | repeated incident class after the relevant governed artifact was available ÷ comparable exposures, % | requires retrieval/citation coverage; never presented as causality | knowledge audit + incidents | PDU manager | Phase 4–5; target TBD |
+
+Phase 3 code completion starts a controlled 30-day pilot for metrics available by that phase. Phase
+4–5 metrics establish their own later baselines. Commercial SLAs must not be invented from the
+current deployment sample.
+
+---
+
+## 9. Delivery plan and release gates
+
+### Phase 0 — contracts, governance and privacy
+
+Deliver governance and canonical fixtures, not the Phase 2 runtime:
+
+- R0 schemas, separate layer state/transition tables, idempotency and fencing rules;
+- Project Assignment Requester ADR/REQ;
+- ADR-009 and REQ-PROJECT-BOARD amendment for ProjectRef/Space/typed-room migration;
+- committed target router/client-governance baseline and compatibility mapping;
+- fail-closed resource-hold/lease saga contract;
+- R20 endpoint/data-class/retention policy and threat model;
+- knowledge/RBAC capability schema and cross-project denial test plan.
+
+Gate:
+
+- governance documents, canonical fixtures, threat model and contract-test plan are Accepted at
+  immutable commits by both repository owners;
+- schemas define source of record, actor, idempotency, replay, fence and recovery for every layer;
+- no schema accepts arbitrary local paths/commands or a desktop fleet-operator token;
+- no clean installation sends prompts/transcripts off-host;
+- the project migration never infers authorisation from Space hierarchy.
+
+### Phase 1 — supply model and qualification
+
+Deliver: R1–R6 profile/taxonomy, qualification and framework detection; R8 Seat/BillingSource schema,
+keyed binding identifiers and migration; current roster fields independent of historical telemetry.
+
+Gate:
+
+- every dispatchable runtime offer is qualified and versioned;
+- invalid/unassigned profiles are visible and cannot enter eligible capacity;
+- shared seat bindings cannot be counted as independent commercial capacity;
+- unsupported remote/framework combinations remain fail-closed;
+- detection separates connection readiness from assignment eligibility.
+
+### Phase 2 — durable staffing
+
+Deliver: R0 assignment/task/dispatch implementation; durable assignment/event store and queue;
+restart reconciliation; HAFleet hold ↔ router lease saga; deterministic eligibility/static-capacity
+selection from R9; R12 Phase 2 roster; R14 Space-aware thin project lens; basic verified acceptance
+projection.
+
+Gate:
+
+- restart at every assignment/dispatch/saga state preserves truth and compensation state;
+- a started dispatch generation is not replayed; recovery uses a distinct dispatch and higher fence;
+- dirty/outcome-unknown resources remain fail-closed until inspection/resolution;
+- every result or queue state includes a stable reason and policy/qualification version;
+- customer approval/acceptance cannot be performed from the workforce console;
+- ProjectRef, requester and acceptance source events/digests are uniquely queryable.
+
+### Phase 3 — telemetry and accounting (**PDU MVP beta code boundary**)
+
+Deliver: R7 usage/interval observations; R10 throttling; R11 price book, cost accrual and allocation;
+R13 utilisation; quota/cost/headroom selection from R9; R12 Phase 3 historical/cost columns.
+
+Gate for controlled beta:
+
+- completed/failed/cancelled assignments and released/expired/compensated holds remain queryable
+  after restart;
+- usage/cost duplicate callbacks are idempotent and corrections use reversal events;
+- every displayed number has provenance or an explicit unknown reason;
+- assignment/project/room/agent/seat aggregates reconcile to the ledger;
+- hard/soft budget and unknown-price behaviour pass contract tests;
+- security and i18n checks pass for all new console states and labels.
+
+### Controlled pilot and Commercial GA
+
+Run the PDU MVP beta for 30 days in a controlled single-customer deployment.
+
+Commercial GA gate:
+
+- metric baselines, targets, operating owner and alert thresholds are approved;
+- accrued costs reconcile against provider invoices with approved variance/correction handling;
+- price book, plan allocation, billing-period close and retention procedures are operational;
+- recovery, backup and operator runbooks pass rehearsal;
+- the commercial SLA states which values are reported, measured, estimated or unknown.
+
+### Phase 4 — scoped organisational learning
+
+Deliver: R16, R17 and privacy-safe R18 export/import.
+
+Gate:
+
+- cross-project and owner-DM knowledge access tests fail closed;
+- remote runners receive only assignment-scoped knowledge;
+- proposals cannot bypass human/PDT promotion;
+- privacy deletion and append-only audit semantics pass policy tests.
+
+### Phase 5 — assessment and improvement evidence
+
+Deliver: R15, R19 and profile-evolution reporting from R3/R18.
+
+Gate:
+
+- scorecards show data coverage, task strata, sample size and confidence;
+- project/external waits are separated from agent-caused delay;
+- reports use correlation language unless a separate causal evaluation exists.
+
+---
+
+## 10. Traceability matrix
+
+`TBD before approval` means this PRD is not yet an estimate or delivery commitment.
+
+| requirement / acceptance | phase | data/API or governance dependency | planned test/gate | accountable role | estimate / status |
+|---|---|---|---|---|---|
+| R0 / A-R0-1 | 0 contract, 2 runtime | request SoR, digest and idempotency | CT/IT-R0-IDEMP | HAFleet + Robrix2 owners | TBD before approval |
+| R0 / A-R0-2 | 0 | requester ADR/REQ, ProjectRef binding, replay protection | CT-R0-AUTH | Security + Matrix owner | TBD before approval |
+| R0 / A-R0-3 | 0 contract, 2 runtime | assignment/task/dispatch/anchor mapping | CT/IT-R0-MAP | Router owner | TBD before approval |
+| R0 / A-R0-4 | 0 contract, 2 runtime | dispatch generation, fence, recovery | IT-R0-RECOVERY | Router owner | TBD before approval |
+| R0 / A-R0-5..6 | 0 contract, 2 runtime | claim/acceptance event contracts | CT/IT-R0-ACCEPT | Matrix + HAFleet owners | TBD before approval |
+| R1 / A-R1-1..2 | 1 | AgentProfile | IT-R1-PROFILE | Fleet operator | TBD before approval |
+| R2 / A-R2-1..2 | 1 | TaxonomyVersion and migration | CT/IT-R2-TAXONOMY | PDU manager | TBD before approval |
+| R3 / A-R3-1..2 | 1 core, 5 reporting | versioned profile and pinned assignment | IT-R3-VERSION | HAFleet owner | TBD before approval |
+| R4 / A-R4-1..2 | 1 | QualificationEvidence | E2E-R4-QUALIFY | Fleet operator | TBD before approval |
+| R5 / A-R5-1..2 | 1 | detection API and i18n | CT/UI-R5-DETECT | HAFleet UI owner | TBD before approval |
+| R6 / A-R6-1 | 1 | adapter status | UI-R6-ADAPTER | Fleet operator | TBD before approval |
+| R7 / A-R7-1..3 | 3 | usage/interval ledger | IT-R7-LEDGER | Accounting telemetry owner | TBD before approval |
+| R8 / A-R8-1,3 | 1 | Seat/Binding/BillingSource | CT/IT-R8-MODEL | PDU manager | TBD before approval |
+| R8 / A-R8-2 | 0 contract, 2 runtime | hold/lease saga | IT-R8-SAGA | HAFleet + Router owners | TBD before approval |
+| R9 / A-R9-1 | 2 | deterministic eligibility/static policy | CT/IT-R9-POLICY | Scheduler owner | TBD before approval |
+| R9 / A-R9-2 | 3 | QuotaObservation | IT-R9-QUOTA | Scheduler owner | TBD before approval |
+| R10 / A-R10-1..2 | 3 | quota and health observations | IT-R10-STATE | Fleet operator | TBD before approval |
+| R11 / A-R11-1..3 | 3 | usage, price book, allocation | IT-R11-ACCRUAL | CFO/PDU manager | TBD before approval |
+| R11 / A-R11-4 | GA | invoice reconciliation | RECON-R11-INVOICE | CFO | TBD before approval |
+| R12 / A-R12-1,3 | 2 | current assignment/health and RBAC | UI/E2E-R12-CURRENT | Dashboard owner | TBD before approval |
+| R12 / A-R12-2 | 3 | utilisation/cost read models | UI/E2E-R12-HISTORY | Dashboard owner | TBD before approval |
+| R13 / A-R13-1..3 | 3 | interval/availability policy | IT/UI-R13-UTIL | PDU manager | TBD before approval |
+| R14 / A-R14-1..3 | 0 governance, 2 runtime | superseding project ADR/REQ, ProjectRef | CT/E2E-R14-SPACE | Matrix + HAFleet owners | TBD before approval |
+| R15 / A-R15-1..3 | 5 | acceptance, cost, waits and incident evidence | IT/UI-R15-SCORE | PDU manager | TBD before approval |
+| R16 / A-R16-1..3 | 0 threat model, 4 runtime | scoped knowledge capability | SEC/E2E-R16-SCOPE | Knowledge + Security owners | TBD before approval |
+| R17 / A-R17-1..2 | 4 | proposal command/promotion audit | E2E-R17-PROMOTE | Knowledge owner | TBD before approval |
+| R18 / A-R18-1..2 | 4 | encrypted export/import and retention | SEC/E2E-R18-PORT | Security owner | TBD before approval |
+| R19 / A-R19-1 | 5 | pinned configurations and stratified evidence | IT/UI-R19-EVIDENCE | PDU manager | TBD before approval |
+| R20 / A-R20-1..3 | 0 | endpoint/data/retention policy | SEC-R20-EGRESS | Security owner | TBD before approval |
+
+---
+
+## 11. Deferred items
+
+| item | reason | prerequisite for reconsideration |
+|---|---|---|
+| Autonomous HR sourcing | comparable qualification, cost and accepted-outcome evidence do not exist before the PDU MVP | R4, R7, R11, R15 plus a governed benchmark |
+| Multi-customer deployment | tenant identity, knowledge, secrets, cost and retention isolation are not specified | separate tenancy ADR/REQ and isolation tests |
+| Cross-organisation capacity market | Matrix federation does not define commercial capacity leasing or trust | protocol, commercial and trust decisions |
+| Customer phase/stage engine | belongs to the customer project plane; workflow IDs are not a HAFleet lifecycle | separate Matrix/Robrix2 product decision |
+| Causal guidance optimisation | observational before/after reports cannot establish causality | controlled evaluation design and sufficient samples |
+
+Project Space and project-to-many-room binding are **not deferred**. They are Phase 0 identity and
+attribution foundations even if the first binding is configured manually.
+
+---
+
+## 12. Decisions still required
+
+These are the currently identified decisions and governance records; discovery may add more before
+the PRD is Accepted.
+
+| ID | decision / recommended default | accountable owner | status | due | unresolved impact |
+|---|---|---|---|---|---|
+| D01 | Assignment ingress uses a new Project Assignment Requester ADR/REQ, not Agent Operations owner-DM authority | Matrix + Security owners | proposed | Phase 0 | no authorised staffing entry point |
+| D02 | Amend/supersede ADR-009 and REQ-PROJECT-BOARD for stable ProjectRef, Space and typed rooms | Matrix + HAFleet owners | proposed | Phase 0 | project identity/cost attribution cannot proceed |
+| D03 | HAFleet hold and router lease use a fail-closed saga; no cross-store atomicity claim | HAFleet + Router owners | proposed | Phase 0 | capacity can leak or double-book across restart |
+| D04 | Per-dispatch at-most-once, outcome inspection and rework/recovery state tables are canonical | Router + Matrix owners | proposed | Phase 0 | recovery can violate fencing or lose acceptance evidence |
+| D05 | Support API and plan in the schema; enable only configured sources per deployment | PDU manager | proposed | Phase 1 | migration and cost capture scope uncertain |
+| D06 | Model shared capacity; isolation is a deployment policy; credential home is not a seat | PDU manager + Security | proposed | Phase 1 | commercial capacity is double-counted |
+| D07 | Choose production Codex transport from qualification/operational evidence; retain the other as trial until retired | Fleet operator | open | end Phase 1 | duplicate adapter/support burden |
+| D08 | One deployment currency and integer micros for MVP; CFO owns allocation/close, engineering owns measurement provenance | CFO + PDU manager | proposed | start Phase 3 | cost records cannot reconcile |
+| D09 | R20 uses allow-listed data classes, default off/local, policy retention and auditable deletion/pseudonymisation | Security owner | proposed | Phase 0 | privacy and ledger policies conflict |
+| D10 | Collect a 30-day controlled baseline, then approve task-class targets and commercial SLA | PDU manager + Product owner | open | Commercial GA | no defensible SLA or commercial launch |
+
+The following are proposed product decisions to approve with this PRD, not pre-existing governance:
+
+- Matrix/Robrix2 is the customer collaboration surface; HAFleet Dashboard is the internal workforce
+  and operator surface.
+- Project identity is stable and Space-aware; room is trace/binding context, not the canonical
+  project identifier.
+- Cost is allocated first to assignment/project/cost centre; room/thread remain trace dimensions.
+- Shared capacity is represented explicitly; credentials are not used as business identifiers.
+
+---
+
+## 13. Approval conditions
+
+This PRD may move from Draft to Accepted only when:
+
+1. The four target router/client-governance documents have immutable commits and are referenced in
+   the evidence baseline.
+2. A Project Assignment Requester ADR/REQ is Accepted; it does not reuse the Agent Operations
+   owner-DM grant or expose the fleet operator token.
+3. ADR-009 and REQ-PROJECT-BOARD are amended/superseded with ProjectRef/Space/typed-room migration,
+   compatibility and authorisation semantics.
+4. R0 schemas, request/assignment/task/dispatch/acceptance state mappings and per-dispatch recovery
+   semantics are Accepted by both `agent-chat` and Robrix2 owners.
+5. The HAFleet-hold/router-lease saga has a single source of truth for each resource, canonical
+   fixtures and restart/compensation tests.
+6. Credential/API-key handling and R20 data-flow/retention/deletion threat review are complete.
+7. Phase 0–3 acceptance-to-test ownership and estimates replace every `TBD before approval` entry.
+8. PDU MVP beta gates, controlled-pilot owner and Commercial GA reconciliation/SLA decisions are
+   named and dated.

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -67,6 +67,8 @@
   "settings.preferences.app.agent_chat.toggle": "Enable remote agent-chat support",
   "settings.preferences.app.agent_chat.description": "Adds the /create-issue, /go, /review and /status workflow slash-commands in rooms that contain a coordinator agent (e.g. wf_coordinator). Requires a build with the 'agent_chat' Cargo feature.",
   "settings.preferences.app.popup.updated_agent_chat": "Agent-chat support setting updated",
+  "settings.preferences.app.agent_ops.contract_notice": "Agent Operations is waiting for released, pinned, byte-verified agent-chat contract artifacts. Robrix does not collect or store a Dashboard token.",
+  "settings.preferences.app.agent_ops.open_status": "View Agent Operations integration status",
   "settings.preferences.app.thumbnail.label": "Maximum Height of Thumbnails",
   "settings.preferences.app.thumbnail.option.small": "Small (200 pixels, default)",
   "settings.preferences.app.thumbnail.option.medium": "Medium (400 pixels)",
@@ -81,7 +83,6 @@
   "settings.preferences.app.popup.invalid_thumbnail_height": "Custom thumbnail height must be a positive whole number.",
   "language.option.english": "English",
   "language.option.chinese_simplified": "Simplified Chinese",
-
   "login.title.login_to_robrix": "Login to Robrix",
   "login.title.create_account": "Create your Robrix account",
   "login.input.user_id": "User ID",
@@ -158,7 +159,6 @@
   "login.status.cancel": "Cancel",
   "login_status_modal.title": "Login Status",
   "login_status_modal.button.cancel": "Cancel",
-
   "room_context_menu.button.mark_unread": "Mark as Unread",
   "room_context_menu.button.mark_read": "Mark as Read",
   "room_context_menu.button.favorite": "Favorite",
@@ -178,7 +178,6 @@
   "room_context_menu.popup.removing_botfather": "Removing BotFather {bot_user_id} from this room...",
   "room_context_menu.popup.inviting_botfather": "Inviting BotFather {bot_user_id} into this room...",
   "room_context_menu.popup.bot_settings_unavailable": "Bot settings are unavailable right now.",
-
   "bot_binding_modal.title": "Manage Room Bots",
   "bot_binding_modal.body": "Add or remove bots for {room_name}.",
   "bot_binding_modal.label.current_room_bots": "Current Room Bots",
@@ -202,7 +201,6 @@
   "bot_binding_modal.status.remark_requires_added_bot": "Add this bot to the room before saving a remark.",
   "bot_binding_modal.popup.inviting": "Adding bot {bot_user_id} to this room...",
   "bot_binding_modal.popup.removing": "Removing bot {bot_user_id} from this room...",
-
   "account_menu.badge.active": "Active",
   "account_menu.item.add_account": "Log Into More Accounts",
   "account_menu.item.settings": "Account Settings",
@@ -320,7 +318,6 @@
   "add_room.word.verb.joined": "fully joined",
   "add_room.word.adj.invited": "invited",
   "add_room.word.adj.joined": "joined",
-
   "settings.account.title": "Account Settings",
   "settings.account.section.your_avatar": "Your Avatar:",
   "settings.account.section.your_display_name": "Your Display Name:",
@@ -384,7 +381,6 @@
   "settings.account.verification.unverified_hint": "Verify it from another client using this info:",
   "settings.account.verification.device_info.with_session": "Session: \"{session_name}\",  Device ID: {device_id}",
   "settings.account.verification.device_info.device_only": "Device ID: {device_id}",
-
   "settings.labs.app_service.title": "App Service",
   "settings.labs.app_service.description": "Enable Matrix app service support here. ",
   "settings.labs.app_service.enable_label": "Enable App Service",
@@ -420,7 +416,6 @@
   "settings.labs.agents.framework.octos_direct.name": "Octos (Direct)",
   "settings.labs.agents.framework.octos_direct.tag": "DIRECT AGENT",
   "settings.labs.agents.framework.octos_direct.blurb": "Octos, added as a Matrix friend.",
-
   "settings.labs.translation.title": "Real-time Translation",
   "settings.labs.translation.description": "Configure an OpenAI-compatible API for real-time message translation in the input bar.",
   "settings.labs.translation.status.enabled": "Enabled",
@@ -435,7 +430,6 @@
   "settings.labs.translation.test.ok": "OK: {result}",
   "settings.labs.translation.test.failed": "Failed: {error}",
   "settings.labs.translation.test.error": "Error: {error}",
-
   "room_input_bar.input.placeholder": "Write a message (in Markdown) ...",
   "room_input_bar.translation.preview.apply": "Apply",
   "room_input_bar.translation.preview.idle": "Start typing to translate...",
@@ -448,7 +442,6 @@
   "room_input_bar.target.reply_bot": "Reply → {display_name}",
   "room_input_bar.target.menu.bound_bot": "{display_name}",
   "room_input_bar.target.menu.room": "To room",
-
   "invite_screen.message.invited_by": "has invited you to join:",
   "invite_screen.message.invited_generic": "You have been invited to join:",
   "invite_screen.button.reject": "Reject Invite",
@@ -481,7 +474,6 @@
   "invite_modal.status.invalid_user_id": "Invalid User ID. Expected format: @user:server.xyz",
   "invite_modal.status.success_invited": "Successfully invited {user_id}!",
   "invite_modal.status.send_failed": "Failed to send invite: {error}",
-
   "join_leave_modal.button.cancel": "Cancel",
   "join_leave_modal.button.yes": "Yes",
   "join_leave_modal.button.okay": "Okay",
@@ -533,24 +525,20 @@
   "join_leave_modal.title.confirm_leave_space": "Leave this space?",
   "join_leave_modal.description.confirm_leave_space": "Are you sure you want to leave \"{room_name}\"?\n\nIf you leave this space, you will also leave any joined rooms within this space.\n\nIf this is a private space, you won't be able to join this space without being re-invited to it.",
   "join_leave_modal.tip.with_button": "Tip: hold Shift when clicking the \"{button_text}\" button to bypass this prompt.",
-
   "rooms_list_entry.invited.by_name_and_user": "Invited by <b>{display_name}</b> ({user_id})",
   "rooms_list_entry.invited.by_user": "Invited by {user_id}",
   "rooms_list_entry.invited.generic": "You were invited",
-
   "loading_pane.title.default": "Loading content...",
   "loading_pane.title.searching_older": "Searching older messages...",
   "loading_pane.status.searching_event": "Looking for event {target_event_id}\n\nFetched {events_paginated} messages so far...",
   "loading_pane.title.error": "Error loading content",
   "loading_pane.button.cancel": "Cancel",
   "loading_pane.button.okay": "Okay",
-
   "rooms_list_header.title.all_rooms": "All Rooms",
   "rooms_list_header.popup.offline": "Cannot reach the Matrix homeserver. Please check your connection.",
   "rooms_list_header.tooltip.syncing": "Syncing...",
   "rooms_list_header.tooltip.offline": "Offline",
   "rooms_list_header.tooltip.synced": "Fully synced",
-
   "room_filter_input.placeholder": "Filter rooms & spaces...",
   "search_messages.button.todo": "Search (TODO)",
   "search_messages.button.tooltip": "Search messages",
@@ -582,10 +570,8 @@
   "new_message_context_menu.button.view_source": "View Source",
   "new_message_context_menu.button.jump_related": "Jump to Related Event",
   "new_message_context_menu.button.delete": "Delete",
-
   "welcome_screen.title": "Welcome to Robrix!",
   "welcome_screen.body_html": "<p>Our Matrix client is under heavy development. Currently, you can access the rooms and spaces that you've joined in other clients.</p><p><br></p><p>But don't worry, we're constantly expanding the featureset of Robrix!</p><p><br></p><p>Look for the latest announcements in our Matrix channel:</p><p><b>#robrix:matrix.org</b></p>",
-
   "room_screen.bot.delete.error.empty_user_id": "Please enter the bot Matrix user ID to delete.",
   "room_screen.bot.delete.error.invalid_user_id": "Invalid Matrix user ID: {full_user_id}",
   "room_screen.bot.delete.error.current_user_unavailable": "Current user ID is unavailable, so the bot homeserver cannot be resolved.",
@@ -628,7 +614,7 @@
   "slash_command.deletebot.description": "Delete an existing bot",
   "slash_command.header": "Bot Commands",
   "slash_command.invitebot.description": "Invite a registered bot to this room",
-  "slash_command.invitebot.empty_hint": "No known bots \u2014 register one in Settings \u2192 Agents first",
+  "slash_command.invitebot.empty_hint": "No known bots — register one in Settings → Agents first",
   "slash_command.invitebot.all_present_hint": "All known bots are already in this room",
   "slash_command.listbots.description": "List all available bots",
   "slash_command.schedule.description": "Schedule a task in this chat",
@@ -662,7 +648,6 @@
   "room_screen.popup.message.forward_not_found": "Could not find a forwardable message in the timeline. Please try again.",
   "room_screen.popup.message.view_source_not_found": "Could not find message in timeline to view source.",
   "room_screen.popup.message.related_not_found": "Could not find related message or event in timeline.",
-
   "forward_modal.title": "Forward Message",
   "forward_modal.body": "Enter the destination Matrix room ID.",
   "forward_modal.input.destination_room_id": "!room:example.org",
@@ -733,7 +718,6 @@
   "room_screen.app_service.button.bot_help": "Bot Help",
   "room_screen.app_service.button.bots": "Bots",
   "room_screen.app_service.button.unbind": "Unbind",
-
   "spaces_bar.tooltip.unknown_space_name": "Unknown Space Name",
   "spaces_bar.status.none_matching": "Found no\nmatching spaces.",
   "spaces_bar.status.none_joined": "Found no\njoined spaces.",
@@ -743,7 +727,6 @@
   "spaces_bar.status.n_joined": "Found {count}\njoined spaces.",
   "spaces_bar.status.many_matching": "Found 99+\nmatching spaces.",
   "spaces_bar.status.many_joined": "Found 99+\njoined spaces.",
-
   "tsp.settings.title": "TSP Wallet Settings",
   "tsp.settings.section.active_identity": "Your active identity:",
   "tsp.settings.section.wallets": "Your Wallets:",
@@ -776,7 +759,6 @@
   "tsp.wallet_entry.modal.remove.body": "Are you sure you want to remove the wallet \"{wallet_name}\" from the list?\n\nThis won't delete the actual wallet file.",
   "tsp.wallet_entry.modal.remove.accept": "Remove",
   "tsp.wallet_entry.popup.delete_not_implemented": "Delete wallet feature is not yet implemented.",
-
   "app.room_filter.search_results_title": "Search Results",
   "app.room_filter.empty_hint": "Type to search rooms and spaces...",
   "app.room_filter.no_local_results": "No local results for \"{keywords}\". Choose a type below to search server.",
@@ -789,14 +771,12 @@
   "app.room_filter.remote.kind.people": "people",
   "app.room_filter.remote.kind.rooms": "rooms",
   "app.room_filter.remote.kind.spaces": "spaces",
-
   "rooms_list.category.invites": "Invites",
   "rooms_list.category.favorites": "Favorites",
   "rooms_list.category.rooms": "Rooms",
   "rooms_list.category.people": "People",
   "rooms_list.category.low_priority": "Low Priority",
   "rooms_list.category.left_rooms": "Left Rooms",
-
   "space_lobby.entry.explore_space": "Explore this Space",
   "space_lobby.header.welcome": "Welcome to the space:",
   "space_lobby.header.public_space": "🌐  Public space",
@@ -820,5 +800,34 @@
   "space_lobby.item.member_one": "1 member",
   "space_lobby.item.member_n": "{count} members",
   "space_lobby.item.child_room_one": "~{count} room",
-  "space_lobby.item.child_room_n": "~{count} rooms"
+  "space_lobby.item.child_room_n": "~{count} rooms",
+  "agent_ops.title": "Agent Operations",
+  "agent_ops.status.contract_blocked": "Integration unavailable: canonical agent-chat client contract artifacts are not ready.",
+  "agent_ops.status.contract_next_step": "No Dashboard credential is requested and no backend operation is sent. Release, pin, and verify every io.agentchat.agent_ops.v1 artifact before building the runtime.",
+  "agent_ops.status.no_manifest": "The agent-chat client contract manifest is missing, so the panel stays closed.",
+  "agent_ops.status.unreadable_manifest": "The agent-chat client contract manifest could not be read, so nothing about it can be trusted.",
+  "agent_ops.status.contract_mismatch": "The bundled manifest describes a different contract than this client speaks.",
+  "agent_ops.status.not_released": "The agent-chat client contract is implemented but not released; its artifacts can still change.",
+  "agent_ops.status.unbound_commit": "The contract is marked released but names no source commit, so its artifacts are still a moving target.",
+  "agent_ops.status.invalid_source_commit": "The contract source binding is not a full Git object ID.",
+  "agent_ops.status.empty_artifacts": "The contract manifest lists no artifacts, so there is nothing to verify against.",
+  "agent_ops.status.invalid_artifact_manifest": "The contract manifest contains an invalid artifact entry.",
+  "agent_ops.status.incomplete_artifact_manifest": "The contract manifest is missing required V1 artifacts.",
+  "agent_ops.status.artifact_set_mismatch": "The compiled artifact set does not match the contract manifest.",
+  "agent_ops.status.artifact_digest_mismatch": "A compiled artifact failed SHA-256 verification.",
+  "agent_ops.status.contract_ready": "The agent-chat client contract artifacts are pinned and verified.",
+  "agent_ops.detail.no_manifest": "No contract manifest was compiled into this build.",
+  "agent_ops.detail.unreadable_manifest": "The compiled manifest could not be parsed, so none of its claims are trusted.",
+  "agent_ops.detail.contract_mismatch": "This client speaks {expected}, but the manifest describes {found}.",
+  "agent_ops.detail.not_released": "The manifest release status is {release_status}; only released artifacts may be consumed.",
+  "agent_ops.detail.unbound_commit": "A released manifest must identify the immutable source commit that produced its artifacts.",
+  "agent_ops.detail.invalid_source_commit": "The source commit must be a complete lowercase 40- or 64-character hexadecimal Git object ID.",
+  "agent_ops.detail.empty_artifacts": "A manifest with no artifacts cannot define a consumable client contract.",
+  "agent_ops.detail.invalid_artifact_manifest": "Artifact paths must be safe relative paths, SHA-256 values must be lowercase hexadecimal, and paths must be unique.",
+  "agent_ops.detail.incomplete_artifact_manifest": "The manifest omits {missing_count} artifacts required by io.agentchat.agent_ops.v1.",
+  "agent_ops.detail.artifact_set_mismatch": "Compared with the manifest, this build has {missing_count} missing artifacts and {unexpected_count} unexpected artifacts.",
+  "agent_ops.detail.artifact_digest_mismatch": "The compiled bytes for {path} do not match agent-chat's published digest.",
+  "agent_ops.detail.contract_ready": "All {artifact_count} artifact digests match the contract released from {source_commit}.",
+  "agent_ops.status.next_step_release": "Robrix requests no credential and sends no backend operation while this gate is closed. Re-vendor the released manifest and every matching canonical artifact from agent-chat.",
+  "agent_ops.status.next_step_runtime": "Contract readiness does not mean connected. Implement and validate client bootstrap, authentication, transport, and the four operational views before enabling a canary."
 }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -528,6 +528,10 @@
   "rooms_list_entry.invited.by_name_and_user": "Invited by <b>{display_name}</b> ({user_id})",
   "rooms_list_entry.invited.by_user": "Invited by {user_id}",
   "rooms_list_entry.invited.generic": "You were invited",
+  "rooms_list_entry.invited.space.by_name_and_user": "Space invite from <b>{display_name}</b> ({user_id})",
+  "rooms_list_entry.invited.space.by_user": "Space invite from {user_id}",
+  "rooms_list_entry.invited.space.generic": "You were invited to a space",
+
   "loading_pane.title.default": "Loading content...",
   "loading_pane.title.searching_older": "Searching older messages...",
   "loading_pane.status.searching_event": "Looking for event {target_event_id}\n\nFetched {events_paginated} messages so far...",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -610,6 +610,7 @@
   "slash_command.go.description": "Run an issue end to end: plan → implement → review → final review",
   "slash_command.review.description": "Re-run the review + Codex final review for an issue",
   "slash_command.status.description": "Show the workflow status of all issues",
+  "slash_command.thread.description": "Configure this thread's agent session: model <name|default> or mode <plan|auto>",
   "slash_command.workflow_header": "Workflow Commands",
   "slash_command.deletebot.description": "Delete an existing bot",
   "slash_command.header": "Bot Commands",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -67,6 +67,8 @@
   "settings.preferences.app.agent_chat.toggle": "启用远程 agent-chat 支持",
   "settings.preferences.app.agent_chat.description": "在含有 coordinator agent（如 wf_coordinator）的房间里提供 /create-issue、/go、/review、/status 工作流斜杠命令。需要用 'agent_chat' Cargo feature 构建。",
   "settings.preferences.app.popup.updated_agent_chat": "已更新 agent-chat 支持设置",
+  "settings.preferences.app.agent_ops.contract_notice": "Agent Operations 正在等待 agent-chat 发布、绑定并通过逐字节校验的合同产物。Robrix 不采集、也不保存 Dashboard Token。",
+  "settings.preferences.app.agent_ops.open_status": "查看 Agent Operations 集成状态",
   "settings.preferences.app.thumbnail.label": "缩略图最大高度",
   "settings.preferences.app.thumbnail.option.small": "小（200 像素，默认）",
   "settings.preferences.app.thumbnail.option.medium": "中（400 像素）",
@@ -81,7 +83,6 @@
   "settings.preferences.app.popup.invalid_thumbnail_height": "自定义缩略图高度必须是正整数。",
   "language.option.english": "English",
   "language.option.chinese_simplified": "简体中文",
-
   "login.title.login_to_robrix": "登录 Robrix",
   "login.title.create_account": "创建你的 Robrix 账号",
   "login.input.user_id": "用户 ID",
@@ -158,7 +159,6 @@
   "login.status.cancel": "取消",
   "login_status_modal.title": "登录状态",
   "login_status_modal.button.cancel": "取消",
-
   "room_context_menu.button.mark_unread": "标记为未读",
   "room_context_menu.button.mark_read": "标记为已读",
   "room_context_menu.button.favorite": "收藏",
@@ -178,7 +178,6 @@
   "room_context_menu.popup.removing_botfather": "正在将 BotFather {bot_user_id} 从该房间移除...",
   "room_context_menu.popup.inviting_botfather": "正在邀请 BotFather {bot_user_id} 加入该房间...",
   "room_context_menu.popup.bot_settings_unavailable": "当前无法获取机器人设置。",
-
   "bot_binding_modal.title": "管理房间机器人",
   "bot_binding_modal.body": "为 {room_name} 添加或移除机器人。",
   "bot_binding_modal.label.current_room_bots": "当前房间机器人",
@@ -202,7 +201,6 @@
   "bot_binding_modal.status.remark_requires_added_bot": "请先将该机器人添加到房间，再保存备注。",
   "bot_binding_modal.popup.inviting": "正在将机器人 {bot_user_id} 添加到该房间...",
   "bot_binding_modal.popup.removing": "正在将机器人 {bot_user_id} 从该房间移除...",
-
   "account_menu.badge.active": "当前",
   "account_menu.item.add_account": "登录更多账号",
   "account_menu.item.settings": "账号设置",
@@ -320,7 +318,6 @@
   "add_room.word.verb.joined": "完整加入",
   "add_room.word.adj.invited": "受邀",
   "add_room.word.adj.joined": "已加入",
-
   "settings.account.title": "账号设置",
   "settings.account.section.your_avatar": "你的头像：",
   "settings.account.section.your_display_name": "你的显示名称：",
@@ -384,7 +381,6 @@
   "settings.account.verification.unverified_hint": "请在其他客户端中使用以下信息完成验证：",
   "settings.account.verification.device_info.with_session": "会话：\"{session_name}\"，设备 ID：{device_id}",
   "settings.account.verification.device_info.device_only": "设备 ID：{device_id}",
-
   "settings.labs.app_service.title": "应用服务",
   "settings.labs.app_service.description": "在这里启用 Matrix 应用服务支持。",
   "settings.labs.app_service.enable_label": "启用应用服务",
@@ -420,7 +416,6 @@
   "settings.labs.agents.framework.octos_direct.name": "Octos (Direct)",
   "settings.labs.agents.framework.octos_direct.tag": "直接 Agent",
   "settings.labs.agents.framework.octos_direct.blurb": "Octos, 作为 Matrix 好友直接添加。",
-
   "settings.labs.translation.title": "实时翻译",
   "settings.labs.translation.description": "在输入栏中配置兼容 OpenAI API 的实时消息翻译服务。",
   "settings.labs.translation.status.enabled": "已启用",
@@ -435,7 +430,6 @@
   "settings.labs.translation.test.ok": "成功：{result}",
   "settings.labs.translation.test.failed": "失败：{error}",
   "settings.labs.translation.test.error": "错误：{error}",
-
   "room_input_bar.input.placeholder": "输入消息（支持 Markdown）...",
   "room_input_bar.translation.preview.apply": "应用",
   "room_input_bar.translation.preview.idle": "开始输入即可翻译...",
@@ -448,7 +442,6 @@
   "room_input_bar.target.reply_bot": "回复 → {display_name}",
   "room_input_bar.target.menu.bound_bot": "{display_name}",
   "room_input_bar.target.menu.room": "发到房间",
-
   "invite_screen.message.invited_by": "邀请你加入：",
   "invite_screen.message.invited_generic": "你被邀请加入：",
   "invite_screen.button.reject": "拒绝邀请",
@@ -535,20 +528,17 @@
   "rooms_list_entry.invited.by_name_and_user": "由 <b>{display_name}</b> ({user_id}) 邀请",
   "rooms_list_entry.invited.by_user": "由 {user_id} 邀请",
   "rooms_list_entry.invited.generic": "你收到了邀请",
-
   "loading_pane.title.default": "正在加载内容...",
   "loading_pane.title.searching_older": "正在搜索更早的消息...",
   "loading_pane.status.searching_event": "正在查找事件 {target_event_id}\n\n目前已拉取 {events_paginated} 条消息...",
   "loading_pane.title.error": "内容加载失败",
   "loading_pane.button.cancel": "取消",
   "loading_pane.button.okay": "确定",
-
   "rooms_list_header.title.all_rooms": "全部房间",
   "rooms_list_header.popup.offline": "无法连接 Matrix 服务器，请检查网络连接。",
   "rooms_list_header.tooltip.syncing": "同步中...",
   "rooms_list_header.tooltip.offline": "离线",
   "rooms_list_header.tooltip.synced": "已完全同步",
-
   "room_filter_input.placeholder": "筛选房间与空间...",
   "search_messages.button.todo": "搜索（待实现）",
   "search_messages.button.tooltip": "搜索消息",
@@ -580,10 +570,8 @@
   "new_message_context_menu.button.view_source": "查看源码",
   "new_message_context_menu.button.jump_related": "跳转到关联事件",
   "new_message_context_menu.button.delete": "删除",
-
   "welcome_screen.title": "欢迎来到 Robrix！",
   "welcome_screen.body_html": "<p>我们的 Matrix 客户端仍在快速开发中。目前，你可以访问你在其他客户端中已加入的房间和空间。</p><p><br></p><p>不过别担心，我们正在持续扩展 Robrix 的功能！</p><p><br></p><p>欢迎在我们的 Matrix 频道查看最新公告：</p><p><b>#robrix:matrix.org</b></p>",
-
   "room_screen.bot.delete.error.empty_user_id": "请输入要删除的机器人 Matrix 用户 ID。",
   "room_screen.bot.delete.error.invalid_user_id": "无效的 Matrix 用户 ID：{full_user_id}",
   "room_screen.bot.delete.error.current_user_unavailable": "当前用户 ID 不可用，无法解析机器人的 homeserver。",
@@ -626,7 +614,7 @@
   "slash_command.deletebot.description": "删除一个已有的 Bot",
   "slash_command.header": "Bot 命令",
   "slash_command.invitebot.description": "邀请一个已注册的 Bot 加入本房间",
-  "slash_command.invitebot.empty_hint": "暂无已知 Bot——请先在 设置 \u2192 Agents 中注册",
+  "slash_command.invitebot.empty_hint": "暂无已知 Bot——请先在 设置 → Agents 中注册",
   "slash_command.invitebot.all_present_hint": "所有已知 Bot 都已在本房间中",
   "slash_command.listbots.description": "列出所有可用的 Bot",
   "slash_command.schedule.description": "在当前聊天中安排任务",
@@ -660,7 +648,6 @@
   "room_screen.popup.message.forward_not_found": "在时间线中找不到可转发的消息，请重试。",
   "room_screen.popup.message.view_source_not_found": "在时间线中找不到要查看源码的消息。",
   "room_screen.popup.message.related_not_found": "在时间线中找不到关联消息或事件。",
-
   "forward_modal.title": "转发消息",
   "forward_modal.body": "请输入目标 Matrix 房间 ID。",
   "forward_modal.input.destination_room_id": "!room:example.org",
@@ -731,7 +718,6 @@
   "room_screen.app_service.button.bot_help": "Bot 帮助",
   "room_screen.app_service.button.bots": "机器人",
   "room_screen.app_service.button.unbind": "解绑",
-
   "spaces_bar.tooltip.unknown_space_name": "未知空间名称",
   "spaces_bar.status.none_matching": "未找到\n匹配的空间。",
   "spaces_bar.status.none_joined": "未找到\n已加入的空间。",
@@ -741,7 +727,6 @@
   "spaces_bar.status.n_joined": "找到 {count} 个\n已加入的空间。",
   "spaces_bar.status.many_matching": "找到 99+ 个\n匹配的空间。",
   "spaces_bar.status.many_joined": "找到 99+ 个\n已加入的空间。",
-
   "tsp.settings.title": "TSP 钱包设置",
   "tsp.settings.section.active_identity": "当前活跃身份：",
   "tsp.settings.section.wallets": "你的钱包：",
@@ -774,7 +759,6 @@
   "tsp.wallet_entry.modal.remove.body": "确认要将钱包“{wallet_name}”从列表中移除吗？\n\n这不会删除实际的钱包文件。",
   "tsp.wallet_entry.modal.remove.accept": "移除",
   "tsp.wallet_entry.popup.delete_not_implemented": "删除钱包功能暂未实现。",
-
   "app.room_filter.search_results_title": "搜索结果",
   "app.room_filter.empty_hint": "输入关键词以搜索房间和空间...",
   "app.room_filter.no_local_results": "本地未找到“{keywords}”相关结果。请选择下方类型以搜索服务器。",
@@ -787,14 +771,12 @@
   "app.room_filter.remote.kind.people": "联系人",
   "app.room_filter.remote.kind.rooms": "房间",
   "app.room_filter.remote.kind.spaces": "空间",
-
   "rooms_list.category.invites": "邀请",
   "rooms_list.category.favorites": "收藏",
   "rooms_list.category.rooms": "房间",
   "rooms_list.category.people": "联系人",
   "rooms_list.category.low_priority": "低优先级",
   "rooms_list.category.left_rooms": "已离开房间",
-
   "space_lobby.entry.explore_space": "探索此空间",
   "space_lobby.header.welcome": "欢迎来到此空间：",
   "space_lobby.header.public_space": "🌐  公开空间",
@@ -818,5 +800,34 @@
   "space_lobby.item.member_one": "1 位成员",
   "space_lobby.item.member_n": "{count} 位成员",
   "space_lobby.item.child_room_one": "~{count} 个房间",
-  "space_lobby.item.child_room_n": "~{count} 个房间"
+  "space_lobby.item.child_room_n": "~{count} 个房间",
+  "agent_ops.title": "Agent 操作",
+  "agent_ops.status.contract_blocked": "集成暂不可用：agent-chat canonical 客户端合同产物尚未就绪。",
+  "agent_ops.status.contract_next_step": "Robrix 不会请求 Dashboard 凭据，也不会发送后台操作。构建运行时前，须发布、绑定并校验全部 io.agentchat.agent_ops.v1 产物。",
+  "agent_ops.status.no_manifest": "缺少 agent-chat 客户端合同清单，面板保持关闭。",
+  "agent_ops.status.unreadable_manifest": "无法读取 agent-chat 客户端合同清单，其内容不可信，面板保持关闭。",
+  "agent_ops.status.contract_mismatch": "随附的清单描述的合同与本客户端所用的不一致。",
+  "agent_ops.status.not_released": "agent-chat 客户端合同已实现但尚未发布，其产物仍可能变化。",
+  "agent_ops.status.unbound_commit": "合同标记为已发布但未指明来源 commit，产物仍是移动目标。",
+  "agent_ops.status.invalid_source_commit": "合同的来源绑定不是完整的 Git 对象 ID。",
+  "agent_ops.status.empty_artifacts": "合同清单未列出任何产物，没有可供校验的对象。",
+  "agent_ops.status.invalid_artifact_manifest": "合同清单包含无效的产物条目。",
+  "agent_ops.status.incomplete_artifact_manifest": "合同清单缺少 V1 必需产物。",
+  "agent_ops.status.artifact_set_mismatch": "编译进客户端的产物集合与合同清单不一致。",
+  "agent_ops.status.artifact_digest_mismatch": "编译进客户端的产物未通过 SHA-256 校验。",
+  "agent_ops.status.contract_ready": "agent-chat 客户端合同产物已固定并通过校验。",
+  "agent_ops.detail.no_manifest": "当前构建没有编译进合同清单。",
+  "agent_ops.detail.unreadable_manifest": "无法解析编译进客户端的清单，因此不会信任其中的任何声明。",
+  "agent_ops.detail.contract_mismatch": "本客户端使用 {expected}，但清单描述的是 {found}。",
+  "agent_ops.detail.not_released": "清单的发布状态为 {release_status}；只有已发布产物才能被使用。",
+  "agent_ops.detail.unbound_commit": "已发布清单必须指明生成这些产物的不可变来源 commit。",
+  "agent_ops.detail.invalid_source_commit": "来源 commit 必须是完整的小写十六进制 Git 对象 ID，长度为 40 或 64 个字符。",
+  "agent_ops.detail.empty_artifacts": "不含产物的清单无法定义可供客户端使用的合同。",
+  "agent_ops.detail.invalid_artifact_manifest": "产物路径必须是安全的相对路径，SHA-256 必须为小写十六进制，且路径不得重复。",
+  "agent_ops.detail.incomplete_artifact_manifest": "清单缺少 io.agentchat.agent_ops.v1 要求的 {missing_count} 个产物。",
+  "agent_ops.detail.artifact_set_mismatch": "与清单相比，当前构建缺少 {missing_count} 个产物，并多出 {unexpected_count} 个产物。",
+  "agent_ops.detail.artifact_digest_mismatch": "编译进客户端的 {path} 与 agent-chat 发布的摘要不一致。",
+  "agent_ops.detail.contract_ready": "共 {artifact_count} 个产物摘要均与来源 commit {source_commit} 发布的合同一致。",
+  "agent_ops.status.next_step_release": "闸门关闭期间，Robrix 不请求任何凭据，也不发送后台操作。请从 agent-chat 重新同步已发布清单及全部匹配的 canonical 产物。",
+  "agent_ops.status.next_step_runtime": "合同就绪不等于已连接。启用 canary 前，仍须实现并验证客户端 bootstrap、鉴权、传输和四个操作视图。"
 }

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -610,6 +610,7 @@
   "slash_command.go.description": "端到端执行 issue：plan → implement → review → 终审",
   "slash_command.review.description": "重跑评审 + Codex 终审",
   "slash_command.status.description": "显示所有 issue 的工作流状态",
+  "slash_command.thread.description": "配置本 thread 的 agent 会话：model <名称|default> 或 mode <plan|auto>",
   "slash_command.workflow_header": "工作流命令",
   "slash_command.deletebot.description": "删除一个已有的 Bot",
   "slash_command.header": "Bot 命令",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -528,6 +528,10 @@
   "rooms_list_entry.invited.by_name_and_user": "由 <b>{display_name}</b> ({user_id}) 邀请",
   "rooms_list_entry.invited.by_user": "由 {user_id} 邀请",
   "rooms_list_entry.invited.generic": "你收到了邀请",
+  "rooms_list_entry.invited.space.by_name_and_user": "<b>{display_name}</b> ({user_id}) 邀请你加入空间",
+  "rooms_list_entry.invited.space.by_user": "{user_id} 邀请你加入空间",
+  "rooms_list_entry.invited.space.generic": "你收到了空间邀请",
+
   "loading_pane.title.default": "正在加载内容...",
   "loading_pane.title.searching_older": "正在搜索更早的消息...",
   "loading_pane.status.searching_event": "正在查找事件 {target_event_id}\n\n目前已拉取 {events_paginated} 条消息...",

--- a/specs/fixtures/agent-ops-client-v1-proposal/invalid-resolve-outcome-request-accept-with-recovery.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/invalid-resolve-outcome-request-accept-with-recovery.json
@@ -1,0 +1,27 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "request_id": "request-invalid-resolution-accept",
+  "client_session_id": "server-session-invalid",
+  "scope_id": "scope-room-agent-1",
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "snapshot_seq": 42,
+  "action_capability": "fixture-action-capability-resolution-invalid",
+  "target": {
+    "entity_kind": "dispatch",
+    "entity_id": "dispatch-invalid",
+    "entity_version": 7
+  },
+  "resource_precondition": {
+    "resource_id": "resource-invalid",
+    "dirty_generation": 2
+  },
+  "inspection_id": "inspection-invalid",
+  "inspection_token": "fixture-inspection-token-invalid",
+  "operator_note": "This fixture must be rejected",
+  "resolution": {
+    "kind": "accept_completed",
+    "recovery_instruction": "This field is forbidden for terminal resolutions"
+  }
+}

--- a/specs/fixtures/agent-ops-client-v1-proposal/invalidation.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/invalidation.json
@@ -1,0 +1,8 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "scope_id": "scope-room-agent-1",
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "seq": 43
+}

--- a/specs/fixtures/agent-ops-client-v1-proposal/outcome-inspection.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/outcome-inspection.json
@@ -1,0 +1,47 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "scope_id": "scope-room-agent-1",
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "snapshot_seq": 42,
+  "client_session_id": "server-session-1",
+  "inspection_id": "inspection-1",
+  "inspection_token": "fixture-inspection-token",
+  "dispatch_target": {
+    "entity_kind": "dispatch",
+    "entity_id": "dispatch-1",
+    "entity_version": 7
+  },
+  "task_id": "task-1",
+  "terminal_reason": "runner process exited before final outcome was confirmed",
+  "expires_at_unix_ms": 1785947100000,
+  "resource": {
+    "resource_id": "resource-1",
+    "entity_version": 9,
+    "dirty_generation": 2,
+    "label": "robrix2 · task-1",
+    "branch": "agentchat/task-1",
+    "dirty_reason": "runner exited after work may have been applied"
+  },
+  "resolution_action": {
+    "action_id": "action-resolve-1",
+    "kind": "resolve_outcome",
+    "target": {
+      "entity_kind": "dispatch",
+      "entity_id": "dispatch-1",
+      "entity_version": 7
+    },
+    "resource_precondition": {
+      "resource_id": "resource-1",
+      "dirty_generation": 2
+    },
+    "allowed_resolutions": [
+      "continue",
+      "accept_completed",
+      "keep_blocked"
+    ],
+    "expires_at_unix_ms": 1785947100000,
+    "capability": "fixture-action-capability-resolution"
+  }
+}

--- a/specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-accept-completed.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-accept-completed.json
@@ -1,0 +1,26 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "request_id": "request-resolution-accept",
+  "client_session_id": "server-session-accept",
+  "scope_id": "scope-room-agent-1",
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "snapshot_seq": 42,
+  "action_capability": "fixture-action-capability-resolution-accept",
+  "target": {
+    "entity_kind": "dispatch",
+    "entity_id": "dispatch-accept",
+    "entity_version": 7
+  },
+  "resource_precondition": {
+    "resource_id": "resource-accept",
+    "dirty_generation": 2
+  },
+  "inspection_id": "inspection-accept",
+  "inspection_token": "fixture-inspection-token-accept",
+  "operator_note": "The inspected result is complete and requires no recovery dispatch",
+  "resolution": {
+    "kind": "accept_completed"
+  }
+}

--- a/specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-continue.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-continue.json
@@ -1,0 +1,27 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "request_id": "request-resolution-continue",
+  "client_session_id": "server-session-continue",
+  "scope_id": "scope-room-agent-1",
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "snapshot_seq": 42,
+  "action_capability": "fixture-action-capability-resolution-continue",
+  "target": {
+    "entity_kind": "dispatch",
+    "entity_id": "dispatch-continue",
+    "entity_version": 7
+  },
+  "resource_precondition": {
+    "resource_id": "resource-continue",
+    "dirty_generation": 2
+  },
+  "inspection_id": "inspection-continue",
+  "inspection_token": "fixture-inspection-token-continue",
+  "operator_note": "The partial changes are understood and can be continued safely",
+  "resolution": {
+    "kind": "continue",
+    "recovery_instruction": "Continue from the inspected changes and run the focused tests"
+  }
+}

--- a/specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-keep-blocked.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-keep-blocked.json
@@ -1,0 +1,26 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "request_id": "request-resolution-blocked",
+  "client_session_id": "server-session-blocked",
+  "scope_id": "scope-room-agent-1",
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "snapshot_seq": 42,
+  "action_capability": "fixture-action-capability-resolution-blocked",
+  "target": {
+    "entity_kind": "dispatch",
+    "entity_id": "dispatch-blocked",
+    "entity_version": 7
+  },
+  "resource_precondition": {
+    "resource_id": "resource-blocked",
+    "dirty_generation": 2
+  },
+  "inspection_id": "inspection-blocked",
+  "inspection_token": "fixture-inspection-token-blocked",
+  "operator_note": "The result is understood but the task must remain blocked for follow-up",
+  "resolution": {
+    "kind": "keep_blocked"
+  }
+}

--- a/specs/fixtures/agent-ops-client-v1-proposal/snapshot.json
+++ b/specs/fixtures/agent-ops-client-v1-proposal/snapshot.json
@@ -1,0 +1,135 @@
+{
+  "schema": "io.robrix.agent_ops.proposal.r3",
+  "scope": {
+    "scope_id": "scope-room-agent-1",
+    "project_room_id": "!project-room:example.org",
+    "agent_id": "reviewer",
+    "owner_mxid": "@owner:example.org",
+    "owner_dm_room_id": "!owner-room:example.org"
+  },
+  "projection_id": "projection-1",
+  "stream_epoch": "bb47bc6e-9f02-41df-90f6-8bb83b924b88",
+  "auth_fence_generation": 3,
+  "seq": 42,
+  "attention": [
+    {
+      "id": "attention-1",
+      "kind": "outcome_unknown",
+      "summary": "Runner outcome is unknown; inspect the workspace",
+      "task_id": "task-1",
+      "dispatch_id": "dispatch-1",
+      "resource_id": "resource-1",
+      "agent": "reviewer",
+      "waiting_ms": 61000,
+      "thread": {
+        "room_id": "!owner-room:example.org",
+        "thread_root_event_id": "$task-thread:example.org"
+      },
+      "available_actions": [
+        {
+          "action_id": "action-inspect-1",
+          "kind": "begin_outcome_inspection",
+          "target": {
+            "entity_kind": "dispatch",
+            "entity_id": "dispatch-1",
+            "entity_version": 7
+          },
+          "resource_precondition": {
+            "resource_id": "resource-1",
+            "dirty_generation": 2
+          },
+          "expires_at_unix_ms": 1785946500000,
+          "capability": "fixture-action-capability-inspect"
+        }
+      ]
+    },
+    {
+      "id": "attention-2",
+      "kind": "workspace_dirty",
+      "summary": "Released workspace has uncommitted changes",
+      "task_id": "task-2",
+      "resource_id": "resource-2",
+      "available_actions": [
+        {
+          "action_id": "action-resource-2",
+          "kind": "mark_resource_inspected",
+          "target": {
+            "entity_kind": "resource",
+            "entity_id": "resource-2",
+            "entity_version": 4
+          },
+          "resource_precondition": {
+            "resource_id": "resource-2",
+            "dirty_generation": 1
+          },
+          "expires_at_unix_ms": 1785946500000,
+          "capability": "fixture-action-capability-resource"
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "task-1",
+      "entity_version": 5,
+      "title": "Review Agent Operations contract",
+      "agent": "reviewer",
+      "state": "blocked",
+      "dispatch_state": "outcome_unknown",
+      "elapsed_ms": 125000,
+      "thread": {
+        "room_id": "!owner-room:example.org",
+        "thread_root_event_id": "$task-thread:example.org"
+      }
+    }
+  ],
+  "queue": [
+    {
+      "dispatch_id": "dispatch-2",
+      "entity_version": 3,
+      "task_id": "task-2",
+      "agent": "implementer",
+      "state": "queued",
+      "waiting_on": "shared workspace lease",
+      "held_by_dispatch_id": "dispatch-3"
+    }
+  ],
+  "worktrees": [
+    {
+      "resource_id": "resource-1",
+      "entity_version": 9,
+      "label": "robrix2 · task-1",
+      "branch": "agentchat/task-1",
+      "dirty": true,
+      "dirty_generation": 2,
+      "task_id": "task-1",
+      "available_actions": []
+    },
+    {
+      "resource_id": "resource-2",
+      "entity_version": 4,
+      "label": "robrix2 · task-2",
+      "branch": "agentchat/task-2",
+      "dirty": true,
+      "dirty_generation": 1,
+      "task_id": "task-2",
+      "available_actions": [
+        {
+          "action_id": "action-resource-2",
+          "kind": "mark_resource_inspected",
+          "target": {
+            "entity_kind": "resource",
+            "entity_id": "resource-2",
+            "entity_version": 4
+          },
+          "resource_precondition": {
+            "resource_id": "resource-2",
+            "dirty_generation": 1
+          },
+          "expires_at_unix_ms": 1785946500000,
+          "capability": "fixture-action-capability-resource"
+        }
+      ]
+    }
+  ]
+}

--- a/specs/fixtures/agent-ops-client-v1/manifest.json
+++ b/specs/fixtures/agent-ops-client-v1/manifest.json
@@ -1,0 +1,87 @@
+{
+  "contract": "io.agentchat.agent_ops.v1",
+  "release_status": "development",
+  "source_commit": null,
+  "artifacts": [
+    {
+      "path": "cancel-dispatch-response.json",
+      "sha256": "6bd224e94f9cefad13710d8d889b0b810b6685b9db02dbfc1409db419bd126cf"
+    },
+    {
+      "path": "client-session-grant.json",
+      "sha256": "561fc4f5f209078e79ebacb53e5c5b8a945e86ea6e97b1ddc721a26c38c189c4"
+    },
+    {
+      "path": "client-session-request.json",
+      "sha256": "a4c219b10b04e98a721fd6b16d91780edf106fd94dc7bbd64916965318e9bc2e"
+    },
+    {
+      "path": "client-session.json",
+      "sha256": "25446426f9ad025f5d3246c819a4716df714a1c1cba5cd8d5f7ae90e2f9cdb77"
+    },
+    {
+      "path": "contract.schema.json",
+      "sha256": "a463dcba08fe0a07067a2e1b2355276835d0eca8f0ea44937c0b08dccd054aba"
+    },
+    {
+      "path": "error-precondition-failed.json",
+      "sha256": "4046a401d6d371488e4adece124fefbc69a68c3b3e23516fd78b6f2a8b477bba"
+    },
+    {
+      "path": "grant-exchange-request.json",
+      "sha256": "ff29ad94d5195881ab46d8b36166f5b9d1958c29863b49bf8bc426543511a602"
+    },
+    {
+      "path": "grant-proof-material.json",
+      "sha256": "f86d496d4b904bc255c292c20312fc452fb831f70613dfd3f027500fc60ebe67"
+    },
+    {
+      "path": "invalid-empty-capability.json",
+      "sha256": "61ad91438c1109bd77d33fa58d03c2e536ae0a51f56fbfe92152f258a6edb092"
+    },
+    {
+      "path": "invalid-terminal-resolution-with-recovery.json",
+      "sha256": "d82cf0d68b9bb81ac876945cde6ace941980454eb5f7a24b24911c2982d7cce4"
+    },
+    {
+      "path": "invalidation.json",
+      "sha256": "5375afae21e612150f1adee5baf1bdcb313f284813a488c7a6bb918b98c1783b"
+    },
+    {
+      "path": "outcome-inspection.json",
+      "sha256": "40452eca93162e4cdc2d8c05d0bc398f178bf4a3339bd028b751d0eafc106f10"
+    },
+    {
+      "path": "protocol-limits.json",
+      "sha256": "956a380298ffd576f5b8ca008b4992c08befab6d1eddc1baa0be18c3adb02c75"
+    },
+    {
+      "path": "resolve-outcome-request-accept-completed.json",
+      "sha256": "73404a948dd15bfe52d9fb0024ec46f5edb1cc50e9c939377c05e6aa225ca76c"
+    },
+    {
+      "path": "resolve-outcome-request-continue.json",
+      "sha256": "4277104e0fb7f434c2c6a37fd6dc1848f8437b2c7be4b4b4a5801f7a169d3cda"
+    },
+    {
+      "path": "resolve-outcome-request-keep-blocked.json",
+      "sha256": "386d4bcdd7de125ef9e9d1fd45dd7a08e273115212d753599b6085a6f2348c6a"
+    },
+    {
+      "path": "resolve-outcome-response.json",
+      "sha256": "a04ab41eb9e687f0f7b9bc6bdce8939ae49e09ff0953f53bd9a76bcaccf85216"
+    },
+    {
+      "path": "session-proof-material.json",
+      "sha256": "c0979e6bbe9f757e9519626b0627ad463e6e5c4bc8c0f3744a9ba536203b051c"
+    },
+    {
+      "path": "snapshot.json",
+      "sha256": "aa043f86d6d0edbfc2ed20784cce3ea2be9a6b2628533fff62fa4d812ebfe718"
+    },
+    {
+      "path": "stable-errors.json",
+      "sha256": "3dee6ae037277d4d2713fc8e8d7bf9a52795506a2495c1181daadb1c0c925b19"
+    }
+  ]
+}

--- a/specs/task-agent-ops-panel.spec.md
+++ b/specs/task-agent-ops-panel.spec.md
@@ -1,0 +1,256 @@
+spec: task
+name: "Agent Operations Panel — Client Contract Gate"
+inherits: project
+tags: [feature, agent-chat, ops, security, contract]
+estimate: 3d
+---
+
+## Intent
+
+Robrix2 needs an Agent Operations Panel. agent-chat has supplied a development
+manifest for `io.agentchat.agent_ops.v1`, but it is not released, is not bound
+to an immutable source commit, and its canonical artifact bytes are not
+vendored into Robrix2. The client runtime is also not implemented. Keep the
+integration explicitly unavailable and fail closed while preserving a
+separate, test-only R3 model experiment for historical design review.
+
+## Decisions
+
+### Current Gate Decisions
+
+- The `agent_chat` feature may expose an integration-status screen, but it does
+  not expose operational rows or controls while the contract gate is closed.
+- Robrix2 does not collect, persist, log, or transmit the agent-chat Dashboard
+  token, router bearer, bridge secret, or any equivalent backend credential.
+- Robrix2 does not call the existing Dashboard `/api/router/*` endpoints. Those
+  endpoints are not a supported Robrix2 client API.
+- The canonical contract identifier is `io.agentchat.agent_ops.v1`. Its
+  development manifest does not make it consumable. Proposal types and fixtures
+  use the Robrix-owned `io.robrix.agent_ops.proposal.r3` schema, are compiled
+  only in tests, and are never exported to or consumed by production runtime.
+- Contract readiness requires a released manifest, a complete immutable source
+  commit, the complete required artifact set, and a byte-for-byte SHA-256 match
+  for every artifact compiled into Robrix2.
+- Contract readiness does not mean connected. The operational runtime remains
+  a separate future task covering bootstrap, authentication, transport, and
+  all four views.
+
+### Non-binding Future Contract Proposal
+
+- The following decisions describe review material, not an accepted agent-chat
+  contract and not current runtime behavior.
+- The historical R3 experiment assumed Matrix as the authenticated control plane for
+  session bootstrap, invalidation, revocation, and audit correlation, plus a
+  co-resident desktop loopback scoped-HTTP data plane for snapshots and
+  sensitive commands. A separately accepted agent-chat ADR must define exact
+  owner/scope binding, device and E2EE evidence, sender-constrained proof of
+  possession, endpoint identity, replay, expiry, and revocation.
+- `snapshot_seq` is not mutation authorization. Actionable entities carry an
+  entity version; resources carry `dirty_generation`; each available mutation
+  is explicitly authorized by a backend-issued, short-lived, entity-bound
+  action capability.
+- Each projection is bound to one owner/project/agent scope and carries a
+  projection id, stream epoch, auth-fence generation, and scope-local sequence.
+  A global panel composes scopes without sharing their capabilities.
+- The future projection is backend-owned. Robrix2 will not infer router state,
+  actions, blocking chains, or approval eligibility from Matrix events.
+- Approval remains exclusively in the existing owner-DM approval flow.
+- The future projection carries `resource_id` for workspace actions and a full
+  Matrix room/thread reference for navigation. It never carries absolute paths.
+- `outcome_unknown` requires a complete begin-inspection then resolve sequence.
+  Resolution has exactly three choices: `continue`, `accept_completed`, and
+  `keep_blocked`; all require the inspection credential and operator note, and
+  only `continue` accepts a required recovery instruction. The backend
+  explicitly returns the allowed resolution subset; non-task dispatches only
+  receive `continue`.
+- Fixtures under `agent-ops-client-v1-proposal` are proposal-only. agent-chat is
+  the canonical artifact owner and must publish a released digest manifest and
+  the matching artifact bytes before the operational client can consume them.
+
+## Boundaries
+
+### Allowed Changes
+
+- src/agent_ops/**
+- src/agent_ops_dummy.rs
+- src/app.rs
+- src/home/home_screen.rs
+- src/home/navigation_tab_bar.rs
+- src/i18n.rs
+- src/persistence/app_state.rs
+- src/settings/app_settings.rs
+- src/lib.rs
+- resources/i18n/en.json
+- resources/i18n/zh-CN.json
+- docs/README.md
+- docs/agent-system-planes.md
+- docs/robrix-with-agentchat/README.md
+- docs/robrix-with-agentchat/agent-ops-client-contract-v1-proposal.md
+- specs/fixtures/agent-ops-client-v1/**
+- specs/fixtures/agent-ops-client-v1-proposal/**
+- specs/task-agent-ops-panel.spec.md
+
+### Forbidden
+
+- Do not embed or persist agent-chat backend credentials
+- Do not call the local Dashboard router endpoints from Robrix2
+- Do not present operational rows or mutations while the contract is not ready
+- Do not add approve or deny controls
+- Do not derive session, task, dispatch, lease, queue, or action state locally
+- Do not expose absolute paths, secrets, or approval content
+- Do not use Makepad 1.x syntax or hardcoded screen colors
+
+## Completion Criteria
+
+Scenario: The contract gate is fail closed
+  Test: contract_gate_is_fail_closed
+  Given the vendored agent-chat client contract is not released and verified
+  When the Agent Operations integration is opened
+  Then it reports that the contract is unavailable
+  And it cannot become operational from local configuration
+
+Scenario: Manifest claims cannot substitute for canonical bytes
+  Test: manifest_only_release_cannot_open_without_compiled_artifacts
+  Given a released manifest with a complete source commit and artifact list
+  When no matching artifact bytes are compiled into Robrix2
+  Then the contract remains unavailable
+
+Scenario: Canonical artifacts are verified byte for byte
+  Test: artifact_set_and_digest_mismatches_stay_closed
+  Given a released manifest and its compiled artifact set
+  When a path is absent or any artifact body is changed
+  Then the contract remains unavailable with a named verification failure
+
+Scenario: The panel has no Dashboard transport
+  Test: panel_contains_no_backend_transport_or_credentials
+  Given the contract gate is closed
+  When Agent Operations and its settings request entry points are inspected
+  Then they contain no HTTP request path or authorization header
+  And it never polls the Dashboard
+
+Scenario: Proposal types are test-only and not runtime integration types
+  Test: proposal_model_is_not_wired_into_runtime_panel
+  Given the local proposal model and fixtures compile only under cfg(test)
+  When the contract-gated panel runtime is inspected
+  Then it does not consume Snapshot, Invalidation, or command proposal types
+  And no proposal fixture can make the panel operational
+
+Scenario: Preferences collect no backend secret
+  Test: settings_contains_no_agent_ops_secret_input
+  Given a build with the agent_chat feature enabled
+  When Preferences renders the integration section
+  Then it contains no Dashboard token input
+  And no Agent Operations credential is added to AppState
+
+Scenario: Legacy prototype credentials are removed on restore
+  Test: legacy_agent_ops_credentials_are_removed_from_disk_before_restore
+  Given an old AppState containing the experimental Dashboard configuration
+  When that state is loaded
+  Then the obsolete agent_ops field is absent
+  And the old token is removed from the persisted JSON before restore
+
+Scenario: Credential cleanup failure stops restoration
+  Test: credential_scrub_write_failure_aborts_restore
+  Given persisted state contains an obsolete Agent Operations credential
+  When sanitized state cannot be written back
+  Then restoration returns an error instead of continuing with secret-bearing state
+
+Scenario: Disabling agent-chat cannot restore the status page
+  Test: closing_settings_never_returns_to_disabled_agent_ops
+  Given Settings was opened from Agent Operations
+  When agent-chat is disabled and Settings closes
+  Then Home is selected instead of the disabled Agent Operations page
+
+Scenario: Selecting a room always reveals the room workspace
+  Test: opening_room_leaves_every_overlay_page_for_home
+  Given Add Room, Settings, Directory, or Agent Operations is the active page
+  When a room selection action is handled
+  Then Home is selected before the desktop Dock handles the room
+  And Home or a selected Space remains unchanged because it already shows the room workspace
+
+Scenario: Contract status uses stable semantic presentation
+  Test: contract_status_presentation_covers_tone_and_next_step
+  Given every Agent Operations contract availability state
+  When the panel presentation is derived
+  Then ready is success and points to runtime construction
+  And pending release states are warning
+  And invalid or mismatched contract material is danger
+
+Scenario: Agent Operations diagnostics are localized
+  Test: agent_ops_status_and_detail_keys_exist_in_all_locales
+  Given English and Simplified Chinese resources
+  When every contract state and next-step message is resolved
+  Then both locales provide native text without English fallback
+
+Scenario: Proposal fixtures remain explicitly versioned
+  Test: proposal_snapshot_fixture_matches_the_proposed_model
+  Given the non-canonical R3 snapshot fixture
+  When the fixture is parsed
+  Then its schema is io.robrix.agent_ops.proposal.r3
+  And it identifies its owner/project/agent scope and projection stream
+
+Scenario: Snapshot actions bind entity-specific concurrency state
+  Test: proposal_snapshot_fixture_matches_the_proposed_model
+  Given an actionable dispatch and a dirty resource in the proposed snapshot
+  When their available actions are parsed
+  Then each action carries entity_version and an opaque expiring capability
+  And the resource action also carries dirty_generation
+
+Scenario: Outcome inspection issues a scoped resolution capability
+  Test: proposal_inspection_fixture_carries_explicit_resolution_grants
+  Given a successful outcome inspection response
+  When the proposed fixture is parsed
+  Then it carries inspection identity, expiry, and resource dirty_generation
+  And it provides a dispatch-bound resolve_outcome capability with explicit allowed resolutions
+
+Scenario: Outcome resolution covers all three choices
+  Test: resolution_fixtures_cover_the_complete_outcome_closure
+  Given an outcome_unknown dispatch has been inspected
+  When the three proposed resolution fixtures are parsed
+  Then continue includes a recovery instruction
+  And accept_completed and keep_blocked cannot carry one
+
+Scenario: Terminal resolution rejects recovery instructions on the wire
+  Test: terminal_resolution_rejects_recovery_instruction
+  Given an accept_completed request contains recovery_instruction
+  When the strict proposed command model parses it
+  Then the complete command is rejected
+
+Scenario: Wrong schema is rejected during trusted-model construction
+  Test: wrong_schema_is_rejected_during_deserialization
+  Given a projection uses an unaccepted schema identifier
+  When the proposed model parses it
+  Then parsing fails before any caller can use the data
+
+Scenario: Capability values are not exposed through Debug
+  Test: capability_debug_output_is_redacted_and_empty_values_are_rejected
+  Given a parsed action or inspection capability
+  When the value is debug formatted
+  Then the secret value is absent
+  And a redacted marker is present
+
+Scenario: All proposed presentation text rejects paths
+  Test: complete_projection_rejects_embedded_filesystem_paths
+  Given an absolute path embedded in any display string
+  When the proposed model parses it
+  Then the entire projection is rejected
+
+Scenario: The panel has no second approval entry point
+  Test: panel_contains_no_backend_transport_or_credentials
+  Given the integration status screen
+  When its controls are inspected
+  Then no approve or deny operation exists
+
+Scenario: The panel is absent without the agent_chat feature
+  Test: test_panel_absent_without_agent_chat_feature
+  Given a build with the agent_chat feature disabled
+  When the app starts
+  Then no Agent Operations entry appears in Preferences
+
+## Out of Scope
+
+- Consuming live snapshots or invalidations
+- Sending Agent Operations commands
+- Rendering Attention, Tasks, Queue, or Worktrees data
+- Adding a new agent-chat authentication mechanism
+- Changing agent-chat source code from this repository

--- a/src/agent_ops/mod.rs
+++ b/src/agent_ops/mod.rs
@@ -1,0 +1,23 @@
+//! Agent Operations Panel client-contract gate.
+//!
+//! The operational UI is intentionally unavailable until agent-chat releases
+//! canonical contract artifacts and a separate client runtime is implemented.
+//! The test-only `model` module validates non-canonical design fixtures;
+//! [`state`] makes the production gate explicit, while `panel` renders the
+//! resulting status and performs no I/O.
+
+#[cfg(test)]
+mod model;
+pub mod panel;
+pub mod state;
+mod sha256;
+
+use makepad_widgets::Cx;
+
+pub fn script_mod(vm: &mut makepad_widgets::ScriptVm) {
+    panel::script_mod(vm);
+}
+
+/// Placeholder so `Cx` stays referenced if the widget layer is compiled out.
+#[allow(dead_code)]
+fn _assert_cx_in_scope(_cx: &mut Cx) {}

--- a/src/agent_ops/model.rs
+++ b/src/agent_ops/model.rs
@@ -1,0 +1,1052 @@
+//! Test-only R3 presentation experiment for the Agent Operations Panel.
+//!
+//! These types do **not** mirror agent-chat's current Dashboard response. They
+//! are non-canonical review material shared with
+//! `docs/robrix-with-agentchat/agent-ops-client-contract-v1-proposal.md` and are
+//! compiled only by tests. They deliberately use a Robrix-owned experimental
+//! schema so they cannot be mistaken for agent-chat's canonical V1 wire model.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+const PROPOSAL_SCHEMA: &str = "io.robrix.agent_ops.proposal.r3";
+const MAX_JSON_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+const MAX_CAPABILITY_BYTES: usize = 8 * 1024;
+
+/// Text that is safe to present in Robrix.
+///
+/// The producer remains responsible for redaction. This consumer-side check is
+/// only a path heuristic; it is not a general secret detector.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct PrivacyFilteredText(String);
+
+impl PrivacyFilteredText {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PrivacyFilteredText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A server-issued capability that must never be rendered or logged.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OpaqueCapability(String);
+
+impl fmt::Debug for OpaqueCapability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("OpaqueCapability(<redacted>)")
+    }
+}
+
+impl OpaqueCapability {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Serialize for OpaqueCapability {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for OpaqueCapability {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value.trim().is_empty() {
+            return Err(D::Error::custom("capability must not be empty"));
+        }
+        if value.len() > MAX_CAPABILITY_BYTES {
+            return Err(D::Error::custom("capability exceeds the proposed size limit"));
+        }
+        Ok(Self(value))
+    }
+}
+
+impl<'de> Deserialize<'de> for PrivacyFilteredText {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value.trim().is_empty() {
+            return Err(D::Error::custom("presentation text must not be empty"));
+        }
+        if contains_absolute_path(&value) {
+            return Err(D::Error::custom(
+                "filesystem paths are not allowed in the Agent Operations projection",
+            ));
+        }
+        Ok(Self(value))
+    }
+}
+
+fn contains_absolute_path(value: &str) -> bool {
+    if value
+        .split(|character: char| {
+            character.is_whitespace()
+                || matches!(character, '=' | ':' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';' | '"' | '\'')
+        })
+        .filter(|token| !token.is_empty())
+        .any(looks_like_filesystem_path)
+    {
+        return true;
+    }
+
+    let bytes = value.as_bytes();
+    bytes.windows(3).enumerate().any(|(index, window)| {
+        let boundary = index == 0
+            || bytes[index - 1].is_ascii_whitespace()
+            || matches!(bytes[index - 1], b'=' | b':' | b'(' | b'[' | b'{' | b'"' | b'\'');
+        boundary
+            && window[0].is_ascii_alphabetic()
+            && window[1] == b':'
+            && matches!(window[2], b'/' | b'\\')
+    })
+}
+
+fn looks_like_filesystem_path(value: &str) -> bool {
+    let value = value.trim();
+    std::path::Path::new(value).is_absolute()
+        || (value.starts_with('~') && value[1..].contains(['/', '\\']))
+        || value.starts_with("\\\\")
+}
+
+fn require_id(value: &str, field: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        Err(format!("{field} must not be empty"))
+    } else {
+        Ok(())
+    }
+}
+
+fn require_safe_integer(value: u64, field: &str) -> Result<(), String> {
+    if value > MAX_JSON_SAFE_INTEGER {
+        Err(format!("{field} exceeds the JSON safe-integer range"))
+    } else {
+        Ok(())
+    }
+}
+
+fn require_positive_version(value: u64, field: &str) -> Result<(), String> {
+    require_safe_integer(value, field)?;
+    if value == 0 {
+        Err(format!("{field} must be greater than zero"))
+    } else {
+        Ok(())
+    }
+}
+
+/// Lifecycle of one dispatch, as reported by the backend projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchState {
+    Queued,
+    Leased,
+    Started,
+    Parked,
+    Completed,
+    CancelledBeforeStart,
+    OutcomeUnknown,
+    #[serde(other)]
+    Other,
+}
+
+/// Why the projection says a row needs a human.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttentionKind {
+    OutcomeUnknown,
+    ParkedApproval,
+    ThreadDeliveryFailed,
+    WorkspaceDirty,
+    #[serde(other)]
+    Other,
+}
+
+/// Entity kind bound into a short-lived action capability.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionEntityKind {
+    Dispatch,
+    Resource,
+    #[serde(other)]
+    Other,
+}
+
+/// Action kinds the proposed V1 client understands.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AvailableActionKind {
+    CancelDispatch,
+    BeginOutcomeInspection,
+    ResolveOutcome,
+    MarkResourceInspected,
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutcomeResolutionKind {
+    Continue,
+    AcceptCompleted,
+    KeepBlocked,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionTarget {
+    pub entity_kind: ActionEntityKind,
+    pub entity_id: String,
+    pub entity_version: u64,
+}
+
+impl ActionTarget {
+    fn validate(&self) -> Result<(), String> {
+        require_id(&self.entity_id, "target.entity_id")?;
+        require_positive_version(self.entity_version, "target.entity_version")?;
+        if self.entity_kind == ActionEntityKind::Other {
+            return Err("unknown target entity kind is not actionable".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResourcePrecondition {
+    pub resource_id: String,
+    pub dirty_generation: u64,
+}
+
+impl ResourcePrecondition {
+    fn validate(&self) -> Result<(), String> {
+        require_id(&self.resource_id, "resource_precondition.resource_id")?;
+        require_safe_integer(
+            self.dirty_generation,
+            "resource_precondition.dirty_generation",
+        )
+    }
+}
+
+/// Backend-issued, entity-scoped permission to request one operation.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AvailableAction {
+    pub action_id: String,
+    pub kind: AvailableActionKind,
+    pub target: ActionTarget,
+    #[serde(default)]
+    pub resource_precondition: Option<ResourcePrecondition>,
+    #[serde(default)]
+    pub allowed_resolutions: Vec<OutcomeResolutionKind>,
+    pub expires_at_unix_ms: u64,
+    pub capability: OpaqueCapability,
+}
+
+impl AvailableAction {
+    fn validate(&self) -> Result<(), String> {
+        require_id(&self.action_id, "action_id")?;
+        self.target.validate()?;
+        require_safe_integer(self.expires_at_unix_ms, "expires_at_unix_ms")?;
+        if self.expires_at_unix_ms == 0 {
+            return Err("expires_at_unix_ms must be greater than zero".into());
+        }
+        if let Some(resource) = &self.resource_precondition {
+            resource.validate()?;
+        }
+
+        match self.kind {
+            AvailableActionKind::CancelDispatch => {
+                if self.target.entity_kind != ActionEntityKind::Dispatch {
+                    return Err("cancel_dispatch must target a dispatch".into());
+                }
+            }
+            AvailableActionKind::BeginOutcomeInspection => {
+                if self.target.entity_kind != ActionEntityKind::Dispatch
+                    || self.resource_precondition.is_none()
+                {
+                    return Err(
+                        "begin_outcome_inspection must bind a dispatch and resource generation"
+                            .into(),
+                    );
+                }
+            }
+            AvailableActionKind::ResolveOutcome => {
+                if self.target.entity_kind != ActionEntityKind::Dispatch
+                    || self.resource_precondition.is_none()
+                    || self.allowed_resolutions.is_empty()
+                {
+                    return Err(
+                        "resolve_outcome must bind a dispatch, resource, and allowed resolutions"
+                            .into(),
+                    );
+                }
+            }
+            AvailableActionKind::MarkResourceInspected => {
+                let resource = self.resource_precondition.as_ref().ok_or_else(|| {
+                    "mark_resource_inspected requires a resource precondition".to_string()
+                })?;
+                if self.target.entity_kind != ActionEntityKind::Resource
+                    || self.target.entity_id != resource.resource_id
+                {
+                    return Err(
+                        "mark_resource_inspected target must match its resource precondition"
+                            .into(),
+                    );
+                }
+            }
+            AvailableActionKind::Other => {
+                return Err("unknown actions are not part of the trusted projection".into());
+            }
+        }
+
+        if self.kind != AvailableActionKind::ResolveOutcome
+            && !self.allowed_resolutions.is_empty()
+        {
+            return Err("only resolve_outcome may carry allowed_resolutions".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentOpsScope {
+    pub scope_id: String,
+    pub project_room_id: String,
+    pub agent_id: String,
+    pub owner_mxid: String,
+    pub owner_dm_room_id: String,
+}
+
+impl AgentOpsScope {
+    fn validate(&self) -> Result<(), String> {
+        require_id(&self.scope_id, "scope.scope_id")?;
+        require_id(&self.project_room_id, "scope.project_room_id")?;
+        require_id(&self.agent_id, "scope.agent_id")?;
+        require_id(&self.owner_mxid, "scope.owner_mxid")?;
+        require_id(&self.owner_dm_room_id, "scope.owner_dm_room_id")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ThreadRef {
+    pub room_id: String,
+    pub thread_root_event_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttentionItem {
+    pub id: String,
+    pub kind: AttentionKind,
+    pub summary: PrivacyFilteredText,
+    #[serde(default)]
+    pub task_id: Option<String>,
+    #[serde(default)]
+    pub dispatch_id: Option<String>,
+    #[serde(default)]
+    pub resource_id: Option<String>,
+    #[serde(default)]
+    pub agent: Option<PrivacyFilteredText>,
+    #[serde(default)]
+    pub waiting_ms: Option<u64>,
+    #[serde(default)]
+    pub thread: Option<ThreadRef>,
+    #[serde(default)]
+    pub available_actions: Vec<AvailableAction>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskRow {
+    pub task_id: String,
+    pub entity_version: u64,
+    pub title: PrivacyFilteredText,
+    pub agent: PrivacyFilteredText,
+    pub state: PrivacyFilteredText,
+    #[serde(default)]
+    pub dispatch_state: Option<DispatchState>,
+    #[serde(default)]
+    pub elapsed_ms: Option<u64>,
+    #[serde(default)]
+    pub thread: Option<ThreadRef>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueueRow {
+    pub dispatch_id: String,
+    pub entity_version: u64,
+    #[serde(default)]
+    pub task_id: Option<String>,
+    pub agent: PrivacyFilteredText,
+    pub state: DispatchState,
+    #[serde(default)]
+    pub waiting_on: Option<PrivacyFilteredText>,
+    #[serde(default)]
+    pub held_by_dispatch_id: Option<String>,
+    #[serde(default)]
+    pub attention_kind: Option<AttentionKind>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorktreeRow {
+    pub resource_id: String,
+    pub entity_version: u64,
+    pub label: PrivacyFilteredText,
+    pub branch: PrivacyFilteredText,
+    #[serde(default)]
+    pub dirty: bool,
+    pub dirty_generation: u64,
+    #[serde(default)]
+    pub task_id: Option<String>,
+    #[serde(default)]
+    pub available_actions: Vec<AvailableAction>,
+}
+
+/// One authoritative, privacy-filtered presentation snapshot for exactly one
+/// owner/project/agent scope. A future UI may compose several such snapshots.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Snapshot {
+    pub schema: String,
+    pub scope: AgentOpsScope,
+    pub projection_id: String,
+    pub stream_epoch: String,
+    pub auth_fence_generation: u64,
+    pub seq: u64,
+    pub attention: Vec<AttentionItem>,
+    pub tasks: Vec<TaskRow>,
+    pub queue: Vec<QueueRow>,
+    pub worktrees: Vec<WorktreeRow>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotWire {
+    schema: String,
+    scope: AgentOpsScope,
+    projection_id: String,
+    stream_epoch: String,
+    auth_fence_generation: u64,
+    seq: u64,
+    #[serde(default)]
+    attention: Vec<AttentionItem>,
+    #[serde(default)]
+    tasks: Vec<TaskRow>,
+    #[serde(default)]
+    queue: Vec<QueueRow>,
+    #[serde(default)]
+    worktrees: Vec<WorktreeRow>,
+}
+
+impl TryFrom<SnapshotWire> for Snapshot {
+    type Error = String;
+
+    fn try_from(wire: SnapshotWire) -> Result<Self, Self::Error> {
+        if wire.schema != PROPOSAL_SCHEMA {
+            return Err("snapshot schema is not the proposed contract schema".into());
+        }
+        wire.scope.validate()?;
+        require_id(&wire.projection_id, "projection_id")?;
+        require_id(&wire.stream_epoch, "stream_epoch")?;
+        require_safe_integer(wire.auth_fence_generation, "auth_fence_generation")?;
+        require_safe_integer(wire.seq, "seq")?;
+
+        for item in &wire.attention {
+            require_id(&item.id, "attention.id")?;
+            if let Some(waiting_ms) = item.waiting_ms {
+                require_safe_integer(waiting_ms, "attention.waiting_ms")?;
+            }
+            for action in &item.available_actions {
+                action.validate()?;
+                if action.target.entity_kind == ActionEntityKind::Dispatch
+                    && item.dispatch_id.as_deref() != Some(&action.target.entity_id)
+                {
+                    return Err("attention action targets a different dispatch".into());
+                }
+                if let Some(resource) = &action.resource_precondition {
+                    if item.resource_id.as_deref() != Some(&resource.resource_id) {
+                        return Err("attention action targets a different resource".into());
+                    }
+                }
+            }
+        }
+        for task in &wire.tasks {
+            require_id(&task.task_id, "task.task_id")?;
+            require_positive_version(task.entity_version, "task.entity_version")?;
+            if let Some(elapsed_ms) = task.elapsed_ms {
+                require_safe_integer(elapsed_ms, "task.elapsed_ms")?;
+            }
+        }
+        for row in &wire.queue {
+            require_id(&row.dispatch_id, "queue.dispatch_id")?;
+            require_positive_version(row.entity_version, "queue.entity_version")?;
+        }
+        for row in &wire.worktrees {
+            require_id(&row.resource_id, "worktree.resource_id")?;
+            require_positive_version(row.entity_version, "worktree.entity_version")?;
+            require_safe_integer(row.dirty_generation, "worktree.dirty_generation")?;
+            for action in &row.available_actions {
+                action.validate()?;
+                if action.target.entity_kind != ActionEntityKind::Resource
+                    || action.target.entity_id != row.resource_id
+                    || action.target.entity_version != row.entity_version
+                {
+                    return Err("worktree action target does not match its row".into());
+                }
+                let resource = action.resource_precondition.as_ref().ok_or_else(|| {
+                    "worktree mutation lacks a resource precondition".to_string()
+                })?;
+                if resource.resource_id != row.resource_id
+                    || resource.dirty_generation != row.dirty_generation
+                {
+                    return Err("worktree action generation does not match its row".into());
+                }
+            }
+        }
+
+        Ok(Self {
+            schema: wire.schema,
+            scope: wire.scope,
+            projection_id: wire.projection_id,
+            stream_epoch: wire.stream_epoch,
+            auth_fence_generation: wire.auth_fence_generation,
+            seq: wire.seq,
+            attention: wire.attention,
+            tasks: wire.tasks,
+            queue: wire.queue,
+            worktrees: wire.worktrees,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Snapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        SnapshotWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(D::Error::custom)
+    }
+}
+
+/// An invalidation signal. A future client re-requests a complete snapshot; it
+/// does not reconstruct backend state by applying local deltas.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Invalidation {
+    pub schema: String,
+    pub scope_id: String,
+    pub projection_id: String,
+    pub stream_epoch: String,
+    pub auth_fence_generation: u64,
+    pub seq: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InvalidationWire {
+    schema: String,
+    scope_id: String,
+    projection_id: String,
+    stream_epoch: String,
+    auth_fence_generation: u64,
+    seq: u64,
+}
+
+impl<'de> Deserialize<'de> for Invalidation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = InvalidationWire::deserialize(deserializer)?;
+        if wire.schema != PROPOSAL_SCHEMA {
+            return Err(D::Error::custom(
+                "invalidation schema is not the proposed contract schema",
+            ));
+        }
+        require_id(&wire.scope_id, "scope_id").map_err(D::Error::custom)?;
+        require_id(&wire.projection_id, "projection_id").map_err(D::Error::custom)?;
+        require_id(&wire.stream_epoch, "stream_epoch").map_err(D::Error::custom)?;
+        require_safe_integer(wire.auth_fence_generation, "auth_fence_generation")
+            .map_err(D::Error::custom)?;
+        require_safe_integer(wire.seq, "seq").map_err(D::Error::custom)?;
+        Ok(Self {
+            schema: wire.schema,
+            scope_id: wire.scope_id,
+            projection_id: wire.projection_id,
+            stream_epoch: wire.stream_epoch,
+            auth_fence_generation: wire.auth_fence_generation,
+            seq: wire.seq,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct InspectionResource {
+    pub resource_id: String,
+    pub entity_version: u64,
+    pub dirty_generation: u64,
+    pub label: PrivacyFilteredText,
+    #[serde(default)]
+    pub branch: Option<PrivacyFilteredText>,
+    #[serde(default)]
+    pub dirty_reason: Option<PrivacyFilteredText>,
+}
+
+/// Result of beginning inspection. Both capabilities are memory-only secrets:
+/// neither belongs in AppState, logs, or Matrix timeline content.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct OutcomeInspection {
+    pub schema: String,
+    pub scope_id: String,
+    pub projection_id: String,
+    pub stream_epoch: String,
+    pub auth_fence_generation: u64,
+    pub snapshot_seq: u64,
+    pub client_session_id: String,
+    pub inspection_id: String,
+    pub inspection_token: OpaqueCapability,
+    pub dispatch_target: ActionTarget,
+    pub task_id: Option<String>,
+    pub terminal_reason: PrivacyFilteredText,
+    pub expires_at_unix_ms: u64,
+    pub resource: InspectionResource,
+    pub resolution_action: AvailableAction,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OutcomeInspectionWire {
+    schema: String,
+    scope_id: String,
+    projection_id: String,
+    stream_epoch: String,
+    auth_fence_generation: u64,
+    snapshot_seq: u64,
+    client_session_id: String,
+    inspection_id: String,
+    inspection_token: OpaqueCapability,
+    dispatch_target: ActionTarget,
+    #[serde(default)]
+    task_id: Option<String>,
+    terminal_reason: PrivacyFilteredText,
+    expires_at_unix_ms: u64,
+    resource: InspectionResource,
+    resolution_action: AvailableAction,
+}
+
+impl TryFrom<OutcomeInspectionWire> for OutcomeInspection {
+    type Error = String;
+
+    fn try_from(wire: OutcomeInspectionWire) -> Result<Self, Self::Error> {
+        if wire.schema != PROPOSAL_SCHEMA {
+            return Err("inspection schema is not the proposed contract schema".into());
+        }
+        require_id(&wire.scope_id, "scope_id")?;
+        require_id(&wire.projection_id, "projection_id")?;
+        require_id(&wire.stream_epoch, "stream_epoch")?;
+        require_safe_integer(wire.auth_fence_generation, "auth_fence_generation")?;
+        require_safe_integer(wire.snapshot_seq, "snapshot_seq")?;
+        require_id(&wire.client_session_id, "client_session_id")?;
+        require_id(&wire.inspection_id, "inspection_id")?;
+        require_safe_integer(wire.expires_at_unix_ms, "expires_at_unix_ms")?;
+        wire.dispatch_target.validate()?;
+        if wire.dispatch_target.entity_kind != ActionEntityKind::Dispatch {
+            return Err("inspection target must be a dispatch".into());
+        }
+        require_id(&wire.resource.resource_id, "resource.resource_id")?;
+        require_positive_version(wire.resource.entity_version, "resource.entity_version")?;
+        require_safe_integer(wire.resource.dirty_generation, "resource.dirty_generation")?;
+        wire.resolution_action.validate()?;
+        if wire.resolution_action.kind != AvailableActionKind::ResolveOutcome
+            || wire.resolution_action.target != wire.dispatch_target
+        {
+            return Err("resolution action does not match the inspected dispatch".into());
+        }
+        let resource = wire
+            .resolution_action
+            .resource_precondition
+            .as_ref()
+            .ok_or_else(|| "resolution action lacks a resource precondition".to_string())?;
+        if resource.resource_id != wire.resource.resource_id
+            || resource.dirty_generation != wire.resource.dirty_generation
+        {
+            return Err("resolution action does not match the inspected resource".into());
+        }
+        if wire.task_id.is_none()
+            && wire.resolution_action.allowed_resolutions
+                != [OutcomeResolutionKind::Continue]
+        {
+            return Err("non-task inspection may only authorize continue".into());
+        }
+
+        Ok(Self {
+            schema: wire.schema,
+            scope_id: wire.scope_id,
+            projection_id: wire.projection_id,
+            stream_epoch: wire.stream_epoch,
+            auth_fence_generation: wire.auth_fence_generation,
+            snapshot_seq: wire.snapshot_seq,
+            client_session_id: wire.client_session_id,
+            inspection_id: wire.inspection_id,
+            inspection_token: wire.inspection_token,
+            dispatch_target: wire.dispatch_target,
+            task_id: wire.task_id,
+            terminal_reason: wire.terminal_reason,
+            expires_at_unix_ms: wire.expires_at_unix_ms,
+            resource: wire.resource,
+            resolution_action: wire.resolution_action,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for OutcomeInspection {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        OutcomeInspectionWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(D::Error::custom)
+    }
+}
+
+/// Strict resolution choice. Terminal choices reject recovery instructions as
+/// unknown fields instead of silently discarding them.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OutcomeResolutionChoice {
+    Continue {
+        recovery_instruction: PrivacyFilteredText,
+    },
+    AcceptCompleted,
+    KeepBlocked,
+}
+
+impl<'de> Deserialize<'de> for OutcomeResolutionChoice {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let object = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("resolution must be an object"))?;
+        let kind = object
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| D::Error::custom("resolution.kind must be a string"))?;
+
+        match kind {
+            "continue" => {
+                if object.len() != 2 || !object.contains_key("recovery_instruction") {
+                    return Err(D::Error::custom(
+                        "continue requires only kind and recovery_instruction",
+                    ));
+                }
+                let instruction = object
+                    .get("recovery_instruction")
+                    .cloned()
+                    .ok_or_else(|| D::Error::custom("missing recovery_instruction"))?;
+                let recovery_instruction = serde_json::from_value(instruction)
+                    .map_err(D::Error::custom)?;
+                Ok(Self::Continue {
+                    recovery_instruction,
+                })
+            }
+            "accept_completed" => {
+                if object.len() != 1 {
+                    return Err(D::Error::custom(
+                        "accept_completed must not carry additional fields",
+                    ));
+                }
+                Ok(Self::AcceptCompleted)
+            }
+            "keep_blocked" => {
+                if object.len() != 1 {
+                    return Err(D::Error::custom(
+                        "keep_blocked must not carry additional fields",
+                    ));
+                }
+                Ok(Self::KeepBlocked)
+            }
+            _ => Err(D::Error::custom("unknown outcome resolution")),
+        }
+    }
+}
+
+/// Proposed command for completing an inspected `outcome_unknown` dispatch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ResolveOutcomeCommand {
+    pub schema: String,
+    pub request_id: String,
+    pub client_session_id: String,
+    pub scope_id: String,
+    pub projection_id: String,
+    pub stream_epoch: String,
+    pub auth_fence_generation: u64,
+    pub snapshot_seq: u64,
+    pub action_capability: OpaqueCapability,
+    pub target: ActionTarget,
+    pub resource_precondition: ResourcePrecondition,
+    pub inspection_id: String,
+    pub inspection_token: OpaqueCapability,
+    pub operator_note: PrivacyFilteredText,
+    pub resolution: OutcomeResolutionChoice,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResolveOutcomeCommandWire {
+    schema: String,
+    request_id: String,
+    client_session_id: String,
+    scope_id: String,
+    projection_id: String,
+    stream_epoch: String,
+    auth_fence_generation: u64,
+    snapshot_seq: u64,
+    action_capability: OpaqueCapability,
+    target: ActionTarget,
+    resource_precondition: ResourcePrecondition,
+    inspection_id: String,
+    inspection_token: OpaqueCapability,
+    operator_note: PrivacyFilteredText,
+    resolution: OutcomeResolutionChoice,
+}
+
+impl TryFrom<ResolveOutcomeCommandWire> for ResolveOutcomeCommand {
+    type Error = String;
+
+    fn try_from(wire: ResolveOutcomeCommandWire) -> Result<Self, Self::Error> {
+        if wire.schema != PROPOSAL_SCHEMA {
+            return Err("command schema is not the proposed contract schema".into());
+        }
+        require_id(&wire.request_id, "request_id")?;
+        require_id(&wire.client_session_id, "client_session_id")?;
+        require_id(&wire.scope_id, "scope_id")?;
+        require_id(&wire.projection_id, "projection_id")?;
+        require_id(&wire.stream_epoch, "stream_epoch")?;
+        require_safe_integer(wire.auth_fence_generation, "auth_fence_generation")?;
+        require_safe_integer(wire.snapshot_seq, "snapshot_seq")?;
+        wire.target.validate()?;
+        if wire.target.entity_kind != ActionEntityKind::Dispatch {
+            return Err("resolve_outcome must target a dispatch".into());
+        }
+        wire.resource_precondition.validate()?;
+        require_id(&wire.inspection_id, "inspection_id")?;
+
+        Ok(Self {
+            schema: wire.schema,
+            request_id: wire.request_id,
+            client_session_id: wire.client_session_id,
+            scope_id: wire.scope_id,
+            projection_id: wire.projection_id,
+            stream_epoch: wire.stream_epoch,
+            auth_fence_generation: wire.auth_fence_generation,
+            snapshot_seq: wire.snapshot_seq,
+            action_capability: wire.action_capability,
+            target: wire.target,
+            resource_precondition: wire.resource_precondition,
+            inspection_id: wire.inspection_id,
+            inspection_token: wire.inspection_token,
+            operator_note: wire.operator_note,
+            resolution: wire.resolution,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for ResolveOutcomeCommand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        ResolveOutcomeCommandWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposal_snapshot_fixture_matches_the_proposed_model() {
+        let fixture = include_str!("../../specs/fixtures/agent-ops-client-v1-proposal/snapshot.json");
+        let snapshot: Snapshot = serde_json::from_str(fixture).unwrap();
+        assert_eq!(snapshot.schema, PROPOSAL_SCHEMA);
+        assert_eq!(snapshot.seq, 42);
+        assert_eq!(snapshot.scope.scope_id, "scope-room-agent-1");
+        assert_eq!(snapshot.worktrees[0].resource_id, "resource-1");
+        assert_eq!(snapshot.worktrees[0].dirty_generation, 2);
+
+        let actions = snapshot
+            .attention
+            .iter()
+            .flat_map(|item| &item.available_actions)
+            .chain(
+                snapshot
+                    .worktrees
+                    .iter()
+                    .flat_map(|row| &row.available_actions),
+            )
+            .collect::<Vec<_>>();
+        assert!(!actions.is_empty());
+        for action in actions {
+            assert!(action.target.entity_version > 0);
+            assert!(action.expires_at_unix_ms > 0);
+            assert!(!action.capability.is_empty());
+            if action.kind == AvailableActionKind::MarkResourceInspected {
+                assert!(action.resource_precondition.is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn proposal_invalidation_fixture_matches_the_proposed_model() {
+        let fixture = include_str!("../../specs/fixtures/agent-ops-client-v1-proposal/invalidation.json");
+        let invalidation: Invalidation = serde_json::from_str(fixture).unwrap();
+        assert_eq!(invalidation.schema, PROPOSAL_SCHEMA);
+        assert_eq!(invalidation.scope_id, "scope-room-agent-1");
+        assert_eq!(invalidation.seq, 43);
+    }
+
+    #[test]
+    fn wrong_schema_is_rejected_during_deserialization() {
+        let mut fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../specs/fixtures/agent-ops-client-v1-proposal/snapshot.json"
+        ))
+        .unwrap();
+        fixture["schema"] = "io.agentchat.agent_ops.future".into();
+        assert!(serde_json::from_value::<Snapshot>(fixture).is_err());
+    }
+
+    #[test]
+    fn unknown_enum_values_fail_closed() {
+        let mut fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../specs/fixtures/agent-ops-client-v1-proposal/snapshot.json"
+        ))
+        .unwrap();
+        fixture["attention"][0]["available_actions"][0]["kind"] =
+            "some_future_action".into();
+        assert!(serde_json::from_value::<Snapshot>(fixture).is_err());
+    }
+
+    #[test]
+    fn complete_projection_rejects_embedded_filesystem_paths() {
+        for text in [
+            "/Users/alex/robrix2",
+            "workspace: /Users/alex/robrix2 is dirty",
+            "path=~/Work/robrix2",
+            "path=~alice/Work/robrix2",
+            r"workspace C:\Users\alex\robrix2",
+            r"resource \\server\share\robrix2",
+        ] {
+            let mut fixture: serde_json::Value = serde_json::from_str(include_str!(
+                "../../specs/fixtures/agent-ops-client-v1-proposal/snapshot.json"
+            ))
+            .unwrap();
+            fixture["attention"][0]["summary"] = text.into();
+            assert!(
+                serde_json::from_value::<Snapshot>(fixture).is_err(),
+                "filesystem path should reject the projection: {text}",
+            );
+        }
+    }
+
+    #[test]
+    fn branch_names_are_not_mistaken_for_absolute_paths() {
+        let parsed: PrivacyFilteredText =
+            serde_json::from_str("\"agentchat/wf/thread-a\"").unwrap();
+        assert_eq!(parsed.as_str(), "agentchat/wf/thread-a");
+    }
+
+    #[test]
+    fn proposal_inspection_fixture_carries_explicit_resolution_grants() {
+        let fixture = include_str!("../../specs/fixtures/agent-ops-client-v1-proposal/outcome-inspection.json");
+        let inspection: OutcomeInspection = serde_json::from_str(fixture).unwrap();
+        assert_eq!(inspection.schema, PROPOSAL_SCHEMA);
+        assert_eq!(
+            inspection.resolution_action.kind,
+            AvailableActionKind::ResolveOutcome,
+        );
+        assert_eq!(
+            inspection.resolution_action.allowed_resolutions,
+            [
+                OutcomeResolutionKind::Continue,
+                OutcomeResolutionKind::AcceptCompleted,
+                OutcomeResolutionKind::KeepBlocked,
+            ],
+        );
+        assert_eq!(inspection.resource.dirty_generation, 2);
+    }
+
+    #[test]
+    fn resolution_fixtures_cover_the_complete_outcome_closure() {
+        let fixtures = [
+            include_str!("../../specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-continue.json"),
+            include_str!("../../specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-accept-completed.json"),
+            include_str!("../../specs/fixtures/agent-ops-client-v1-proposal/resolve-outcome-request-keep-blocked.json"),
+        ];
+        let commands: Vec<ResolveOutcomeCommand> = fixtures
+            .into_iter()
+            .map(|fixture| serde_json::from_str(fixture).unwrap())
+            .collect();
+
+        assert!(matches!(
+            commands[0].resolution,
+            OutcomeResolutionChoice::Continue { .. },
+        ));
+        assert_eq!(
+            commands[1].resolution,
+            OutcomeResolutionChoice::AcceptCompleted,
+        );
+        assert_eq!(
+            commands[2].resolution,
+            OutcomeResolutionChoice::KeepBlocked,
+        );
+        for command in commands {
+            let encoded = serde_json::to_value(&command).unwrap();
+            let decoded: ResolveOutcomeCommand = serde_json::from_value(encoded).unwrap();
+            assert_eq!(decoded, command);
+        }
+    }
+
+    #[test]
+    fn terminal_resolution_rejects_recovery_instruction() {
+        let fixture = include_str!(
+            "../../specs/fixtures/agent-ops-client-v1-proposal/invalid-resolve-outcome-request-accept-with-recovery.json"
+        );
+        assert!(serde_json::from_str::<ResolveOutcomeCommand>(fixture).is_err());
+    }
+
+    #[test]
+    fn capability_debug_output_is_redacted_and_empty_values_are_rejected() {
+        let capability: OpaqueCapability = serde_json::from_str("\"fixture-secret\"").unwrap();
+        let debug = format!("{capability:?}");
+        assert!(!debug.contains("fixture-secret"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!capability.is_empty());
+        assert!(serde_json::from_str::<OpaqueCapability>("\"   \"").is_err());
+    }
+}

--- a/src/agent_ops/panel.rs
+++ b/src/agent_ops/panel.rs
@@ -1,0 +1,498 @@
+//! Fail-closed Agent Operations integration status.
+//!
+//! The full panel must not connect to agent-chat's local Dashboard. The router
+//! endpoints use a backend-wide credential and return a different wire model.
+//! This screen remains intentionally inert until agent-chat's canonical client
+//! contract is released and verified, and a separate client runtime is
+//! implemented. The local R3 model experiment is test-only and cannot open the
+//! production gate.
+
+use makepad_widgets::*;
+
+use crate::{
+    app::AppState,
+    agent_ops::state::{AgentOpsAvailability, AgentOpsContractGate},
+    i18n::{AppLanguage, tr_fmt, tr_key},
+    shared::design_tokens::{
+        RBX_DANGER_BG, RBX_DANGER_FG, RBX_SUCCESS_BG, RBX_SUCCESS_FG,
+        RBX_WARNING_BG, RBX_WARNING_FG,
+    },
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AgentOpsStatusTone {
+    Success,
+    Warning,
+    Danger,
+}
+
+impl AgentOpsStatusTone {
+    fn colors(self) -> (Vec4, Vec4) {
+        match self {
+            Self::Success => (RBX_SUCCESS_BG, RBX_SUCCESS_FG),
+            Self::Warning => (RBX_WARNING_BG, RBX_WARNING_FG),
+            Self::Danger => (RBX_DANGER_BG, RBX_DANGER_FG),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AgentOpsPresentation {
+    status_key: &'static str,
+    next_step_key: &'static str,
+    tone: AgentOpsStatusTone,
+}
+
+impl AgentOpsPresentation {
+    fn for_availability(availability: &AgentOpsAvailability) -> Self {
+        let (status_key, tone) = match availability {
+            AgentOpsAvailability::NoContractManifest => (
+                "agent_ops.status.no_manifest",
+                AgentOpsStatusTone::Warning,
+            ),
+            AgentOpsAvailability::NotReleased { .. } => (
+                "agent_ops.status.not_released",
+                AgentOpsStatusTone::Warning,
+            ),
+            AgentOpsAvailability::UnboundSourceCommit => (
+                "agent_ops.status.unbound_commit",
+                AgentOpsStatusTone::Warning,
+            ),
+            AgentOpsAvailability::UnreadableManifest => (
+                "agent_ops.status.unreadable_manifest",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::ContractMismatch { .. } => (
+                "agent_ops.status.contract_mismatch",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::InvalidSourceCommit => (
+                "agent_ops.status.invalid_source_commit",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::EmptyArtifactSet => (
+                "agent_ops.status.empty_artifacts",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::InvalidArtifactManifest => (
+                "agent_ops.status.invalid_artifact_manifest",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::IncompleteArtifactManifest { .. } => (
+                "agent_ops.status.incomplete_artifact_manifest",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::ArtifactSetMismatch { .. } => (
+                "agent_ops.status.artifact_set_mismatch",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::ArtifactDigestMismatch { .. } => (
+                "agent_ops.status.artifact_digest_mismatch",
+                AgentOpsStatusTone::Danger,
+            ),
+            AgentOpsAvailability::ContractReady { .. } => (
+                "agent_ops.status.contract_ready",
+                AgentOpsStatusTone::Success,
+            ),
+        };
+        let next_step_key = if availability.is_contract_ready() {
+            "agent_ops.status.next_step_runtime"
+        } else {
+            "agent_ops.status.next_step_release"
+        };
+        Self { status_key, next_step_key, tone }
+    }
+}
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.AgentOpsPanel = #(AgentOpsPanel::register_widget(vm)) {
+        ..mod.widgets.View
+        width: Fill, height: Fill
+        flow: Down
+        padding: Inset{top: 10, left: 12, right: 12, bottom: 12}
+        spacing: (SPACE_MD)
+        show_bg: true
+        draw_bg +: { color: (RBX_BG_SURFACE) }
+
+        title := Label {
+            width: Fill, height: Fit
+            margin: Inset{top: 4, bottom: 4, left: 4}
+            draw_text +: {
+                color: (RBX_FG_PRIMARY)
+                text_style: (RBX_TEXT_PAGE_TITLE)
+            }
+            text: ""
+        }
+
+        contract_card := RoundedView {
+            width: Fill, height: Fit
+            flow: Down
+            spacing: (SPACE_SM)
+            padding: Inset{
+                top: (SPACE_MD), right: (SPACE_MD),
+                bottom: (SPACE_MD), left: (SPACE_MD)
+            }
+            show_bg: true
+            draw_bg +: {
+                color: (RBX_WARNING_BG)
+                border_radius: (RBX_RADIUS_SM)
+                border_size: 1.0
+                border_color: (RBX_STROKE_SOFT)
+            }
+
+            contract_status := Label {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
+                draw_text +: {
+                    color: (RBX_WARNING_FG)
+                    text_style: (RBX_TEXT_BODY_STRONG)
+                }
+                text: ""
+            }
+
+            contract_next_step := Label {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
+                draw_text +: {
+                    color: (RBX_FG_SECONDARY)
+                    text_style: (RBX_TEXT_BODY)
+                }
+                text: ""
+            }
+        }
+    }
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct AgentOpsPanel {
+    #[deref]
+    view: View,
+    #[rust(AgentOpsContractGate::from_vendored_manifest())]
+    contract_gate: AgentOpsContractGate,
+    #[rust]
+    app_language: AppLanguage,
+    #[rust(false)]
+    app_language_initialized: bool,
+}
+
+impl Widget for AgentOpsPanel {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.sync_language(cx, scope);
+        self.view.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.sync_language(cx, scope);
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl AgentOpsPanel {
+    fn sync_language(&mut self, cx: &mut Cx, scope: &mut Scope) {
+        let app_language = scope
+            .data
+            .get::<AppState>()
+            .map(|state| state.app_language)
+            .unwrap_or_default();
+        if self.app_language_initialized && self.app_language == app_language {
+            return;
+        }
+
+        self.app_language = app_language;
+        self.app_language_initialized = true;
+        self.view
+            .label(cx, ids!(title))
+            .set_text(cx, tr_key(app_language, "agent_ops.title"));
+
+        let availability = self.contract_gate.availability();
+        let presentation = AgentOpsPresentation::for_availability(availability);
+        let diagnostic = match availability {
+            AgentOpsAvailability::NoContractManifest => {
+                tr_key(app_language, "agent_ops.detail.no_manifest").to_string()
+            }
+            AgentOpsAvailability::UnreadableManifest => {
+                tr_key(app_language, "agent_ops.detail.unreadable_manifest").to_string()
+            }
+            AgentOpsAvailability::ContractMismatch { expected, found } => tr_fmt(
+                app_language,
+                "agent_ops.detail.contract_mismatch",
+                &[("expected", expected), ("found", found)],
+            ),
+            AgentOpsAvailability::NotReleased { release_status } => tr_fmt(
+                app_language,
+                "agent_ops.detail.not_released",
+                &[("release_status", release_status)],
+            ),
+            AgentOpsAvailability::UnboundSourceCommit => {
+                tr_key(app_language, "agent_ops.detail.unbound_commit").to_string()
+            }
+            AgentOpsAvailability::InvalidSourceCommit => {
+                tr_key(app_language, "agent_ops.detail.invalid_source_commit").to_string()
+            }
+            AgentOpsAvailability::EmptyArtifactSet => {
+                tr_key(app_language, "agent_ops.detail.empty_artifacts").to_string()
+            }
+            AgentOpsAvailability::InvalidArtifactManifest => {
+                tr_key(app_language, "agent_ops.detail.invalid_artifact_manifest").to_string()
+            }
+            AgentOpsAvailability::IncompleteArtifactManifest { missing_count } => {
+                let missing_count = missing_count.to_string();
+                tr_fmt(
+                    app_language,
+                    "agent_ops.detail.incomplete_artifact_manifest",
+                    &[("missing_count", &missing_count)],
+                )
+            }
+            AgentOpsAvailability::ArtifactSetMismatch {
+                missing_count,
+                unexpected_count,
+            } => {
+                let missing_count = missing_count.to_string();
+                let unexpected_count = unexpected_count.to_string();
+                tr_fmt(
+                    app_language,
+                    "agent_ops.detail.artifact_set_mismatch",
+                    &[
+                        ("missing_count", &missing_count),
+                        ("unexpected_count", &unexpected_count),
+                    ],
+                )
+            }
+            AgentOpsAvailability::ArtifactDigestMismatch { path } => tr_fmt(
+                app_language,
+                "agent_ops.detail.artifact_digest_mismatch",
+                &[("path", path)],
+            ),
+            AgentOpsAvailability::ContractReady { source_commit, artifact_count } => {
+                let artifact_count = artifact_count.to_string();
+                tr_fmt(
+                    app_language,
+                    "agent_ops.detail.contract_ready",
+                    &[
+                        ("source_commit", source_commit),
+                        ("artifact_count", &artifact_count),
+                    ],
+                )
+            }
+        };
+        let (background_color, foreground_color) = presentation.tone.colors();
+        let mut contract_card = self.view.view(cx, ids!(contract_card));
+        script_apply_eval!(cx, contract_card, {
+            draw_bg +: { color: #(background_color) }
+        });
+        let mut contract_status = self.view.label(cx, ids!(contract_card.contract_status));
+        script_apply_eval!(cx, contract_status, {
+            draw_text +: { color: #(foreground_color) }
+        });
+        contract_status.set_text(cx, tr_key(app_language, presentation.status_key));
+
+        let detail = format!(
+            "{}\n\n{}",
+            diagnostic,
+            tr_key(app_language, presentation.next_step_key),
+        );
+        self.view
+            .label(cx, ids!(contract_card.contract_next_step))
+            .set_text(cx, &detail);
+        self.redraw(cx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::AppState;
+
+    #[test]
+    fn panel_contains_no_backend_transport_or_credentials() {
+        for (path, source) in [
+            ("agent_ops/mod.rs", include_str!("mod.rs")),
+            ("agent_ops/panel.rs", include_str!("panel.rs")),
+            ("agent_ops/state.rs", include_str!("state.rs")),
+            ("home/home_screen.rs", include_str!("../home/home_screen.rs")),
+            ("home/navigation_tab_bar.rs", include_str!("../home/navigation_tab_bar.rs")),
+            ("settings/app_settings.rs", include_str!("../settings/app_settings.rs")),
+            ("lib.rs", include_str!("../lib.rs")),
+        ] {
+            let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+            for forbidden in [
+                "HttpRequest",
+                "http_request",
+                "Authorization",
+                "Bearer ",
+                "/api/router/",
+                "submit_async_request",
+            ] {
+                assert!(
+                    !production.contains(forbidden),
+                    "contract-gated source {path} must not contain {forbidden}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn proposal_model_is_not_wired_into_runtime_panel() {
+        let agent_ops_module = include_str!("mod.rs");
+        assert!(
+            agent_ops_module.contains("#[cfg(test)]\nmod model;"),
+            "the non-canonical proposal model must compile only in tests",
+        );
+        assert!(
+            !agent_ops_module.contains("pub mod model;"),
+            "the non-canonical proposal model must not be a production API",
+        );
+
+        let panel = include_str!("panel.rs");
+        let production = panel.split("#[cfg(test)]").next().unwrap_or(panel);
+        for proposal_type in [
+            "agent_ops::model",
+            "Snapshot",
+            "Invalidation",
+            "OutcomeInspection",
+            "ResolveOutcomeCommand",
+        ] {
+            assert!(
+                !production.contains(proposal_type),
+                "runtime panel must not consume proposal type {proposal_type}",
+            );
+        }
+    }
+
+    #[test]
+    fn contract_status_presentation_covers_tone_and_next_step() {
+        let source = include_str!("panel.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production.contains("AgentOpsPresentation::for_availability(availability)"),
+            "the runtime panel must derive its text and tone from the tested presentation",
+        );
+
+        for (availability, status_key, tone) in [
+            (
+                AgentOpsAvailability::NoContractManifest,
+                "agent_ops.status.no_manifest",
+                AgentOpsStatusTone::Warning,
+            ),
+            (
+                AgentOpsAvailability::NotReleased { release_status: "development".into() },
+                "agent_ops.status.not_released",
+                AgentOpsStatusTone::Warning,
+            ),
+            (
+                AgentOpsAvailability::UnboundSourceCommit,
+                "agent_ops.status.unbound_commit",
+                AgentOpsStatusTone::Warning,
+            ),
+            (
+                AgentOpsAvailability::UnreadableManifest,
+                "agent_ops.status.unreadable_manifest",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::ContractMismatch {
+                    expected: "expected".into(),
+                    found: "found".into(),
+                },
+                "agent_ops.status.contract_mismatch",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::InvalidSourceCommit,
+                "agent_ops.status.invalid_source_commit",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::EmptyArtifactSet,
+                "agent_ops.status.empty_artifacts",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::InvalidArtifactManifest,
+                "agent_ops.status.invalid_artifact_manifest",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::IncompleteArtifactManifest { missing_count: 1 },
+                "agent_ops.status.incomplete_artifact_manifest",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::ArtifactSetMismatch {
+                    missing_count: 1,
+                    unexpected_count: 1,
+                },
+                "agent_ops.status.artifact_set_mismatch",
+                AgentOpsStatusTone::Danger,
+            ),
+            (
+                AgentOpsAvailability::ArtifactDigestMismatch { path: "snapshot.json".into() },
+                "agent_ops.status.artifact_digest_mismatch",
+                AgentOpsStatusTone::Danger,
+            ),
+        ] {
+            assert_eq!(
+                AgentOpsPresentation::for_availability(&availability),
+                AgentOpsPresentation {
+                    status_key,
+                    next_step_key: "agent_ops.status.next_step_release",
+                    tone,
+                },
+            );
+        }
+
+        let ready = AgentOpsAvailability::ContractReady {
+            source_commit: "0123456789abcdef0123456789abcdef01234567".into(),
+            artifact_count: 20,
+        };
+        assert_eq!(
+            AgentOpsPresentation::for_availability(&ready),
+            AgentOpsPresentation {
+                status_key: "agent_ops.status.contract_ready",
+                next_step_key: "agent_ops.status.next_step_runtime",
+                tone: AgentOpsStatusTone::Success,
+            },
+        );
+    }
+
+    #[test]
+    fn settings_contains_no_agent_ops_secret_input() {
+        let settings = include_str!("../settings/app_settings.rs");
+        let production = settings.split("#[cfg(test)]").next().unwrap_or(settings);
+        for forbidden in [
+            "agent_ops_token_input",
+            "bearer_token",
+            "AgentOpsConfig",
+        ] {
+            assert!(
+                !production.contains(forbidden),
+                "settings must not collect or persist {forbidden}",
+            );
+        }
+
+        let stored = serde_json::to_value(AppState::default()).unwrap();
+        assert!(
+            stored.get("agent_ops").is_none(),
+            "AppState must not contain Agent Operations credentials or configuration",
+        );
+    }
+
+    #[test]
+    fn legacy_agent_ops_credentials_are_not_reserialized() {
+        let mut stored = serde_json::to_value(AppState::default()).unwrap();
+        stored["agent_ops"] = serde_json::json!({
+            "base_url": "http://127.0.0.1:8084",
+            "bearer_token": "legacy-prototype-secret",
+        });
+
+        let restored: AppState = serde_json::from_value(stored).unwrap();
+        let rewritten = serde_json::to_value(restored).unwrap();
+        assert!(
+            rewritten.get("agent_ops").is_none(),
+            "obsolete Agent Operations credentials must be dropped on the next state save",
+        );
+    }
+}

--- a/src/agent_ops/sha256.rs
+++ b/src/agent_ops/sha256.rs
@@ -1,0 +1,131 @@
+//! Minimal SHA-256 implementation for verifying vendored contract artifacts.
+//!
+//! The project deliberately adds no dependency for this small build-time-sized
+//! use case. This module is private to the contract gate and is covered by
+//! standard test vectors below.
+
+const INITIAL_STATE: [u32; 8] = [
+    0x6a09e667,
+    0xbb67ae85,
+    0x3c6ef372,
+    0xa54ff53a,
+    0x510e527f,
+    0x9b05688c,
+    0x1f83d9ab,
+    0x5be0cd19,
+];
+
+const ROUND_CONSTANTS: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+pub(super) fn hex_digest(input: &[u8]) -> String {
+    let bit_len = (input.len() as u64).wrapping_mul(8);
+    let mut message = Vec::with_capacity(input.len().saturating_add(72));
+    message.extend_from_slice(input);
+    message.push(0x80);
+    while message.len() % 64 != 56 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+
+    let mut state = INITIAL_STATE;
+    for block in message.chunks_exact(64) {
+        compress(&mut state, block);
+    }
+
+    let mut output = String::with_capacity(64);
+    for word in state {
+        use std::fmt::Write as _;
+        write!(&mut output, "{word:08x}").expect("writing SHA-256 into a String cannot fail");
+    }
+    output
+}
+
+fn compress(state: &mut [u32; 8], block: &[u8]) {
+    debug_assert_eq!(block.len(), 64);
+    let mut schedule = [0u32; 64];
+    for (index, bytes) in block.chunks_exact(4).enumerate() {
+        schedule[index] = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    }
+    for index in 16..64 {
+        let sigma_0 = schedule[index - 15].rotate_right(7)
+            ^ schedule[index - 15].rotate_right(18)
+            ^ (schedule[index - 15] >> 3);
+        let sigma_1 = schedule[index - 2].rotate_right(17)
+            ^ schedule[index - 2].rotate_right(19)
+            ^ (schedule[index - 2] >> 10);
+        schedule[index] = schedule[index - 16]
+            .wrapping_add(sigma_0)
+            .wrapping_add(schedule[index - 7])
+            .wrapping_add(sigma_1);
+    }
+
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+    for index in 0..64 {
+        let sum_1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+        let choose = (e & f) ^ ((!e) & g);
+        let temp_1 = h
+            .wrapping_add(sum_1)
+            .wrapping_add(choose)
+            .wrapping_add(ROUND_CONSTANTS[index])
+            .wrapping_add(schedule[index]);
+        let sum_0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+        let majority = (a & b) ^ (a & c) ^ (b & c);
+        let temp_2 = sum_0.wrapping_add(majority);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(temp_1);
+        d = c;
+        c = b;
+        b = a;
+        a = temp_1.wrapping_add(temp_2);
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_standard_sha256_vectors() {
+        assert_eq!(
+            hex_digest(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+        assert_eq!(
+            hex_digest(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        );
+        assert_eq!(
+            hex_digest(b"The quick brown fox jumps over the lazy dog"),
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        );
+    }
+}

--- a/src/agent_ops/state.rs
+++ b/src/agent_ops/state.rs
@@ -1,0 +1,674 @@
+//! Contract gate for the Agent Operations Panel.
+//!
+//! agent-chat has supplied a development manifest for a dedicated client
+//! contract. Robrix2 has no released canonical artifact set or operational
+//! runtime yet. The panel stays closed until the manifest says the contract is
+//! *released* and names the immutable commit it was cut from.
+//!
+//! The gate verifies both the manifest and the exact artifact bytes compiled
+//! into Robrix. Opening therefore requires an auditable diff that vendors and
+//! registers the complete release; changing only the status field can never
+//! make unverified contract material usable.
+//!
+//! See `docs/agent-system-planes.md` for why this boundary exists at all.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use super::sha256;
+
+/// The cross-repository contract this client speaks.
+pub const AGENT_OPS_CLIENT_CONTRACT: &str = "io.agentchat.agent_ops.v1";
+
+/// The only `release_status` that may open the gate.
+const RELEASED_STATUS: &str = "released";
+
+/// Artifacts that make up the accepted V1 contract. A released manifest must
+/// contain every one of these paths; listing one arbitrary file is not enough
+/// to claim that the contract is consumable.
+const REQUIRED_ARTIFACT_PATHS: &[&str] = &[
+    "cancel-dispatch-response.json",
+    "client-session-grant.json",
+    "client-session-request.json",
+    "client-session.json",
+    "contract.schema.json",
+    "error-precondition-failed.json",
+    "grant-exchange-request.json",
+    "grant-proof-material.json",
+    "invalid-empty-capability.json",
+    "invalid-terminal-resolution-with-recovery.json",
+    "invalidation.json",
+    "outcome-inspection.json",
+    "protocol-limits.json",
+    "resolve-outcome-request-accept-completed.json",
+    "resolve-outcome-request-continue.json",
+    "resolve-outcome-request-keep-blocked.json",
+    "resolve-outcome-response.json",
+    "session-proof-material.json",
+    "snapshot.json",
+    "stable-errors.json",
+];
+
+/// One canonical artifact compiled into this Robrix build.
+///
+/// The development manifest has been vendored, but agent-chat has not released
+/// the canonical artifact bytes yet. Keep this list empty until those exact
+/// files are copied into `specs/fixtures/agent-ops-client-v1/`, then register
+/// each with `include_bytes!`. A manifest-only status flip therefore cannot
+/// open the gate.
+#[derive(Clone, Copy, Debug)]
+struct VendoredArtifact<'a> {
+    path: &'a str,
+    bytes: &'a [u8],
+}
+
+const VENDORED_ARTIFACTS: &[VendoredArtifact<'static>] = &[];
+
+/// agent-chat's canonical artifact manifest.
+///
+/// Unknown fields are ignored so the manifest can grow, but every field the
+/// gate depends on is required: a manifest that fails to parse cannot open it.
+#[derive(Clone, Debug, Deserialize)]
+pub struct ContractManifest {
+    pub contract: String,
+    pub release_status: String,
+    /// The immutable commit the artifacts were cut from. `None` until the
+    /// producing repository has committed them.
+    #[serde(default)]
+    pub source_commit: Option<String>,
+    #[serde(default)]
+    pub artifacts: Vec<ManifestArtifact>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ManifestArtifact {
+    pub path: String,
+    pub sha256: String,
+}
+
+/// The contract material's readiness state.
+///
+/// Each variant names something a human can act on; none of them is a generic
+/// failure, because "it doesn't work" is not a reviewable state for a gate that
+/// guards privileged access.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum AgentOpsAvailability {
+    /// No manifest was supplied to the gate.
+    #[default]
+    NoContractManifest,
+    /// The manifest could not be parsed, so nothing about it can be trusted.
+    UnreadableManifest,
+    /// The manifest describes a different contract than this client speaks.
+    ContractMismatch { expected: String, found: String },
+    /// The manifest does not claim a released contract; its artifacts may
+    /// still change, so a client built against them would drift.
+    NotReleased { release_status: String },
+    /// Released, but not bound to a commit — the artifacts are still a moving
+    /// target even though the status claims otherwise.
+    UnboundSourceCommit,
+    /// The source binding is not a full Git object id, so it does not identify
+    /// one immutable producer revision.
+    InvalidSourceCommit,
+    /// The manifest carries no artifacts, so there is nothing to verify against.
+    EmptyArtifactSet,
+    /// An artifact path, digest, or uniqueness rule is malformed.
+    InvalidArtifactManifest,
+    /// The manifest omitted one or more artifacts required by V1.
+    IncompleteArtifactManifest { missing_count: usize },
+    /// The manifest and the artifact bytes compiled into this build do not name
+    /// exactly the same set.
+    ArtifactSetMismatch {
+        missing_count: usize,
+        unexpected_count: usize,
+    },
+    /// A compiled artifact does not match the digest published by agent-chat.
+    ArtifactDigestMismatch { path: String },
+    /// The contract artifacts are pinned and verified. This says nothing about
+    /// runtime bootstrap or backend connectivity.
+    ContractReady {
+        source_commit: String,
+        artifact_count: usize,
+    },
+}
+
+impl AgentOpsAvailability {
+    pub fn is_contract_ready(&self) -> bool {
+        matches!(self, Self::ContractReady { .. })
+    }
+
+    /// An English diagnostic for logs and tests. The panel uses localized
+    /// templates and only interpolates the manifest values from these variants.
+    pub fn explanation(&self) -> String {
+        match self {
+            Self::NoContractManifest => {
+                "The agent-chat client contract manifest was not found. The panel stays closed \
+                 until agent-chat ships a released manifest."
+                    .to_string()
+            }
+            Self::UnreadableManifest => {
+                "The agent-chat client contract manifest could not be read. Nothing about it can \
+                 be trusted, so the panel stays closed."
+                    .to_string()
+            }
+            Self::ContractMismatch { expected, found } => format!(
+                "This client speaks {expected}, but the manifest describes {found}. The panel \
+                 stays closed rather than guess at a translation."
+            ),
+            Self::NotReleased { release_status } => format!(
+                "The agent-chat client contract is marked \"{release_status}\", not released. Its \
+                 artifacts can still change, so the panel stays closed."
+            ),
+            Self::UnboundSourceCommit => {
+                "The agent-chat client contract is marked released but names no source commit, so \
+                 its artifacts are still a moving target. The panel stays closed."
+                    .to_string()
+            }
+            Self::InvalidSourceCommit => {
+                "The agent-chat client contract source binding is not a full Git object id. The \
+                 panel stays closed until it names one immutable producer revision."
+                    .to_string()
+            }
+            Self::EmptyArtifactSet => {
+                "The agent-chat client contract manifest lists no artifacts, so there is nothing \
+                 to verify against. The panel stays closed."
+                    .to_string()
+            }
+            Self::InvalidArtifactManifest => {
+                "The agent-chat client contract manifest contains an invalid artifact path, digest, \
+                 or duplicate entry. The panel stays closed."
+                    .to_string()
+            }
+            Self::IncompleteArtifactManifest { missing_count } => format!(
+                "The agent-chat client contract manifest omits {missing_count} artifacts required \
+                 by V1. The panel stays closed."
+            ),
+            Self::ArtifactSetMismatch { missing_count, unexpected_count } => format!(
+                "The compiled artifact set does not match the manifest ({missing_count} missing, \
+                 {unexpected_count} unexpected). The panel stays closed."
+            ),
+            Self::ArtifactDigestMismatch { path } => format!(
+                "The compiled artifact {path} does not match agent-chat's published SHA-256 digest. \
+                 The panel stays closed."
+            ),
+            Self::ContractReady { source_commit, artifact_count } => format!(
+                "The agent-chat client contract artifacts are pinned to {source_commit} and all \
+                 {artifact_count} digests match. No runtime connection has been attempted."
+            ),
+        }
+    }
+}
+
+/// Decides whether the contract is ready for a future runtime.
+///
+/// Deliberately has no configuration, credential, URL, polling, or mutation
+/// API. Those belong to the client runtime, which may only be built after this
+/// gate reports [`AgentOpsAvailability::ContractReady`].
+#[derive(Clone, Debug, Default)]
+pub struct AgentOpsContractGate {
+    availability: AgentOpsAvailability,
+}
+
+/// agent-chat's manifest, vendored into this repository and compiled in.
+///
+/// Embedding rather than reading it at runtime is deliberate: the gate's answer
+/// becomes a fact pinned by *this* repository's commit, with no filesystem
+/// lookup, no environment dependence, and no network call. Updating the
+/// contract is therefore an explicit, reviewable act — copy the released
+/// manifest and every canonical artifact in, then register their bytes above.
+const VENDORED_MANIFEST: &str =
+    include_str!("../../specs/fixtures/agent-ops-client-v1/manifest.json");
+
+impl AgentOpsContractGate {
+    /// The gate as it stands in this build, judged from the vendored manifest.
+    pub fn from_vendored_manifest() -> Self {
+        Self::from_manifest_json_and_artifacts(VENDORED_MANIFEST, VENDORED_ARTIFACTS)
+    }
+
+    /// A gate with no manifest: closed.
+    pub fn closed() -> Self {
+        Self { availability: AgentOpsAvailability::NoContractManifest }
+    }
+
+    /// Evaluate raw manifest bytes. Any failure closes the gate; there is no
+    /// path through this function that opens it on partial information.
+    pub fn from_manifest_json(json: &str) -> Self {
+        Self::from_manifest_json_and_artifacts(json, &[])
+    }
+
+    fn from_manifest_json_and_artifacts(
+        json: &str,
+        artifacts: &[VendoredArtifact<'_>],
+    ) -> Self {
+        let Ok(manifest) = serde_json::from_str::<ContractManifest>(json) else {
+            return Self { availability: AgentOpsAvailability::UnreadableManifest };
+        };
+        Self::from_manifest_and_artifacts(&manifest, artifacts)
+    }
+
+    pub fn from_manifest(manifest: &ContractManifest) -> Self {
+        Self::from_manifest_and_artifacts(manifest, &[])
+    }
+
+    fn from_manifest_and_artifacts(
+        manifest: &ContractManifest,
+        artifacts: &[VendoredArtifact<'_>],
+    ) -> Self {
+        Self { availability: Self::evaluate(manifest, artifacts) }
+    }
+
+    fn evaluate(
+        manifest: &ContractManifest,
+        artifacts: &[VendoredArtifact<'_>],
+    ) -> AgentOpsAvailability {
+        if manifest.contract != AGENT_OPS_CLIENT_CONTRACT {
+            return AgentOpsAvailability::ContractMismatch {
+                expected: AGENT_OPS_CLIENT_CONTRACT.to_string(),
+                found: manifest.contract.clone(),
+            };
+        }
+        if manifest.release_status != RELEASED_STATUS {
+            return AgentOpsAvailability::NotReleased {
+                release_status: manifest.release_status.clone(),
+            };
+        }
+        // Released without a commit is the more dangerous case of the two: the
+        // status invites trust that the binding does not support.
+        let Some(commit) = manifest.source_commit.as_deref().map(str::trim).filter(|c| !c.is_empty())
+        else {
+            return AgentOpsAvailability::UnboundSourceCommit;
+        };
+        if !is_full_git_object_id(commit) {
+            return AgentOpsAvailability::InvalidSourceCommit;
+        }
+        if manifest.artifacts.is_empty() {
+            return AgentOpsAvailability::EmptyArtifactSet;
+        }
+
+        let mut manifest_by_path = HashMap::with_capacity(manifest.artifacts.len());
+        for artifact in &manifest.artifacts {
+            if !is_safe_artifact_path(&artifact.path)
+                || !is_lowercase_hex(&artifact.sha256, 64)
+                || manifest_by_path.insert(artifact.path.as_str(), artifact.sha256.as_str()).is_some()
+            {
+                return AgentOpsAvailability::InvalidArtifactManifest;
+            }
+        }
+
+        let missing_required = REQUIRED_ARTIFACT_PATHS
+            .iter()
+            .filter(|path| !manifest_by_path.contains_key(**path))
+            .count();
+        if missing_required > 0 {
+            return AgentOpsAvailability::IncompleteArtifactManifest {
+                missing_count: missing_required,
+            };
+        }
+
+        let mut vendored_by_path = HashMap::with_capacity(artifacts.len());
+        for artifact in artifacts {
+            if !is_safe_artifact_path(artifact.path)
+                || vendored_by_path.insert(artifact.path, artifact.bytes).is_some()
+            {
+                return AgentOpsAvailability::InvalidArtifactManifest;
+            }
+        }
+        let missing_count = manifest_by_path
+            .keys()
+            .filter(|path| !vendored_by_path.contains_key(**path))
+            .count();
+        let unexpected_count = vendored_by_path
+            .keys()
+            .filter(|path| !manifest_by_path.contains_key(**path))
+            .count();
+        if missing_count > 0 || unexpected_count > 0 {
+            return AgentOpsAvailability::ArtifactSetMismatch {
+                missing_count,
+                unexpected_count,
+            };
+        }
+
+        for (path, expected_digest) in manifest_by_path {
+            let Some(bytes) = vendored_by_path.get(path) else {
+                return AgentOpsAvailability::ArtifactSetMismatch {
+                    missing_count: 1,
+                    unexpected_count: 0,
+                };
+            };
+            if sha256::hex_digest(bytes) != expected_digest {
+                return AgentOpsAvailability::ArtifactDigestMismatch {
+                    path: path.to_string(),
+                };
+            }
+        }
+
+        AgentOpsAvailability::ContractReady {
+            source_commit: commit.to_string(),
+            artifact_count: manifest.artifacts.len(),
+        }
+    }
+
+    pub fn availability(&self) -> &AgentOpsAvailability {
+        &self.availability
+    }
+
+    pub fn is_contract_ready(&self) -> bool {
+        self.availability.is_contract_ready()
+    }
+
+    pub fn explanation(&self) -> String {
+        self.availability.explanation()
+    }
+}
+
+fn is_full_git_object_id(value: &str) -> bool {
+    is_lowercase_hex(value, 40) || is_lowercase_hex(value, 64)
+}
+
+fn is_lowercase_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn is_safe_artifact_path(value: &str) -> bool {
+    let path = std::path::Path::new(value);
+    !value.is_empty()
+        && !value.contains('\\')
+        && !path.is_absolute()
+        && path.components().all(|component| {
+            matches!(component, std::path::Component::Normal(_))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE_COMMIT: &str = "9f2c1ab4d5e6f70819a2b3c4d5e6f7089a1b2c3d";
+
+    fn manifest_json(status: &str, commit: &str) -> String {
+        let commit_field =
+            if commit.is_empty() { "null".to_string() } else { format!("\"{commit}\"") };
+        format!(
+            r#"{{"contract":"{AGENT_OPS_CLIENT_CONTRACT}","release_status":"{status}",
+                "source_commit":{commit_field},"artifacts":[]}}"#,
+        )
+    }
+
+    fn matching_artifacts() -> Vec<VendoredArtifact<'static>> {
+        REQUIRED_ARTIFACT_PATHS
+            .iter()
+            .map(|path| VendoredArtifact {
+                path,
+                bytes: path.as_bytes(),
+            })
+            .collect()
+    }
+
+    fn released_manifest(artifacts: &[VendoredArtifact<'_>]) -> ContractManifest {
+        ContractManifest {
+            contract: AGENT_OPS_CLIENT_CONTRACT.into(),
+            release_status: RELEASED_STATUS.into(),
+            source_commit: Some(SOURCE_COMMIT.into()),
+            artifacts: artifacts
+                .iter()
+                .map(|artifact| ManifestArtifact {
+                    path: artifact.path.into(),
+                    sha256: sha256::hex_digest(artifact.bytes),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn contract_gate_is_fail_closed() {
+        let gate = AgentOpsContractGate::closed();
+        assert!(!gate.is_contract_ready());
+        assert_eq!(gate.availability(), &AgentOpsAvailability::NoContractManifest);
+        assert!(gate.explanation().contains("stays closed"));
+    }
+
+    /// The manifest agent-chat ships today is deliberately not released. This
+    /// is the exact condition the gate exists to hold shut.
+    #[test]
+    fn development_manifest_keeps_the_panel_closed() {
+        let gate = AgentOpsContractGate::from_manifest_json(&manifest_json("development", ""));
+        assert!(!gate.is_contract_ready());
+        assert_eq!(
+            gate.availability(),
+            &AgentOpsAvailability::NotReleased { release_status: "development".into() },
+        );
+        assert!(gate.explanation().contains("development"));
+    }
+
+    /// Claiming released while naming no commit is the trap worth naming
+    /// separately: the status invites trust the binding cannot support.
+    #[test]
+    fn released_without_a_source_commit_stays_closed() {
+        let gate = AgentOpsContractGate::from_manifest_json(&manifest_json("released", ""));
+        assert!(!gate.is_contract_ready());
+        assert_eq!(gate.availability(), &AgentOpsAvailability::UnboundSourceCommit);
+    }
+
+    #[test]
+    fn blank_source_commit_is_treated_as_unbound() {
+        let gate = AgentOpsContractGate::from_manifest_json(&manifest_json("released", "   "));
+        assert_eq!(gate.availability(), &AgentOpsAvailability::UnboundSourceCommit);
+    }
+
+    #[test]
+    fn abbreviated_source_commit_stays_closed() {
+        let gate = AgentOpsContractGate::from_manifest_json(&manifest_json("released", "abc123"));
+        assert_eq!(gate.availability(), &AgentOpsAvailability::InvalidSourceCommit);
+    }
+
+    /// The core promise of the byte layer: a manifest can look perfect —
+    /// released, fully bound, all twenty required artifacts with correct
+    /// digests — yet the gate must stay shut while this build vendors no
+    /// artifact bytes. A status-field flip alone can never open it.
+    #[test]
+    fn a_perfect_manifest_with_no_vendored_bytes_stays_closed() {
+        let manifest = released_manifest(&matching_artifacts());
+        // Deliberately verify against an EMPTY vendored set, exactly the state
+        // this build ships in (VENDORED_ARTIFACTS == &[]).
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &[]);
+        assert!(!gate.is_contract_ready());
+        assert!(
+            matches!(gate.availability(), &AgentOpsAvailability::ArtifactSetMismatch { .. }),
+            "empty vendored bytes must be a set mismatch, not readiness: {:?}",
+            gate.availability(),
+        );
+    }
+
+    /// The shipping build's own gate, with its real empty vendored set, must
+    /// not be ready regardless of what the vendored manifest later becomes.
+    #[test]
+    fn shipping_gate_with_empty_vendored_set_is_not_ready() {
+        assert!(!AgentOpsContractGate::from_vendored_manifest().is_contract_ready());
+        assert!(VENDORED_ARTIFACTS.is_empty(), "guarding the assumption this test relies on");
+    }
+
+    #[test]
+    fn released_manifest_and_matching_artifacts_make_the_contract_ready() {
+        let artifacts = matching_artifacts();
+        let manifest = released_manifest(&artifacts);
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &artifacts);
+        assert!(gate.is_contract_ready());
+        assert_eq!(
+            gate.availability(),
+            &AgentOpsAvailability::ContractReady {
+                source_commit: SOURCE_COMMIT.into(),
+                artifact_count: 20,
+            },
+        );
+        assert!(gate.explanation().contains("9f2c1ab4"));
+        assert!(gate.explanation().contains("No runtime connection"));
+    }
+
+    #[test]
+    fn a_released_manifest_with_no_artifacts_stays_closed() {
+        let gate = AgentOpsContractGate::from_manifest_json(&manifest_json("released", SOURCE_COMMIT));
+        assert_eq!(gate.availability(), &AgentOpsAvailability::EmptyArtifactSet);
+    }
+
+    #[test]
+    fn manifest_only_release_cannot_open_without_compiled_artifacts() {
+        let artifacts = matching_artifacts();
+        let manifest = released_manifest(&artifacts);
+        let gate = AgentOpsContractGate::from_manifest(&manifest);
+        assert_eq!(
+            gate.availability(),
+            &AgentOpsAvailability::ArtifactSetMismatch {
+                missing_count: REQUIRED_ARTIFACT_PATHS.len(),
+                unexpected_count: 0,
+            },
+        );
+    }
+
+    #[test]
+    fn incomplete_v1_manifest_stays_closed() {
+        let artifacts = matching_artifacts();
+        let mut manifest = released_manifest(&artifacts);
+        manifest.artifacts.pop();
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(
+            &manifest,
+            &artifacts[..artifacts.len() - 1],
+        );
+        assert_eq!(
+            gate.availability(),
+            &AgentOpsAvailability::IncompleteArtifactManifest { missing_count: 1 },
+        );
+    }
+
+    #[test]
+    fn malformed_or_duplicate_artifact_entries_stay_closed() {
+        let artifacts = matching_artifacts();
+        let mut manifest = released_manifest(&artifacts);
+        manifest.artifacts[0].sha256 = "not-a-sha256".into();
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &artifacts);
+        assert_eq!(gate.availability(), &AgentOpsAvailability::InvalidArtifactManifest);
+
+        let mut manifest = released_manifest(&artifacts);
+        manifest.artifacts.push(manifest.artifacts[0].clone());
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &artifacts);
+        assert_eq!(gate.availability(), &AgentOpsAvailability::InvalidArtifactManifest);
+
+        let mut manifest = released_manifest(&artifacts);
+        manifest.artifacts[0].path = "../contract.schema.json".into();
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &artifacts);
+        assert_eq!(gate.availability(), &AgentOpsAvailability::InvalidArtifactManifest);
+
+        let mut manifest = released_manifest(&artifacts);
+        manifest.artifacts[0].path = r#"nested\contract.schema.json"#.into();
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &artifacts);
+        assert_eq!(gate.availability(), &AgentOpsAvailability::InvalidArtifactManifest);
+    }
+
+    #[test]
+    fn artifact_set_and_digest_mismatches_stay_closed() {
+        let artifacts = matching_artifacts();
+        let manifest = released_manifest(&artifacts);
+
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(
+            &manifest,
+            &artifacts[..artifacts.len() - 1],
+        );
+        assert_eq!(
+            gate.availability(),
+            &AgentOpsAvailability::ArtifactSetMismatch {
+                missing_count: 1,
+                unexpected_count: 0,
+            },
+        );
+
+        let mut tampered = artifacts.clone();
+        tampered[0].bytes = b"tampered";
+        let gate = AgentOpsContractGate::from_manifest_and_artifacts(&manifest, &tampered);
+        assert!(matches!(
+            gate.availability(),
+            AgentOpsAvailability::ArtifactDigestMismatch { .. },
+        ));
+    }
+
+    #[test]
+    fn a_different_contract_never_opens_the_gate() {
+        let json = r#"{"contract":"io.agentchat.agent_ops.v2","release_status":"released",
+                       "source_commit":"abc123","artifacts":[{"path":"a.json","sha256":"00"}]}"#;
+        let gate = AgentOpsContractGate::from_manifest_json(json);
+        assert!(!gate.is_contract_ready());
+        assert!(matches!(
+            gate.availability(),
+            AgentOpsAvailability::ContractMismatch { .. },
+        ));
+        assert!(gate.explanation().contains("v2"));
+    }
+
+    #[test]
+    fn unparsable_manifest_stays_closed() {
+        for json in ["", "not json", "{}", r#"{"contract":"io.agentchat.agent_ops.v1"}"#] {
+            let gate = AgentOpsContractGate::from_manifest_json(json);
+            assert!(!gate.is_contract_ready(), "must not open on {json:?}");
+        }
+    }
+
+    /// The manifest actually vendored in this build must parse and must name
+    /// the contract this client speaks. Whether it opens the gate is a fact
+    /// about the contract's release state, asserted separately below.
+    #[test]
+    fn vendored_manifest_is_parseable_and_names_this_contract() {
+        let manifest: ContractManifest = serde_json::from_str(VENDORED_MANIFEST)
+            .expect("the vendored manifest must parse");
+        assert_eq!(manifest.contract, AGENT_OPS_CLIENT_CONTRACT);
+        assert!(!manifest.artifacts.is_empty(), "a contract with no artifacts is not a contract");
+    }
+
+    /// A future release-status change must be accompanied by all canonical
+    /// bytes and their registrations. Changing only the manifest must fail.
+    #[test]
+    fn vendored_manifest_only_becomes_ready_with_verified_artifacts() {
+        let manifest: ContractManifest = serde_json::from_str(VENDORED_MANIFEST).unwrap();
+        let gate = AgentOpsContractGate::from_vendored_manifest();
+
+        if manifest.release_status == RELEASED_STATUS {
+            assert!(
+                gate.is_contract_ready(),
+                "a released manifest must have a full commit binding and every matching artifact",
+            );
+        } else {
+            assert!(!gate.is_contract_ready());
+        }
+    }
+
+    /// Every closed state must say something a human can act on, and no closed
+    /// state may claim the panel is connected.
+    #[test]
+    fn every_closed_state_explains_itself() {
+        let closed = vec![
+            AgentOpsAvailability::NoContractManifest,
+            AgentOpsAvailability::UnreadableManifest,
+            AgentOpsAvailability::ContractMismatch {
+                expected: "a".into(),
+                found: "b".into(),
+            },
+            AgentOpsAvailability::NotReleased { release_status: "development".into() },
+            AgentOpsAvailability::UnboundSourceCommit,
+            AgentOpsAvailability::InvalidSourceCommit,
+            AgentOpsAvailability::EmptyArtifactSet,
+            AgentOpsAvailability::InvalidArtifactManifest,
+            AgentOpsAvailability::IncompleteArtifactManifest { missing_count: 1 },
+            AgentOpsAvailability::ArtifactSetMismatch {
+                missing_count: 1,
+                unexpected_count: 0,
+            },
+            AgentOpsAvailability::ArtifactDigestMismatch { path: "snapshot.json".into() },
+        ];
+        for state in closed {
+            assert!(!state.is_contract_ready());
+            let text = state.explanation();
+            assert!(text.len() > 40, "explanation too thin: {text}");
+            assert!(!text.contains("Connected"), "closed state must not claim connection");
+        }
+    }
+}

--- a/src/agent_ops_dummy.rs
+++ b/src/agent_ops_dummy.rs
@@ -1,0 +1,43 @@
+//! An inert stand-in for the Agent Operations Panel.
+//!
+//! `HomeScreen`'s DSL declares an `agent_ops_page` unconditionally, so the
+//! `AgentOpsPanel` name has to resolve in builds without the `agent_chat`
+//! feature too. This provides that name and nothing else: the page exists but
+//! is unreachable, because no navigation entry emits `GoToAgentOps` without the
+//! feature, and `update_active_page_from_selection` normalizes any stale
+//! `AgentOps` selection back to Home.
+//!
+//! Same shape as `tsp_dummy` — see that module for the original of this pattern.
+
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.AgentOpsPanel = View {
+        visible: false,
+        width: Fill, height: Fill
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_panel_absent_without_agent_chat_feature() {
+        assert!(!cfg!(feature = "agent_chat"));
+
+        let settings = include_str!("settings/app_settings.rs");
+        let emit_site = settings
+            .find("NavigationBarAction::GoToAgentOps")
+            .expect("feature build should retain the integration-status entry");
+        let preceding = &settings[..emit_site];
+        let guard = preceding
+            .rfind("#[cfg(feature = \"agent_chat\")]")
+            .expect("entry must be guarded by the agent_chat feature");
+        assert!(
+            !preceding[guard..].contains("#[cfg(not(feature = \"agent_chat\"))]"),
+            "the entry must remain inside the feature-gated block",
+        );
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -2313,6 +2313,11 @@ impl AppMain for App {
         crate::join_leave_room_modal::script_mod(vm);
         crate::verification_modal::script_mod(vm);
         crate::profile::script_mod(vm);
+        // HomeScreen's DSL references AgentOpsPanel, so it must be registered first.
+        #[cfg(feature = "agent_chat")]
+        crate::agent_ops::script_mod(vm);
+        #[cfg(not(feature = "agent_chat"))]
+        crate::agent_ops_dummy::script_mod(vm);
         crate::home::script_mod(vm);
         crate::login::script_mod(vm);
         crate::register::script_mod(vm);
@@ -2737,16 +2742,8 @@ impl App {
             room_to_close,
         );
 
-        // Before we navigate to the room, if a non-room tab is currently shown
-        // (AddRoom, or Settings — e.g. tapping "Open chat" on a registered agent
-        // in Settings ▸ Labs), programmatically navigate to the Home tab so the
-        // actual room becomes visible. On mobile the pushed StackNavigation view
-        // covers everything regardless; but on desktop the layout is driven by
-        // `selected_tab`, so without this the room opens in the dock *behind* the
-        // still-shown Settings page and nothing appears to happen.
-        if matches!(self.app_state.selected_tab, SelectedTab::AddRoom | SelectedTab::Settings) {
-            cx.action(NavigationBarAction::GoToHome);
-        }
+        // HomeScreen owns top-level navigation state and normalizes every
+        // RoomsListAction::Selected before the desktop Dock handles it.
         cx.widget_action(
             self.ui.widget_uid(), 
             RoomsListAction::Selected(new_selected_room),

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -2,7 +2,10 @@ use makepad_widgets::*;
 
 use crate::{
     app::AppState,
-    home::navigation_tab_bar::{NavigationBarAction, SelectedTab},
+    home::{
+        navigation_tab_bar::{NavigationBarAction, SelectedTab},
+        rooms_list::RoomsListAction,
+    },
     settings::app_preferences::{AppPreferencesAction, ViewModeOverride},
     settings::settings_screen::SettingsScreenWidgetRefExt,
     shared::room_filter_input_bar::{MainFilterAction, RoomFilterInputBarWidgetExt},
@@ -359,6 +362,16 @@ script_mod! {
                             directory_screen := mod.widgets.DirectoryScreen {}
                         }
                     }
+
+                    agent_ops_page := SolidView {
+                        width: Fill, height: Fill
+                        show_bg: true,
+                        draw_bg.color: (COLOR_PRIMARY)
+
+                        CachedWidget {
+                            agent_ops_panel := mod.widgets.AgentOpsPanel {}
+                        }
+                    }
                 }
             }
 
@@ -412,6 +425,14 @@ script_mod! {
 
                                 CachedWidget {
                                     directory_screen := mod.widgets.DirectoryScreen {}
+                                }
+                            }
+
+                            agent_ops_page := View {
+                                width: Fill, height: Fill
+
+                                CachedWidget {
+                                    agent_ops_panel := mod.widgets.AgentOpsPanel {}
                                 }
                             }
                         }
@@ -522,6 +543,25 @@ impl Widget for HomeScreen {
 
             let app_state = scope.data.get_mut::<AppState>().unwrap();
             for action in actions {
+                // A room selection can originate from the sidebar or from any
+                // programmatic navigation path. Normalize the top-level page
+                // here, before forwarding the action to the desktop Dock, so
+                // the focused room can never open behind an overlay page.
+                if matches!(
+                    action.as_widget_action().cast_ref(),
+                    RoomsListAction::Selected(_),
+                ) {
+                    let next_selection = selection_after_opening_room(&app_state.selected_tab);
+                    if next_selection != app_state.selected_tab {
+                        self.previous_selection = app_state.selected_tab.clone();
+                        app_state.selected_tab = next_selection;
+                        cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
+                        self.update_active_page_from_selection(cx, app_state);
+                        self.view.redraw(cx);
+                    }
+                    continue;
+                }
+
                 if let Some(AppPreferencesAction::ViewModeChanged(new_mode)) = action.downcast_ref() {
                     if *new_mode != self.applied_view_mode {
                         self.apply_view_mode(cx, *new_mode);
@@ -558,6 +598,18 @@ impl Widget for HomeScreen {
                             self.view.redraw(cx);
                         }
                     }
+                    Some(NavigationBarAction::GoToAgentOps) => {
+                        #[cfg(feature = "agent_chat")]
+                        if app_state.app_prefs.agent_chat_enabled
+                            && !matches!(app_state.selected_tab, SelectedTab::AgentOps)
+                        {
+                            self.previous_selection = app_state.selected_tab.clone();
+                            app_state.selected_tab = SelectedTab::AgentOps;
+                            cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
+                            self.update_active_page_from_selection(cx, app_state);
+                            self.view.redraw(cx);
+                        }
+                    }
                     Some(NavigationBarAction::GoToSpace { space_name_id }) => {
                         let new_space_selection = SelectedTab::Space { space_name_id: space_name_id.clone() };
                         if app_state.selected_tab != new_space_selection {
@@ -586,7 +638,11 @@ impl Widget for HomeScreen {
                     }
                     Some(NavigationBarAction::CloseSettings) => {
                         if matches!(app_state.selected_tab, SelectedTab::Settings) {
-                            app_state.selected_tab = self.previous_selection.clone();
+                            let next_selection = selection_after_closing_settings(
+                                &self.previous_selection,
+                                app_state,
+                            );
+                            app_state.selected_tab = next_selection;
                             cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
                             self.update_active_page_from_selection(cx, app_state);
                             self.view.redraw(cx);
@@ -636,6 +692,12 @@ impl HomeScreen {
         cx: &mut Cx,
         app_state: &mut AppState,
     ) -> Option<WidgetRef> {
+        if matches!(app_state.selected_tab, SelectedTab::AgentOps)
+            && (!cfg!(feature = "agent_chat") || !app_state.app_prefs.agent_chat_enabled)
+        {
+            app_state.selected_tab = SelectedTab::Home;
+        }
+
         self.view
             .page_flip(cx, ids!(home_screen_page_flip))
             .set_active_page(
@@ -646,7 +708,111 @@ impl HomeScreen {
                     SelectedTab::Settings => id!(settings_page),
                     SelectedTab::AddRoom => id!(add_room_page),
                     SelectedTab::Directory => id!(directory_page),
+                    SelectedTab::AgentOps => id!(agent_ops_page),
                 },
             )
+    }
+}
+
+fn selection_after_opening_room(current_selection: &SelectedTab) -> SelectedTab {
+    if current_selection.shows_room_workspace() {
+        current_selection.clone()
+    } else {
+        SelectedTab::Home
+    }
+}
+
+fn selection_after_closing_settings(
+    previous_selection: &SelectedTab,
+    app_state: &AppState,
+) -> SelectedTab {
+    if matches!(previous_selection, SelectedTab::AgentOps)
+        && (!cfg!(feature = "agent_chat") || !app_state.app_prefs.agent_chat_enabled)
+    {
+        SelectedTab::Home
+    } else {
+        previous_selection.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn space_selection() -> SelectedTab {
+        let room_id: matrix_sdk::ruma::OwnedRoomId =
+            "!agent-ops-space:example.org".try_into().unwrap();
+        SelectedTab::Space {
+            space_name_id: crate::utils::RoomNameId::empty(room_id),
+        }
+    }
+
+    #[test]
+    fn opening_room_preserves_pages_that_show_the_room_workspace() {
+        for selection in [SelectedTab::Home, space_selection()] {
+            assert_eq!(selection_after_opening_room(&selection), selection);
+        }
+    }
+
+    #[test]
+    fn opening_room_leaves_every_overlay_page_for_home() {
+        for selection in [
+            SelectedTab::AddRoom,
+            SelectedTab::Settings,
+            SelectedTab::Directory,
+            SelectedTab::AgentOps,
+        ] {
+            assert_eq!(
+                selection_after_opening_room(&selection),
+                SelectedTab::Home,
+                "room selected while {selection:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn production_navigation_actions_use_the_tested_transitions() {
+        let source = include_str!("home_screen.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+
+        assert!(
+            production.contains("RoomsListAction::Selected(_)")
+                && production.matches("selection_after_opening_room(").count() == 2,
+            "the room-selection action must call the tested page transition",
+        );
+        assert_eq!(
+            production.matches("selection_after_closing_settings(").count(),
+            2,
+            "the CloseSettings action must call the tested page transition",
+        );
+    }
+
+    #[test]
+    fn closing_settings_never_returns_to_disabled_agent_ops() {
+        let app_state = AppState::default();
+        assert_eq!(
+            selection_after_closing_settings(&SelectedTab::AgentOps, &app_state),
+            SelectedTab::Home,
+        );
+    }
+
+    #[test]
+    fn closing_settings_preserves_other_previous_pages() {
+        let app_state = AppState::default();
+        assert_eq!(
+            selection_after_closing_settings(&SelectedTab::Directory, &app_state),
+            SelectedTab::Directory,
+        );
+    }
+
+    #[cfg(feature = "agent_chat")]
+    #[test]
+    fn closing_settings_may_return_to_enabled_agent_ops() {
+        let mut app_state = AppState::default();
+        app_state.app_prefs.agent_chat_enabled = true;
+        assert_eq!(
+            selection_after_closing_settings(&SelectedTab::AgentOps, &app_state),
+            SelectedTab::AgentOps,
+        );
     }
 }

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -849,8 +849,24 @@ pub enum SelectedTab {
     /// Entered from the sidebar header's compass button; no dedicated tab in the
     /// navigation bar (so no button to keep selected here).
     Directory,
+    /// The Agent Operations Panel (`AgentOpsPanel`).
+    /// Like `Directory`, it has no dedicated navigation-bar button.
+    ///
+    /// The variant is declared unconditionally so the shared navigation state
+    /// has one shape across feature configurations. `HomeScreen` normalizes it
+    /// back to Home whenever agent-chat support is unavailable or disabled.
+    AgentOps,
     // AlertsInbox,
     Space { space_name_id: RoomNameId },
+}
+
+impl SelectedTab {
+    /// Whether selecting a room can make that room visible without changing
+    /// the top-level page. Every other page overlays the room workspace on
+    /// desktop and must return to Home before the room is focused.
+    pub fn shows_room_workspace(&self) -> bool {
+        matches!(self, Self::Home | Self::Space { .. })
+    }
 }
 
 
@@ -890,6 +906,8 @@ pub enum NavigationBarAction {
     GoToAddRoom,
     /// Go to the public room directory browser view (`DirectoryScreen`).
     GoToDirectory,
+    /// Go to the Agent Operations Panel (`AgentOpsPanel`).
+    GoToAgentOps,
     /// Go to the Settings view (open the `SettingsScreen`).
     OpenSettings,
     /// Close the Settings view (`SettingsScreen`), returning to the previous view.

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -174,4 +174,49 @@ mod tests {
             "输入消息（支持 Markdown）...",
         );
     }
+
+    #[test]
+    fn agent_ops_status_and_detail_keys_exist_in_all_locales() {
+        for suffix in [
+            "status.no_manifest",
+            "status.unreadable_manifest",
+            "status.contract_mismatch",
+            "status.not_released",
+            "status.unbound_commit",
+            "status.invalid_source_commit",
+            "status.empty_artifacts",
+            "status.invalid_artifact_manifest",
+            "status.incomplete_artifact_manifest",
+            "status.artifact_set_mismatch",
+            "status.artifact_digest_mismatch",
+            "status.contract_ready",
+            "detail.no_manifest",
+            "detail.unreadable_manifest",
+            "detail.contract_mismatch",
+            "detail.not_released",
+            "detail.unbound_commit",
+            "detail.invalid_source_commit",
+            "detail.empty_artifacts",
+            "detail.invalid_artifact_manifest",
+            "detail.incomplete_artifact_manifest",
+            "detail.artifact_set_mismatch",
+            "detail.artifact_digest_mismatch",
+            "detail.contract_ready",
+            "status.next_step_release",
+            "status.next_step_runtime",
+        ] {
+            let key = format!("agent_ops.{suffix}");
+            for language in AppLanguage::ALL {
+                assert!(
+                    dictionary(language).contains_key(&key),
+                    "missing i18n key {key:?} for language {language:?}",
+                );
+            }
+            assert_ne!(
+                dictionary(AppLanguage::English).get(&key),
+                dictionary(AppLanguage::ChineseSimplified).get(&key),
+                "Chinese Agent Operations text must not fall back to English for {key}",
+            );
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,12 @@ pub mod register;
 pub mod logout;
 /// Core UI content: the main home screen (rooms list), room screen.
 pub mod home;
+/// Agent Operations Panel: a fail-closed client-contract status screen.
+#[cfg(feature = "agent_chat")]
+pub mod agent_ops;
+/// Inert stand-in so the panel's DSL name resolves without the feature.
+#[cfg(not(feature = "agent_chat"))]
+pub mod agent_ops_dummy;
 /// User profile info and a user profile sliding pane.
 pub mod profile;
 /// A modal/dialog popup for interactive verification of users/devices.

--- a/src/persistence/app_state.rs
+++ b/src/persistence/app_state.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 
+use anyhow::Context as _;
 use makepad_widgets::*;
 use serde::{self, Deserialize, Serialize};
 use matrix_sdk::ruma::{OwnedUserId, UserId};
@@ -37,9 +38,18 @@ pub fn serialize_app_state(app_state: &AppState) -> anyhow::Result<Vec<u8>> {
 
 /// Save pre-serialized app state bytes to persistent storage.
 pub fn save_app_state_bytes(app_state_json: &[u8], user_id: &UserId) -> anyhow::Result<()> {
-    let state_dir = persistent_state_dir(user_id);
-    std::fs::create_dir_all(&state_dir)?;
-    let file = std::fs::File::create(state_dir.join(LATEST_APP_STATE_FILE_NAME))?;
+    let state_path = persistent_state_dir(user_id).join(LATEST_APP_STATE_FILE_NAME);
+    save_app_state_bytes_to_path(app_state_json, &state_path)
+}
+
+fn save_app_state_bytes_to_path(
+    app_state_json: &[u8],
+    state_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    if let Some(state_dir) = state_path.parent() {
+        std::fs::create_dir_all(state_dir)?;
+    }
+    let file = std::fs::File::create(state_path)?;
     let mut writer = std::io::BufWriter::new(file);
     writer.write_all(app_state_json)?;
     writer.flush()?;
@@ -90,7 +100,14 @@ pub fn save_window_state(window_ref: WindowRef, cx: &Cx) -> anyhow::Result<()> {
 /// this function returns a default `AppState` and backs up the old file if it exists.
 pub async fn load_app_state(user_id: &UserId) -> anyhow::Result<AppState> {
     let state_path = persistent_state_dir(user_id).join(LATEST_APP_STATE_FILE_NAME);
-    let file_bytes = match tokio::fs::read(&state_path).await {
+    load_app_state_from_path(&state_path).await
+}
+
+/// Production restore pipeline extracted around its resolved path so tests can
+/// exercise file read, credential removal, deserialization, and migrations as
+/// one effectful unit without writing to a real user's application directory.
+async fn load_app_state_from_path(state_path: &std::path::Path) -> anyhow::Result<AppState> {
+    let file_bytes = match tokio::fs::read(state_path).await {
         Ok(fb) => fb,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             log!("No saved app state found, using default.");
@@ -98,11 +115,109 @@ pub async fn load_app_state(user_id: &UserId) -> anyhow::Result<AppState> {
         }
         Err(e) => return Err(e.into())
     };
-    let mut app_state = deserialize_app_state_or_recover(&file_bytes, &state_path);
+    let file_bytes = sanitize_persisted_agent_ops_credentials(state_path, file_bytes).await?;
+    let mut app_state = deserialize_app_state_or_recover(&file_bytes, state_path);
     // Migration: upgraded users with a legacy known-bot list but no registry
     // get their bots seeded into the global AgentRegistry on load.
     app_state.seed_agent_registry_from_known_bots();
     Ok(app_state)
+}
+
+/// Removes the short-lived Agent Operations Dashboard prototype configuration.
+///
+/// That prototype stored a backend-wide credential under `agent_ops`. The
+/// operational panel no longer supports that authentication model, so valid
+/// legacy state is sanitized before it reaches `AppState` and before recovery
+/// can create a backup. Unknown future `agent_ops` objects that do not contain
+/// the prototype fields are left untouched.
+#[derive(Debug, PartialEq, Eq)]
+enum LegacyAgentOpsSanitization {
+    Unchanged,
+    Sanitized(Vec<u8>),
+    UnreadableWithCredentials,
+}
+
+async fn sanitize_persisted_agent_ops_credentials(
+    state_path: &std::path::Path,
+    file_bytes: Vec<u8>,
+) -> anyhow::Result<Vec<u8>> {
+    match inspect_legacy_agent_ops_config(&file_bytes) {
+        LegacyAgentOpsSanitization::Unchanged => Ok(file_bytes),
+        LegacyAgentOpsSanitization::Sanitized(sanitized) => {
+            tokio::fs::write(state_path, &sanitized)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to remove obsolete Agent Operations credentials from {}",
+                        state_path.display(),
+                    )
+                })?;
+            log!("Removed obsolete Agent Operations credentials from persisted app state.");
+            Ok(sanitized)
+        }
+        LegacyAgentOpsSanitization::UnreadableWithCredentials => {
+            // Recovery normally preserves malformed state as a `.json.bak`.
+            // A file containing the retired backend-wide credential is the one
+            // exception: overwrite it before deserialization so no successful
+            // restore can leave the credential in either the live file or a
+            // recovery backup. If this write fails, propagate the error and do
+            // not restore the account state.
+            let sanitized = b"{}".to_vec();
+            tokio::fs::write(state_path, &sanitized)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to discard unreadable app state containing obsolete Agent Operations credentials at {}",
+                        state_path.display(),
+                    )
+                })?;
+            warning!(
+                "Discarded unreadable app state containing obsolete Agent Operations credentials; no credential-bearing backup was created."
+            );
+            Ok(sanitized)
+        }
+    }
+}
+
+fn inspect_legacy_agent_ops_config(file_bytes: &[u8]) -> LegacyAgentOpsSanitization {
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(file_bytes) else {
+        return if contains_legacy_agent_ops_markers(file_bytes) {
+            LegacyAgentOpsSanitization::UnreadableWithCredentials
+        } else {
+            LegacyAgentOpsSanitization::Unchanged
+        };
+    };
+    let is_legacy = value
+        .get("agent_ops")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|config| {
+            config.contains_key("base_url") || config.contains_key("bearer_token")
+        });
+    if !is_legacy {
+        return LegacyAgentOpsSanitization::Unchanged;
+    }
+    let Some(object) = value.as_object_mut() else {
+        return LegacyAgentOpsSanitization::Unchanged;
+    };
+    object.remove("agent_ops");
+    match serde_json::to_vec(&value) {
+        Ok(sanitized) => LegacyAgentOpsSanitization::Sanitized(sanitized),
+        Err(_) => LegacyAgentOpsSanitization::UnreadableWithCredentials,
+    }
+}
+
+fn contains_legacy_agent_ops_markers(file_bytes: &[u8]) -> bool {
+    contains_bytes(file_bytes, br#""agent_ops""#)
+        && (
+            contains_bytes(file_bytes, br#""bearer_token""#)
+                || contains_bytes(file_bytes, br#""base_url""#)
+        )
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 /// Deserializes persisted app-state bytes, or — when the bytes are unreadable
@@ -160,15 +275,117 @@ pub fn load_window_state(window_ref: WindowRef, cx: &mut Cx) -> anyhow::Result<(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::*;
     use crate::app::AgentEntry;
+
+    fn temporary_state_path(test_name: &str) -> std::path::PathBuf {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir()
+            .join(format!(
+                "robrix-agent-ops-scrub-{}-{}-{test_name}",
+                std::process::id(),
+                NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            ))
+            .join(LATEST_APP_STATE_FILE_NAME)
+    }
+
+    #[test]
+    fn legacy_agent_ops_credentials_are_scrubbed_before_restore() {
+        let mut stored = serde_json::to_value(AppState::default()).unwrap();
+        stored["agent_ops"] = serde_json::json!({
+            "base_url": "http://127.0.0.1:8084",
+            "bearer_token": "legacy-prototype-secret",
+        });
+        let bytes = serde_json::to_vec(&stored).unwrap();
+
+        let LegacyAgentOpsSanitization::Sanitized(sanitized) =
+            inspect_legacy_agent_ops_config(&bytes)
+        else {
+            panic!("legacy state must be identified and sanitized");
+        };
+        let text = String::from_utf8(sanitized.clone()).unwrap();
+        assert!(!text.contains("legacy-prototype-secret"));
+        assert!(!text.contains("agent_ops"));
+        serde_json::from_slice::<AppState>(&sanitized).unwrap();
+    }
+
+    #[test]
+    fn future_agent_ops_state_without_legacy_fields_is_not_scrubbed() {
+        let bytes = br#"{"agent_ops":{"contract":"future-version"}}"#;
+        assert_eq!(
+            inspect_legacy_agent_ops_config(bytes),
+            LegacyAgentOpsSanitization::Unchanged,
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_legacy_agent_ops_credentials_are_discarded_without_backup() {
+        let state_path = temporary_state_path("corrupt-entry");
+        let state_dir = state_path.parent().unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let corrupt = br#"{"agent_ops":{"base_url":"http://127.0.0.1:8084","bearer_token":"legacy-prototype-secret"},not-json"#;
+        std::fs::write(&state_path, corrupt).unwrap();
+
+        let restored = load_app_state_from_path(&state_path).await.unwrap();
+
+        assert_eq!(
+            serde_json::to_value(&restored).unwrap(),
+            serde_json::to_value(AppState::default()).unwrap(),
+        );
+        let persisted = std::fs::read(&state_path).unwrap();
+        assert_eq!(persisted, b"{}");
+        assert!(!state_path.with_extension("json.bak").exists());
+        std::fs::remove_dir_all(&state_dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn legacy_agent_ops_credentials_are_removed_from_disk_before_restore() {
+        let state_path = temporary_state_path("valid-entry");
+        let state_dir = state_path.parent().unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let legacy = br#"{"agent_ops":{"base_url":"http://127.0.0.1:8084","bearer_token":"legacy-prototype-secret"},"app_prefs":{}}"#;
+        std::fs::write(&state_path, legacy).unwrap();
+
+        let restored = load_app_state_from_path(&state_path).await.unwrap();
+
+        let persisted = std::fs::read(&state_path).unwrap();
+        let persisted_state = serde_json::from_slice::<AppState>(&persisted).unwrap();
+        assert_eq!(
+            serde_json::to_value(&restored).unwrap(),
+            serde_json::to_value(persisted_state).unwrap(),
+        );
+        assert!(!persisted.windows(b"legacy-prototype-secret".len())
+            .any(|window| window == b"legacy-prototype-secret"));
+        assert!(!persisted.windows(b"agent_ops".len())
+            .any(|window| window == b"agent_ops"));
+        assert!(!state_path.with_extension("json.bak").exists());
+        std::fs::remove_dir_all(&state_dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn credential_scrub_write_failure_aborts_restore() {
+        let state_path = temporary_state_path("write-failure");
+        std::fs::create_dir_all(&state_path).unwrap();
+        let legacy = br#"{"agent_ops":{"bearer_token":"legacy-prototype-secret"}}"#;
+
+        let result = sanitize_persisted_agent_ops_credentials(
+            &state_path,
+            legacy.to_vec(),
+        )
+        .await;
+
+        assert!(result.is_err(), "restore must stop when credential removal cannot be persisted");
+        std::fs::remove_dir_all(state_path.parent().unwrap()).unwrap();
+    }
 
     #[tokio::test]
     async fn test_agent_registry_persists_per_account_no_cross_leak() {
         let alice: OwnedUserId = "@agent-registry-alice:example.org".try_into().unwrap();
         let bob: OwnedUserId = "@agent-registry-bob:example.org".try_into().unwrap();
-        let _ = std::fs::remove_dir_all(persistent_state_dir(alice.as_ref()));
-        let _ = std::fs::remove_dir_all(persistent_state_dir(bob.as_ref()));
+        let alice_path = temporary_state_path("registry-alice");
+        let bob_path = temporary_state_path("registry-bob");
 
         // Distinct accounts map to distinct storage paths, so one account's
         // saved state can never overwrite another's.
@@ -181,36 +398,40 @@ mod tests {
             .register(agent.clone(), AgentEntry::default());
         let bob_state = AppState::default();
 
-        save_app_state(alice_state, alice.clone()).unwrap();
-        save_app_state(bob_state, bob.clone()).unwrap();
+        save_app_state_bytes_to_path(
+            &serialize_app_state(&alice_state).unwrap(),
+            &alice_path,
+        ).unwrap();
+        save_app_state_bytes_to_path(
+            &serialize_app_state(&bob_state).unwrap(),
+            &bob_path,
+        ).unwrap();
 
-        let alice_loaded = load_app_state(alice.as_ref()).await.unwrap();
-        let bob_loaded = load_app_state(bob.as_ref()).await.unwrap();
+        let alice_loaded = load_app_state_from_path(&alice_path).await.unwrap();
+        let bob_loaded = load_app_state_from_path(&bob_path).await.unwrap();
 
         assert!(alice_loaded.agent_registry.contains(agent.as_ref()));
         assert!(bob_loaded.agent_registry.is_empty());
 
-        let _ = std::fs::remove_dir_all(persistent_state_dir(alice.as_ref()));
-        let _ = std::fs::remove_dir_all(persistent_state_dir(bob.as_ref()));
+        std::fs::remove_dir_all(alice_path.parent().unwrap()).unwrap();
+        std::fs::remove_dir_all(bob_path.parent().unwrap()).unwrap();
     }
 
     #[tokio::test]
     async fn test_corrupt_registry_json_falls_back_to_default_state() {
-        let user_id: OwnedUserId = "@agent-registry-corrupt:example.org".try_into().unwrap();
-        let dir = persistent_state_dir(user_id.as_ref());
-        let _ = std::fs::remove_dir_all(&dir);
+        let state_path = temporary_state_path("corrupt-registry");
+        let dir = state_path.parent().unwrap();
         std::fs::create_dir_all(&dir).unwrap();
-        let state_path = dir.join(LATEST_APP_STATE_FILE_NAME);
         let corrupt = br#"{"agent_registry": this is not valid json"#;
         std::fs::write(&state_path, corrupt).unwrap();
 
-        let recovered = load_app_state(user_id.as_ref()).await.unwrap();
+        let recovered = load_app_state_from_path(&state_path).await.unwrap();
 
         // Falls back to a default AppState (empty registry) without panicking.
         assert_eq!(recovered.agent_registry.len(), 0);
         // The unreadable file is preserved as a backup.
         assert!(state_path.with_extension("json.bak").exists());
 
-        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -1524,22 +1524,11 @@ impl RoomInputBar {
             self.redraw(cx);
         }
 
-        // The "/" toolbar shortcut opens the slash-command popup. Guarded to the
-        // main timeline (slash/bot commands aren't supported inside threads).
+        // The "/" toolbar shortcut opens the slash-command popup. Inside a thread
+        // the popup offers only the thread-relevant workflow commands (e.g.
+        // `/thread model|mode`); the list itself is timeline-aware, so no gate here.
         if self.button(cx, ids!(slash_command_button)).clicked(actions) {
-            let in_thread = scope
-                .props
-                .get::<RoomScreenProps>()
-                .is_some_and(|props| props.timeline_kind.thread_root_event_id().is_some());
-            if in_thread {
-                enqueue_popup_notification(
-                    "Slash commands are only supported in the main room timeline.",
-                    PopupKind::Warning,
-                    Some(4.0),
-                );
-            } else {
-                mentionable_text_input.open_slash_command_popup(cx, scope);
-            }
+            mentionable_text_input.open_slash_command_popup(cx, scope);
             self.redraw(cx);
         }
 

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -243,7 +243,7 @@ script_mod! {
 
             View {
                 width: Fill, height: Fit
-                flow: Right
+                flow: Flow.Right{wrap: true}
                 align: Align{y: 0.5}
                 spacing: 8
 
@@ -378,6 +378,32 @@ script_mod! {
 
             agent_chat_description := mod.widgets.SettingsSectionDescription {
                 text: ""
+            }
+
+            agent_ops_contract_notice := mod.widgets.SettingsSectionDescription {
+                margin: Inset{left: 0.5, top: (SPACE_SM), bottom: 0, right: 5}
+                text: ""
+            }
+
+            View {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
+                spacing: (SPACE_SM)
+                margin: Inset{left: 6.5, top: 8}
+
+                // This opens an inert integration-status screen. Runtime
+                // controls remain unavailable until canonical contract bytes
+                // are released, vendored, and verified.
+                agent_ops_open_button := RobrixIconButton {
+                    width: Fit, height: Fit
+                    padding: Inset{left: 12, right: 12, top: 8, bottom: 8}
+                    draw_bg +: { color: (RBX_BG_SURFACE_SUBTLE) }
+                    draw_text +: {
+                        color: (RBX_FG_PRIMARY)
+                        text_style: (RBX_TEXT_BODY)
+                    }
+                    text: ""
+                }
             }
         }
 
@@ -579,6 +605,13 @@ impl AppSettings {
                         Some(3.0),
                     );
                 }
+                self.view.button(cx, ids!(agent_ops_open_button)).set_enabled(cx, enabled);
+            }
+
+            if app_state.app_prefs.agent_chat_enabled
+                && self.view.button(cx, ids!(agent_ops_open_button)).clicked(actions)
+            {
+                cx.action(crate::home::navigation_tab_bar::NavigationBarAction::GoToAgentOps);
             }
         }
 
@@ -677,6 +710,8 @@ impl AppSettings {
             self.view.view(cx, ids!(agent_chat_section)).set_visible(cx, true);
             self.view.check_box(cx, ids!(agent_chat_enable_toggle))
                 .set_active(cx, prefs.agent_chat_enabled, Animate::No);
+            self.view.button(cx, ids!(agent_ops_open_button))
+                .set_enabled(cx, prefs.agent_chat_enabled);
         }
 
         let (small, medium, unlimited, custom, custom_text) = match prefs.thumbnail_max_height {
@@ -721,6 +756,12 @@ impl AppSettings {
         self.view
             .label(cx, ids!(agent_chat_description))
             .set_text(cx, tr_key(self.app_language, "settings.preferences.app.agent_chat.description"));
+        self.view
+            .label(cx, ids!(agent_ops_contract_notice))
+            .set_text(cx, tr_key(self.app_language, "settings.preferences.app.agent_ops.contract_notice"));
+        self.view
+            .button(cx, ids!(agent_ops_open_button))
+            .set_text(cx, tr_key(self.app_language, "settings.preferences.app.agent_ops.open_status"));
         self.view
             .label(cx, ids!(preferences_thumb_height_label))
             .set_text(cx, tr_key(self.app_language, "settings.preferences.app.thumbnail.label"));
@@ -796,6 +837,7 @@ impl AppSettings {
         view.text_input(cx, ids!(thumb_custom_input))
             .set_disabled(cx, !enabled);
     }
+
 }
 
 impl AppSettingsRef {

--- a/src/shared/mentionable_text_input.rs
+++ b/src/shared/mentionable_text_input.rs
@@ -424,6 +424,11 @@ const WORKFLOW_SLASH_COMMANDS: &[SlashCommand] = &[
         description_key: "slash_command.status.description",
         needs_args: false,
     },
+    SlashCommand {
+        command: "/thread",
+        description_key: "slash_command.thread.description",
+        needs_args: true,
+    },
 ];
 
 pub(crate) fn is_management_bot_room(
@@ -2273,13 +2278,17 @@ impl MentionableTextInput {
             room_props.resolved_parent_bot_user_id.as_ref(),
             &room_props.known_bot_user_ids,
         );
-        let bot_enabled = bot_context != SlashCommandDiscoveryContext::None;
+        // Management/bot commands and the invite picker are main-timeline-only;
+        // inside a thread the popup offers only the workflow commands (which the
+        // in-thread agent interprets, e.g. `/thread model|mode`).
+        let in_thread = room_props.timeline_kind.thread_root_event_id().is_some();
+        let bot_enabled = !in_thread && bot_context != SlashCommandDiscoveryContext::None;
         // `/invitebot` is a client-side command gated on the user's invite
         // permission — independent of the appservice/BotFather management
         // gating. Additionally requires loaded room members (so already-present
         // bots can be filtered from the picker) and is suppressed entirely for
         // instances that opt out (the message-editing pane).
-        let invite_enabled = invitebot_picker_ready(
+        let invite_enabled = !in_thread && invitebot_picker_ready(
             room_props.can_invite,
             room_props.room_members.is_some(),
             room_props.room_members_sync_pending,


### PR DESCRIPTION
## Summary

robrix2-side companion to the agent-chat backend-owned thread-session runner (LEP-002/ADR-011), which gives every Matrix thread an isolated coding-agent session. Three commits:

- **`/thread` slash-command popup support** (`8f6a5038`): the workflow command catalog now offers `/thread` (configure the thread's agent session: `model <name|default>` / `mode <plan|auto>`), and the slash popup is timeline-aware — inside a thread it lists only workflow commands, while bot-management commands and the `/invitebot` picker remain main-timeline-only. The toolbar `/` button no longer hard-blocks threads.
- **Agent Ops panel behind the `agent_chat` feature** (`b9bc1363`): 7-condition contract gate (released manifest, full git object id, non-empty artifact set, 20 required paths, manifest/vendored byte-set equality, sha256 digest match) with an empty vendored set keeping `ContractReady` structurally unreachable until a manifest is deliberately released; hand-rolled sha256 with known-answer tests; i18n (en/zh-CN).
- **Operations docs** (`8068b29b`): thread-session operations, known issues, and roadmap.

## Testing

- `cargo test --features agent_chat --lib`: 610 passed, 0 failed
- Compiles clean with and without the `agent_chat` feature
- Live-tested against the agent-chat thread-session canary: popup discovery in threads, `/thread model`/`mode` round-trips with in-thread confirmations, and per-thread session isolation verified end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)