### PR TITLE
fix(sync): enable lax sliding-sync-v5 deserialization (suspected invite/new-room materialization fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5967,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.14.1"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "assign",
  "js_int",
@@ -5982,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.22.1"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "as_variant",
  "assign",
@@ -6005,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.17.1"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "as_variant",
  "base64",
@@ -6037,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.32.1"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "as_variant",
  "indexmap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.6.0"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -6070,7 +6070,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.0"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "js_int",
  "thiserror 2.0.17",
@@ -6079,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.17.1"
-source = "git+https://github.com/project-robius/ruma.git?branch=tsp#98196b1db32d3393216f31d2c085a7082bd1d28d"
+source = "git+https://github.com/Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4e8555078e8692ad9f8592b705b9ac23"
 dependencies = [
  "as_variant",
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ askar-storage = { git = "https://github.com/openwallet-foundation/askar.git" }
 ## cherry-pick of ruma#2510 ("unstable-compat-lax-syncv5-deser"): tolerate
 ## non-compliant/corrupt fields in sliding sync v5 responses instead of dropping
 ## the whole per-room object (suspected cause of invites/new rooms never appearing).
-ruma = { git = "https://github.com/project-robius/ruma.git", branch = "tsp-lax-syncv5-deser" }
+ruma = { git = "https://github.com/Project-Robius-China/ruma.git", branch = "tsp-lax-syncv5-deser" }
 
 [build-dependencies]
 toml = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,13 @@ matrix-sdk-ui = { git = "https://github.com/Project-Robius-China/matrix-rust-sdk
 ## * "compat-optional" feature to allow missing body field in m.room.tombstone event.
 ## * "compat-unset-avatar" feature to allow deleting the user's avatar to work properly.
 ## * Note: we need a feature like "compat-unset-display-name" to unset display names, but that doesn't exist yet.
+## * "unstable-compat-lax-syncv5-deser" (ruma#2510) tolerates non-compliant/corrupt fields in
+##   sliding sync v5 responses instead of failing the whole per-room object, which caused
+##   invites/newly-created rooms to never materialize while the client was running.
 ruma = { git = "https://github.com/ruma/ruma", rev = "a0acf4187a7c7557d145db54bcb23b01f6295ce7", features = [
     "compat-optional",
     "compat-unset-avatar",
+    "unstable-compat-lax-syncv5-deser",
 ] }
 rand = "0.8.5"
 rangemap = "1.5.0"
@@ -188,7 +192,11 @@ askar-storage = { git = "https://github.com/openwallet-foundation/askar.git" }
 ## Note: matrix-sdk currently uses a git dependency for ruma,
 ## so we patch the git source, not crates-io.
 [patch."https://github.com/ruma/ruma"]
-ruma = { git = "https://github.com/project-robius/ruma.git", branch = "tsp" }
+## Same as the "tsp" branch (at the rev this repo was already locked to), plus a
+## cherry-pick of ruma#2510 ("unstable-compat-lax-syncv5-deser"): tolerate
+## non-compliant/corrupt fields in sliding sync v5 responses instead of dropping
+## the whole per-room object (suspected cause of invites/new rooms never appearing).
+ruma = { git = "https://github.com/project-robius/ruma.git", branch = "tsp-lax-syncv5-deser" }
 
 [build-dependencies]
 toml = "1"

--- a/docs/deps-ruma-fork.md
+++ b/docs/deps-ruma-fork.md
@@ -1,0 +1,95 @@
+# 依赖决策:ruma fork 分支 `tsp-lax-syncv5-deser`
+
+> 状态:实验验证中(PR #297)· 建立日期:2026-08-14 · 负责分支:`fix/ruma-lax-syncv5-deser`
+
+## TL;DR
+
+robrix2 的 `[patch."https://github.com/ruma/ruma"]` 从 `project-robius/ruma@tsp` 切换到
+**`Project-Robius-China/ruma@tsp-lax-syncv5-deser`**,并在 ruma 依赖上启用
+**`unstable-compat-lax-syncv5-deser`** feature。目的:修复"robrix2 运行期间收到的
+邀请 / 服务端新建房间永远不显示"的 sliding-sync 房间物化 bug,同时**完全不动**
+matrix-sdk fork。
+
+## 分支构成
+
+```
+Project-Robius-China/ruma @ tsp-lax-syncv5-deser (HEAD = 20c2c60f4)
+│
+├─ 20c2c60f4  cherry-pick of ruma#2510 (官方 e8b924f2)
+│             "client-api: Handle non-compliant/corrupt fields in
+│              simplified sliding sync responses"
+│             唯一冲突是 CHANGELOG.md,代码零冲突
+│
+└─ 98196b1db  ← 基底 = project-robius/ruma@tsp 在 robrix2 Cargo.lock
+              里**原本就锁定**的那个 rev(ruma 0.14.1,含全部 TSP 补丁)
+```
+
+关键性质:**基底一个字节都没变**——就是切换前 lock 里锁的那个 commit,
+所以 matrix-sdk fork 看到的 ruma API 与之前完全一致,唯一的增量是那一个
+cherry-pick。ruma 版本保持 0.14.1,无任何 API churn。
+
+## 依赖链全景
+
+```
+robrix2
+├── matrix-sdk{,-base,-ui}  ← Project-Robius-China/matrix-rust-sdk
+│        │                    @ space_room_suggested-event-cache-no-panic(不变)
+│        └── ruma(声明指向 ruma/ruma@a0acf4187)
+│              │
+│              └─[patch."https://github.com/ruma/ruma"]─►
+│                   Project-Robius-China/ruma @ tsp-lax-syncv5-deser   ← 本决策
+└── ruma(直接依赖,同样被 patch 重定向;features 见下)
+```
+
+robrix2 直接依赖上启用的 ruma features:`compat-optional`、`compat-unset-avatar`、
+**`unstable-compat-lax-syncv5-deser`(新增)**。Cargo feature 统一化保证
+matrix-sdk-base 内部使用的同一份 ruma 实例也获得该行为。
+
+## 为什么这么做(决策链)
+
+1. **要修的 bug**(详见 memory `project_robrix_invite_sliding_sync_bug`):
+   robrix2 开着时到达的邀请/新房间,在 sliding sync v5 增量响应中被引用,
+   但 per-room 对象反序列化失败被静默丢弃 → matrix-sdk-base 不建 Room →
+   `must exist` 报错、UI 永不显示,且 pos 越过后重启也救不回。
+2. **上游 robrix 的修法**(提交 `6363b5f8`):整体切回官方 matrix-rust-sdk +
+   新 ruma,并启用 `unstable-compat-lax-syncv5-deser`(ruma#2510:sync v5
+   响应中 room/hero 的 name/avatar 等字段损坏时忽略该字段,而不是让整个
+   room 对象反序列化失败)。
+3. **我们不能整体跟进 SDK**(2026-08-14 实验确认,两个硬冲突):
+   - 官方 SDK 已移除基于 `ring` 的 rustls provider,只剩 `rustls-aws-lc-rs`;
+     与 robrix2 为绕过 Android 上 `rustls-platform-verifier`/aws-lc панic 而
+     精心固定的 `ring` provider 方案直接冲突(见 Cargo.toml rustls 注释)。
+   - `matrix-sdk-sqlite` 新版要求 `libsqlite3-sys ^0.38`,与 TSP 链
+     (`tsp_sdk → aries-askar → sqlx` 补丁分支)的旧版本要求撞 native `links`,
+     需要再 fork 一轮 sqlx,维护成本高。
+4. **因此取最小增量**:只把 ruma#2510 这一个修复 cherry-pick 到我们已锁定的
+   ruma rev 上。风险面 = 一个上游已合并的补丁。
+5. **为什么放 Project-Robius-China 而不是 project-robius**:下游实验分支应放
+   自己可控的 org(matrix-sdk fork 也在这里),不污染上游仓库、不怕被清理。
+
+## 维护规则
+
+- **不要 rebase / force-push 该分支**:robrix2 的 Cargo.lock 以
+  branch+commit 锁定,force-push 会让全体开发者 `cargo update -p ruma` 后
+  构建结果漂移。要加补丁就在分支顶端继续 cherry-pick(追加式)。
+- **不要让该分支自动跟踪上游 tsp**:基底钉死在 98196b1d 是本决策的核心
+  性质(保证 matrix-sdk fork 兼容)。上游 tsp 已升到 ruma 0.16,直接合并
+  会破坏 matrix-sdk 0.14 时代的 API 兼容。
+- **退役条件**:未来 matrix-sdk fork 升级/切官方(需先解决上面第 3 点的两个
+  硬冲突)时,官方 ruma 自带 ruma#2510,本分支与本 patch 应一并删除,
+  feature 改在新 ruma 上直接启用。
+- 更新 lock:`cargo update -p ruma`(仅在分支追加补丁后需要)。
+- 网络注意:该仓库首次 HTTPS 拉取在部分网络环境下会被掐断,已知 workaround
+  是 git 全局配置 `url.git@github.com:Project-Robius-China/ruma.git.insteadOf
+  https://github.com/Project-Robius-China/ruma.git` 走 SSH。
+
+## 验证方法(人工)
+
+1. robrix2 保持运行,用另一账号邀请当前用户 / 由服务端 bot 建房并拉人。
+2. 期望:房间**无需重启**即出现在 Invites/房间列表(修复前:永不出现,
+   日志报 `The room must exist since it has been joined`)。
+3. 回归面:正常收发消息、房间列表增量更新、启动全量同步(`share_pos(false)`
+   路径)不受影响——该 feature 只在"字段损坏"时改变行为,健康响应零差异。
+
+关联:`specs/task-ruma-lax-syncv5-deser.spec.md`(任务合约)、PR #297、
+上游参考 `robrix@6363b5f8`、`ruma/ruma#2510`。

--- a/specs/task-ruma-lax-syncv5-deser.spec.md
+++ b/specs/task-ruma-lax-syncv5-deser.spec.md
@@ -1,0 +1,109 @@
+spec: task
+name: "ruma lax sliding-sync-v5 deserialization"
+inherits: project
+tags: [dependency, sliding-sync, bugfix, ruma]
+estimate: 0.5d
+---
+
+## Intent
+
+修复 robrix2 运行期间收到的邀请/服务端新建房间永不显示的 sliding-sync 房间物化 bug:sync v5 增量响应中 per-room 对象因个别字段损坏而整体反序列化失败,matrix-sdk-base 静默丢弃该房间。采用最小增量方案——把 ruma#2510 的容错反序列化 cherry-pick 到当前已锁定的 ruma rev 上并启用对应 feature,完全不改动 matrix-sdk fork。决策背景与依赖链详见 docs/deps-ruma-fork.md。
+
+## Decisions
+
+- ruma patch 源:`Project-Robius-China/ruma` 分支 `tsp-lax-syncv5-deser`(基底 = 原锁定 rev `98196b1d`,ruma 0.14.1 + 唯一增量 commit `20c2c60f4` = ruma#2510 cherry-pick)
+- 启用 feature:`unstable-compat-lax-syncv5-deser`(加在 robrix2 直接 ruma 依赖上,经 Cargo feature 统一化传导给 matrix-sdk-base 内的同一 ruma 实例)
+- matrix-sdk 三 crate 依赖保持 `space_room_suggested-event-cache-no-panic` 分支不变
+- 不整体升级 matrix-sdk:官方已移除 rustls `ring` provider(与 Android workaround 冲突)且 `libsqlite3-sys` 与 TSP/sqlx 链版本互斥,rebase 路线明确搁置
+- ruma fork 分支只允许追加 cherry-pick,禁止 rebase/force-push;matrix-sdk 未来升级官方版时本分支与 patch 一并退役
+
+## Boundaries
+
+### Allowed Changes
+- Cargo.toml
+- Cargo.lock
+- docs/deps-ruma-fork.md
+- specs/task-ruma-lax-syncv5-deser.spec.md
+
+### Forbidden
+- 不修改任何 src/ 下的 Rust 源码(本任务是纯依赖层变更)
+- 不改动 matrix-sdk / matrix-sdk-base / matrix-sdk-ui 的分支或 rev
+- 不升级 ruma 主版本(保持 0.14.1,不引入 tsp 分支 HEAD 的 0.16 演进)
+
+## Out of Scope
+
+- 整体 rebase matrix-sdk fork 到官方(受阻原因见 docs/deps-ruma-fork.md)
+- Palpo 服务端在增量响应中重发带外变更房间的修复
+- robrix2 侧对 must-exist 的 phantom 房间检测/强制 resync 兜底
+
+## Completion Criteria
+
+### Rule: dependency-pinning — 依赖锁定正确
+
+场景: 依赖解析指向补丁分支(critical)
+  标签: critical
+  测试: manual_test_cargo_tree_ruma_resolves_to_patch_branch
+  层级: manual
+  审核: human
+  假设 工作区为 fix/ruma-lax-syncv5-deser 分支
+  当 执行 `cargo tree -p ruma --depth 0`
+  那么 输出的 ruma 来源为 `Project-Robius-China/ruma.git?branch=tsp-lax-syncv5-deser#20c2c60f4`
+  并且 版本为 "0.14.1"
+
+场景: matrix-sdk 依赖源保持不变
+  测试: manual_test_matrix_sdk_source_unchanged
+  层级: manual
+  审核: human
+  当 对比 Cargo.lock 中 matrix-sdk、matrix-sdk-base、matrix-sdk-ui 的 source 与 main 分支
+  那么 三者均仍为 `space_room_suggested-event-cache-no-panic` 分支的同一 rev
+
+场景: 全量编译通过(critical)
+  标签: critical
+  测试: manual_test_cargo_check_passes
+  层级: manual
+  审核: human
+  当 执行 `cargo check`
+  那么 退出码为 0
+
+### Rule: room-materialization — 损坏字段不再丢房间
+
+场景: 运行期邀请即时显示(critical)
+  标签: critical
+  测试: manual_test_live_invite_materializes_without_restart
+  层级: manual
+  审核: human
+  假设 robrix2 正在运行且已完成初始同步
+  当 另一账号向当前用户发送房间邀请
+  那么 该邀请无需重启即出现在 Invites 列表
+  但是 日志不出现 "The room must exist since it has been joined"
+
+场景: 运行期服务端建房即时显示
+  测试: manual_test_server_created_room_materializes_without_restart
+  层级: manual
+  审核: human
+  假设 robrix2 正在运行且已完成初始同步
+  当 服务端 bot 创建新房间并将当前用户 force-join
+  那么 该房间无需重启即出现在房间列表
+
+场景: 含损坏字段的房间对象仅丢字段不丢房间
+  测试: manual_test_corrupt_field_drops_field_not_room
+  层级: manual
+  审核: human
+  假设 homeserver 在某房间的 sync v5 响应中发送格式非法的 name 或 avatar 字段
+  当 robrix2 处理该增量响应
+  那么 该房间仍被物化并显示(名称/头像回退为空)
+  但是 整个 per-room 对象不因单字段损坏而被丢弃
+
+### Rule: no-regression — 健康路径零回归
+
+场景: 健康响应行为不回归
+  测试: manual_test_healthy_sync_behavior_unchanged
+  层级: manual
+  审核: human
+  假设 robrix2 与账号内既有房间均正常
+  当 执行 启动全量同步、收发消息、房间列表增量更新
+  那么 行为与变更前一致(该 feature 仅在字段损坏时生效)
+
+<!-- lint-ack: error-path — 核心场景"含损坏字段的房间对象仅丢字段不丢房间"即异常路径:输入是非法/损坏字段;本任务无用户输入面,无其他可枚举失败路径 -->
+<!-- lint-ack: decision-coverage — "不整体升级 matrix-sdk"是路线排除决策(不做什么),其可验证面即 matrix-sdk 依赖源保持不变,已由 manual_test_matrix_sdk_source_unchanged 覆盖 -->
+<!-- lint-ack: observable-decision-coverage — "matrix-sdk 依赖源保持不变"由 manual_test_matrix_sdk_source_unchanged 场景经 Cargo.lock 对比覆盖,无 stdout/文件级可观察行为 -->

--- a/specs/task-ruma-lax-syncv5-deser.spec.md
+++ b/specs/task-ruma-lax-syncv5-deser.spec.md
@@ -77,6 +77,15 @@ estimate: 0.5d
   那么 该邀请无需重启即出现在 Invites 列表
   但是 日志不出现 "The room must exist since it has been joined"
 
+场景: main 与本分支 A-B 对照归因
+  测试: manual_test_ab_comparison_against_main
+  层级: manual
+  审核: human
+  假设 同一账号与同一 homeserver,分别运行 main 分支与本分支构建
+  当 在两个构建下重复执行 运行期邀请与服务端建房场景
+  那么 main 构建复现房间不显示,本分支构建房间即时显示
+  并且 归因成立的前提是失败响应确实含 name/avatar/hero 四字段之一的非法值(ruma#2510 仅宽松处理这四个字段;若两个构建行为一致,说明该场景未触发兼容分支,不能作为本修复的证据)
+
 场景: 运行期服务端建房即时显示
   测试: manual_test_server_created_room_materializes_without_restart
   层级: manual

--- a/specs/task-ruma-lax-syncv5-deser.spec.md
+++ b/specs/task-ruma-lax-syncv5-deser.spec.md
@@ -77,14 +77,24 @@ estimate: 0.5d
   那么 该邀请无需重启即出现在 Invites 列表
   但是 日志不出现 "The room must exist since it has been joined"
 
-场景: main 与本分支 A-B 对照归因
+场景: 真实失败 payload 在两版 ruma 上重放归因(critical)
+  标签: critical
+  测试: manual_test_replay_captured_payload_on_both_ruma_revs
+  层级: manual
+  审核: human
+  假设 已捕获一份真实失败的 sync v5 per-room 响应 JSON(通过开启 SDK HTTP 日志或代理抓包,在 main 构建复现房间不显示时截取)
+  当 将完全相同的 payload 分别输入旧 ruma rev(98196b1d)与本分支 ruma rev(20c2c60f4)的 sync v5 响应反序列化(可仿照 ruma#2510 自带单测构造)
+  那么 旧 rev 对该 per-room 对象反序列化失败,新 rev 保留房间对象且仅将非法字段置空
+  并且 归因前提是 payload 确实含四个受宽松处理字段之一的非法值:room name、room avatar、hero displayname、hero avatar_url(ruma#2510 仅覆盖这四个;若捕获的 payload 不含其中任何非法值,则本修复不是该次失败的原因)
+
+场景: 运行期 live A-B 对照(辅助证据)
   测试: manual_test_ab_comparison_against_main
   层级: manual
   审核: human
   假设 同一账号与同一 homeserver,分别运行 main 分支与本分支构建
   当 在两个构建下重复执行 运行期邀请与服务端建房场景
   那么 main 构建复现房间不显示,本分支构建房间即时显示
-  并且 归因成立的前提是失败响应确实含 name/avatar/hero 四字段之一的非法值(ruma#2510 仅宽松处理这四个字段;若两个构建行为一致,说明该场景未触发兼容分支,不能作为本修复的证据)
+  但是 两次服务端响应可能不同,本场景仅作辅助证据,严格归因以 payload 重放场景为准
 
 场景: 运行期服务端建房即时显示
   测试: manual_test_server_created_room_materializes_without_restart
@@ -98,9 +108,9 @@ estimate: 0.5d
   测试: manual_test_corrupt_field_drops_field_not_room
   层级: manual
   审核: human
-  假设 homeserver 在某房间的 sync v5 响应中发送格式非法的 name 或 avatar 字段
+  假设 homeserver 在某房间的 sync v5 响应中发送非法类型的 room name、room avatar、hero displayname 或 hero avatar_url 字段
   当 robrix2 处理该增量响应
-  那么 该房间仍被物化并显示(名称/头像回退为空)
+  那么 该房间仍被物化并显示(对应字段回退为空)
   但是 整个 per-room 对象不因单字段损坏而被丢弃
 
 ### Rule: no-regression — 健康路径零回归


### PR DESCRIPTION
## Summary

Fix for the long-standing bug where **invites and server-created rooms never appear while robrix2 is running** (sliding-sync v5 per-room objects with a corrupt field failed deserialization entirely, so matrix-sdk-base silently dropped the room; once the sync pos advanced past it, even a restart could not recover it).

Minimal-increment approach — the matrix-sdk fork is untouched:

- `[patch]` for ruma now points at **`Project-Robius-China/ruma` branch `tsp-lax-syncv5-deser`**: the exact tsp rev we were already locked to (`98196b1d`, ruma 0.14.1, all TSP patches included) plus a clean cherry-pick of ruma#2510 (`20c2c60f4`). No version bump, no matrix-sdk API churn.
- Enabled the `unstable-compat-lax-syncv5-deser` feature: corrupt name/avatar/hero fields in sync v5 responses are now dropped individually instead of failing the whole room object. Cargo feature unification applies this to the ruma instance inside matrix-sdk-base too.
- `Cargo.lock` regenerated and committed; full `cargo check` passes against the resolved lock.

## Decision record

- `docs/deps-ruma-fork.md` — decision chain, dependency graph, maintenance rules (append-only branch, never rebase/force-push), retirement condition (deleted when matrix-sdk eventually moves to official SDK, which is currently blocked by the rustls `ring`-provider removal vs our Android workaround, and a `libsqlite3-sys` links conflict via the sqlx/TSP chain).
- `specs/task-ruma-lax-syncv5-deser.spec.md` — task contract (agent-spec lint 100%; manual-review scenarios per project convention).

## Testing

- ✅ `cargo check` passes; `cargo tree -p ruma` resolves to `Project-Robius-China/ruma?branch=tsp-lax-syncv5-deser#20c2c60f4`, version 0.14.1.
- ⏳ **Awaiting user manual testing before merge** (scenarios in the spec): with robrix2 running, have another account send an invite / have a server-side bot create a room — it should appear **without a restart** and without `The room must exist since it has been joined` in the logs. Also sanity-check normal messaging and startup sync (the feature only changes behavior for corrupt fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)