### PR TITLE
chore: pin makepad back to ZhangHanDong/makepad (PR #6 merged upstream)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "accessory"
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "as-slice"
@@ -282,7 +282,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "bit-vec",
 ]
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "bit_field"
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "bitmaps"
@@ -1020,7 +1020,7 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "byteorder"
@@ -1031,7 +1031,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "byteorder-lite"
@@ -1132,7 +1132,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "cfg_aliases"
@@ -1143,7 +1143,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "chacha20"
@@ -1505,7 +1505,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "crypto-bigint"
@@ -1921,7 +1921,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "dunce"
@@ -2076,7 +2076,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "errno"
@@ -2300,7 +2300,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "foreign-types"
@@ -2457,9 +2457,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "byteorder 1.5.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
@@ -2665,9 +2665,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "foldhash 0.2.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "foldhash 0.2.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
@@ -2700,7 +2700,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "hilog-sys"
@@ -3182,10 +3182,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "equivalent 1.0.2 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
- "hashbrown 0.16.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "equivalent 1.0.2 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
+ "hashbrown 0.16.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
@@ -3404,9 +3404,9 @@ dependencies = [
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "cfg-if 1.0.4 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "windows-link 0.2.1",
 ]
 
@@ -3478,7 +3478,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "loom"
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -3576,12 +3576,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3623,15 +3623,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "unicode-bidi 0.3.18 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3639,33 +3639,33 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "weezl 0.1.12 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "weezl 0.1.12 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
- "crunchy 0.2.4 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "cfg-if 1.0.4 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
+ "crunchy 0.2.4 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "num-traits 0.2.20",
  "zerocopy 0.8.39",
 ]
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3687,7 +3687,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "ttf-parser",
 ]
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3712,7 +3712,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3728,12 +3728,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3742,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3764,15 +3764,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "bitflags 2.10.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3794,7 +3794,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "smallvec 1.15.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "wayland-client 0.31.12",
  "wayland-egl",
  "wayland-protocols 0.32.10",
@@ -3806,12 +3806,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3819,13 +3819,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "smallvec 1.15.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3842,14 +3842,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "bitflags 2.10.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3859,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3894,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3903,13 +3903,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3926,15 +3926,15 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "simd-adler32 0.3.9 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "simd-adler32 0.3.9 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -4347,7 +4347,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "memoffset"
@@ -4436,20 +4436,20 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "arrayvec 0.7.6 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "arrayvec 0.7.6 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "bit-set",
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 1.0.4 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
- "cfg_aliases 0.2.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
- "hashbrown 0.16.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "cfg-if 1.0.4 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
+ "cfg_aliases 0.2.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
+ "hashbrown 0.16.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "hexf-parse",
- "indexmap 2.13.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "indexmap 2.13.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "makepad-error-log",
  "makepad-half",
  "num-traits 0.2.20",
- "once_cell 1.21.3 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "once_cell 1.21.3 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "num_cpus"
@@ -4803,7 +4803,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5075,7 +5075,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "png"
@@ -5266,10 +5266,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
- "memchr 2.7.6 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "bitflags 2.10.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
+ "memchr 2.7.6 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "unicase 2.9.0",
 ]
 
@@ -6109,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "rustc-hash"
@@ -6234,12 +6234,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
- "bytemuck 1.25.0 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "bitflags 2.10.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
+ "bytemuck 1.25.0 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "smallvec 1.15.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -6328,7 +6328,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "scopeguard"
@@ -6339,7 +6339,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "sealed"
@@ -6655,7 +6655,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "simd_helpers"
@@ -6690,7 +6690,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "socket2"
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "thiserror-impl 2.0.18",
 ]
@@ -7236,7 +7236,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "tungstenite"
@@ -7695,7 +7695,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-bidi"
@@ -7706,17 +7706,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-ident"
@@ -7727,7 +7727,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-normalization"
@@ -7747,12 +7747,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7763,7 +7763,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "unicode-xid"
@@ -8100,11 +8100,11 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
- "downcast-rs 1.2.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "downcast-rs 1.2.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "libc",
- "scoped-tls 1.0.1 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "scoped-tls 1.0.1 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys 0.31.8",
 ]
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -8148,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "wayland-backend 0.3.12",
  "wayland-sys 0.31.8",
@@ -8157,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend 0.3.12",
@@ -8190,10 +8190,10 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "log 0.4.29",
- "pkg-config 0.3.32 (git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378)",
+ "pkg-config 0.3.32 (git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193)",
 ]
 
 [[package]]
@@ -8267,7 +8267,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "whoami"
@@ -8320,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -8393,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -8457,7 +8457,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "windows-numerics"
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/ymote/makepad?rev=1199cace4da2d0f9f2d53f5c08a256e7ac8de378#1199cace4da2d0f9f2d53f5c08a256e7ac8de378"
+source = "git+https://github.com/ZhangHanDong/makepad?rev=1dd8d372cfb65b20160a3782586ed4d593cf8193#1dd8d372cfb65b20160a3782586ed4d593cf8193"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,11 +372,10 @@ used_underscore_binding = "allow"
 ## sandbox dirs, mobile-layout detection, ArkUI native inputs), with the legacy
 ## `old/` crate copies removed so the repo resolves as a cargo git dependency.
 [patch."https://github.com/makepad/makepad"]
-## Pinned to ymote/makepad `robrix2-fixes` (ZhangHanDong/makepad dev @ e40c5c6
-## plus the fixes robrix2 depends on: Splash-isolate shader identity, headless
-## renderer correctness, ttf-parser gvar-alloc for Apple variable fonts, the
-## CoreText outline fallback for hvgl-only system fonts like PingFang, and the
-## closed-Modal overdraw fix). PR'd upstream as ZhangHanDong/makepad#6 —
-## switch back to the upstream branch once that merges.
-makepad-widgets = { git = "https://github.com/ymote/makepad", rev = "1199cace4da2d0f9f2d53f5c08a256e7ac8de378", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/ymote/makepad", rev = "1199cace4da2d0f9f2d53f5c08a256e7ac8de378" }
+## Pinned to ZhangHanDong/makepad dev at the merge of PR #6 (Splash-isolate
+## shader identity, headless renderer correctness, ttf-parser gvar-alloc for
+## Apple variable fonts, the CoreText outline fallback for hvgl-only system
+## fonts like PingFang, and the closed-Modal overdraw fix), plus the
+## selectable-Html fix from PR #5.
+makepad-widgets = { git = "https://github.com/ZhangHanDong/makepad", rev = "1dd8d372cfb65b20160a3782586ed4d593cf8193", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/ZhangHanDong/makepad", rev = "1dd8d372cfb65b20160a3782586ed4d593cf8193" }


### PR DESCRIPTION
ZhangHanDong/makepad#6 — the Splash-isolate shader identity, headless renderer, gvar-alloc, CoreText hvgl-fallback, and closed-Modal fixes robrix2 depends on — merged upstream, so the temporary `ymote/makepad` pin moves back to `ZhangHanDong/makepad` at the merge commit (`1dd8d37`), also picking up the selectable-Html fix from their PR #5. Built clean and all 605 lib tests pass against the new rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)