### PR TITLE
docs(book): rewrite part 2 for HAFleet thread-session mode

### DIFF
--- a/book/en/src/part2/deploy-cloud.md
+++ b/book/en/src/part2/deploy-cloud.md
@@ -36,4 +36,4 @@ Two caveats:
 
 Choose by four verifiable conditions: account provisioning, stable Client-Server APIs, bridge-compatible limits, and an acceptable storage location for unencrypted project data. Cross-homeserver collaboration additionally requires correct public DNS, TLS, and Matrix federation.
 
-For internet-facing dashboards, use an HTTPS reverse proxy, set `AGENT_CHAT_WEB_URL`, and keep the backend API loopback-only unless you deliberately add access control.
+For internet-facing dashboards, use an HTTPS reverse proxy, set `HAFLEET_WEB_URL`, and keep the backend API loopback-only unless you deliberately add access control.

--- a/book/en/src/part2/deploy-local.md
+++ b/book/en/src/part2/deploy-local.md
@@ -13,17 +13,19 @@ flowchart LR
     end
     subgraph local["Local processes"]
         ROBRIX["Robrix2 (cargo run)"]
-        BE["agent-chat backend :8090"]
+        BE["HAFleet backend :8090"]
         DASH["dashboard :8084"]
         BRIDGE["bridge-matrix.js"]
-        TMUX["tmux: Claude Code / Codex"]
+        RUNNER["one-shot runners<br/>claude -p / codex app-server"]
     end
     ROBRIX -->|login http://127.0.0.1:8128| PALPO
     BRIDGE <--> PALPO
     BRIDGE <--> BE
     BE --- DASH
-    BE <-->|MCP + notifications| TMUX
+    BE -->|spawned per turn, exits after replying| RUNNER
 ```
+
+> The agent-chat project has been renamed **HAFleet**; the CLI and env-var prefix changed from `agentchat`/`AGENTCHAT_*` to `hafleet`/`HAFLEET_*` accordingly. This chapter is written for the thread-session runner mode (recommended, and the mode this book was verified against): agents have no resident process — the backend spawns a one-shot runner per conversational turn, and idle agents cost zero processes. The legacy resident-tmux mode remains in the code as a rollback path (turn off `HAFLEET_THREAD_SESSIONS` to fall back) but is no longer the recommended deployment.
 
 ## 1. Start Palpo (Matrix Homeserver)
 
@@ -51,11 +53,11 @@ You can also skip Docker and build/run with `cargo` per the [Palpo repository](h
 
 ## 2. Configure and Start agent-chat
 
-Prerequisites: **Node.js 22+**, **tmux**, and at least one coding runtime (Claude Code or Codex CLI).
+Prerequisites: **Node.js 22+** and at least one coding runtime (Claude Code or Codex CLI). Under thread-session mode tmux is no longer required (it is only used transiently for one-time agent registration, see below).
 
 ```bash
-git clone https://github.com/ZhangHanDong/agent-chat.git
-cd agent-chat
+git clone https://github.com/hagency-org/HAFleet.git
+cd HAFleet
 npm install
 cp .env.example .env
 ```
@@ -80,12 +82,20 @@ MATRIX_AGENT_PASSWORD_SECRET=<another long random secret>
 MATRIX_BRIDGE_SECRET=<secret shared by backend and bridge>
 
 MATRIX_TRUST_MODE=enforce
-MATRIX_TRUSTED_INVITER_MXIDS=@alex:127.0.0.1:8128
+# Note: besides the human operator, the bridge bot itself must be listed —
+# it issues room invites on behalf of the agent puppets
+MATRIX_TRUSTED_INVITER_MXIDS=@alex:127.0.0.1:8128,@agent-bridge-alexlocal:127.0.0.1:8128
 MATRIX_OPERATOR_MXIDS=@alex:127.0.0.1:8128
 MATRIX_DEFAULT_WAKE=off
+
+# thread-session runner mode (recommended): one isolated session per Matrix thread
+HAFLEET_THREAD_SESSIONS=1
+HAFLEET_ROUTER_TASK_CUTOVER=1
 ```
 
-Do not write just a display name or `alex`; security boundaries use full MXIDs. `MATRIX_OPERATOR_MXIDS` / `MATRIX_ADMIN_MXIDS` must not both be left empty, because the admin-command ACL has a `no_acl` fallback for backward compatibility with old deployments (these two entries do not exist in `.env.example` — add them yourself). If homeserver registration is closed, you must also pre-create the bridge account and every `@ac_*` account, or configure a registration token supported by your server.
+> On first start, `HAFLEET_ROUTER_TASK_CUTOVER=1` migrates `tasks.json` one-way into SQLite (a `.bak` is kept automatically); SQLite is the task store of record afterwards. `HAFLEET_THREAD_SESSIONS` requires it. Both variables must reach the backend AND the bridge.
+
+Do not write just a display name or `alex`; security boundaries use full MXIDs. **Omitting the bridge bot from `MATRIX_TRUSTED_INVITER_MXIDS` is the most common deployment mistake** — the symptom is the bridge log filling with `UNTRUSTED reason=untrusted_inviter` while agent puppets never join rooms. `MATRIX_OPERATOR_MXIDS` / `MATRIX_ADMIN_MXIDS` must not both be left empty, because the admin-command ACL has a `no_acl` fallback for backward compatibility with old deployments (these two entries do not exist in `.env.example` — add them yourself). If homeserver registration is closed, you must also pre-create the bridge account and every `@ac_*` account, or configure a registration token supported by your server.
 
 ### Linux: The Supported Install Path
 
@@ -99,17 +109,19 @@ The installer is currently a Linux/systemd path. Whether user units are used dep
 
 ### macOS: The Development Run Path
 
-macOS currently has no equivalent full installer. First remove all `<...>` placeholders and quote any values containing shell special characters correctly; then run the following in four terminals, each from the same environment:
+macOS currently has no equivalent full installer. The recommended path is the repository's local supervisor, which brings up all four services (backend `:8090`, dashboard `:8084`, local notification relay, Matrix bridge) with one command and restarts children when they exit:
 
 ```bash
 set -a; source .env; set +a
-node backend-v2.js
-node server.js
-PUSH_RELAY_MODE=local node push-relay.js
-node bridge-matrix.js
+node services/hafleet-services.mjs run --profile services/services-local.json
 ```
 
-These four are, respectively, the backend `:8090`, the dashboard `:8084`, the local notification relay, and the Matrix bridge; every one of them must inherit the same environment. If you already have a local supervisor/LaunchAgent setup, you can use `bin/agentchat service restart --profile local` — but clone + `npm install` by itself does not create these services on macOS.
+**Two path variables that are easy to get wrong** (we hit both during a real upgrade):
+
+- `HAFLEET_RUNTIME_DIR` — the data directory (where `data/` lives). The supervisor's `--runtime` flag only affects its own state files; **child processes rely entirely on this environment variable**. Left unset, the backend creates an empty `data/` next to the code — the symptom is "services healthy but agents: 0 and messages vanish". If code and data share a directory you can omit it.
+- `HAFLEET_HOMEDIR` — the agent home root (tokens, state, workspaces), default `~/.hafleet`. When upgrading from old agent-chat where agents live under `~/.agentchat`, you must point this back explicitly, or runners fail with `agent token is unavailable`.
+
+You can still start the four processes by hand in four terminals as the old docs described, but every terminal must source the same `.env` plus the variables above.
 
 **Verify the base services**:
 
@@ -118,20 +130,22 @@ curl --noproxy '*' http://127.0.0.1:8090/health   # backend health check
 open http://127.0.0.1:8084                        # local monitoring dashboard
 ```
 
-### Bind a Local Project to the Agent and Start It
+### Register the Agent and Bind a Local Project
 
-Declare the project boundary first, then start the runtime:
+Declare the project boundary first, then do the one-time registration:
 
 ```bash
-bin/agentchat project add wf_coordinator /absolute/path/to/my-project --mode symlink
-bin/agentchat project list wf_coordinator
-bin/agentchat up wf_coordinator /absolute/path/to/my-project claude
-bin/agentchat ls
+bin/hafleet project add wf_coordinator /absolute/path/to/my-project --mode symlink
+bin/hafleet project list wf_coordinator
+bin/hafleet up wf_coordinator /absolute/path/to/my-project claude   # one-time registration
+bin/hafleet ls
 ```
 
-`symlink` lets the agent write directly into the source repository; `copy` is an isolated replica that does not write changes back to the source directory. Add only the project paths the agent needs — do not expose your whole working directory or home. The model can be chosen at launch with `--model <model>`; changing the model requires restarting that runtime. Natural-language per-task model selection from within Robrix2 is not wired up yet.
+`symlink` lets the agent write directly into the source repository; `copy` is an isolated replica that does not write changes back to the source directory. Add only the project paths the agent needs — do not expose your whole working directory or home.
 
-A managed launch registers the `@ac_<name>` puppet account, connects MCP, and pins the runtime permission policy: Claude Code uses `--permission-mode auto` with the approval channel; Codex uses `workspace-write` + the `on-request` hook. Codex's first `up` requires typing `TRUST` once in a local TTY; do not hand-edit the trust state, and do not manually relaunch a CLI inside tmux without the managed parameters.
+What `up` accomplishes here is **registration**: it creates the `@ac_<name>` puppet account, mints the token, and writes the workspace and MCP configuration. Under thread-session mode those are everything a runner needs — once registration completes you can stop the tmux pane with `bin/hafleet down`, and Matrix messages are handled from then on by one-shot runners the backend spawns per turn; no resident runtime is needed. A Codex agent's first `up` requires typing `TRUST` once in a local TTY; do not hand-edit the trust state.
+
+**Per-turn runner permissions are pinned by the backend**: an ordinary chat turn runs Claude with `--permission-mode plan` (read-only) and Codex in a `read-only` sandbox; only turns bound to a task (or explicitly granted by an operator via `/thread mode auto`, see chapter 5.3) get write access, and concurrent writes are serialized by the workspace lease. The model defaults to the agent's configuration and can be overridden per thread with `/thread model <name>` — the model must match the agent's framework (naming a Claude model for a Codex agent fails at runtime).
 
 ## 3. Start Robrix2
 
@@ -151,7 +165,7 @@ After logging in, flip the runtime switch once: **Settings → Preferences → E
 1. **Create the backend group**:
 
    ```bash
-   bin/agentchat cli create-group robrix2-board wf_coordinator
+   bin/hafleet cli create-group robrix2-board wf_coordinator
    ```
 
    **Current bootstrap limitation**: when the bridge observes a new group, it automatically creates a Matrix room of the same name and joins the agent to it; there is currently no "backend group only / no room" switch. In the auto-created room, the agent's inviter is the bridge, so no human owner is established. A formal release should first add that mode or a validated owner-claim flow.
@@ -193,10 +207,13 @@ After logging in, flip the runtime switch once: **Settings → Preferences → E
 | Robrix2 login fails | Palpo container logs; does the homeserver address include the right port |
 | Bridge won't start | Are `API_TOKEN`, `MATRIX_BRIDGE_SECRET`, the bot password, and the agent password secret non-empty; are backend/bridge reading the same `.env` |
 | **The bridge is completely unresponsive to room messages** | Confirm trust mode is enforce and the trusted inviter is the full MXID that invited the bridge; check the bridge trust logs |
-| `!bindroom` replies Group not found | Create the group first with `agentchat cli create-group` |
+| `!bindroom` replies Group not found | Create the group first with `hafleet cli create-group` |
 | `!bindroom` says no permission | The sender is not in `MATRIX_OPERATOR_MXIDS` |
-| @Agent gets no reaction | Is the agent actually in the room; is `agentchat ls` online; did the bridge receive an explicit mention; is the push relay healthy |
+| @Agent gets no reaction | Is the agent actually in the room; is the agent registered in `hafleet ls`; did the bridge receive an explicit mention; is the push relay healthy |
 | No workflow commands in the `/` palette | Built with `--features agent_chat` + the Preferences toggle on; is there a `*_coordinator` in the room |
-| Approval instantly denied / card missing | Is there a unique owner binding; was the approval-room invite accepted; was the runtime launched managed; did the backend create a pending record |
+| Approval instantly denied / card missing | Is there a unique owner binding; was the approval-room invite accepted; are runners spawning normally (backend log `[router-runner]`); did the backend create a pending record |
+| Services healthy but agents: 0, messages vanish | `HAFLEET_RUNTIME_DIR` does not point at the real data directory — the backend is running against an empty `data/` |
+| Every runner fails with `agent token is unavailable` | `HAFLEET_HOMEDIR` disagrees with where the agents actually live (old deployments: `~/.agentchat`) |
+| The agent says it is in plan mode and cannot write | Expected: chat turns are read-only; use the task flow or `/thread mode auto` for write access |
 
 For full layer-by-layer diagnosis see [Operations Acceptance and Troubleshooting](operations.md). Next: [Team Collaboration in Practice](collab-overview.md).

--- a/book/en/src/part2/operations.md
+++ b/book/en/src/part2/operations.md
@@ -1,6 +1,6 @@
 # Operations Acceptance and Troubleshooting
 
-> **Scope**: This chapter provides layer-by-layer checklists from Matrix ingress to tmux and back through the approval return path. Use it for problems like "the agent doesn't reply, Threads go astray, cards don't appear, clicking still shows expired."
+> **Scope**: This chapter provides layer-by-layer checklists from Matrix ingress through thread-session routing and one-shot runners, and back through the approval return path. Use it for problems like "the agent doesn't reply, Threads go astray, cards don't appear, clicking still shows expired."
 
 ## Pre-Release Acceptance Checklist
 
@@ -36,20 +36,19 @@ Check the pipeline layer by layer; do not just restart everything:
 Matrix event
   → explicit mention / trusted room
   → bridge ingestion
-  → backend message
-  → push relay notification
-  → managed tmux
-  → Agent check_inbox
-  → backend post/reply
-  → Matrix puppet send
+  → backend message → thread-session routing (one session per (agent, thread))
+  → dispatch queued (queued → leased → started → completed)
+  → one-shot runner spawned
+  → runner reply → reply outbox
+  → bridge claims outbound → Matrix puppet send
 ```
 
 - Was the full target actually @-mentioned in the room; is `MATRIX_DEFAULT_WAKE` set to `off`;
 - Are both the agent and its companion bridge joined; invite polling may default to roughly 60 seconds;
-- Is `agentchat ls` showing online; is the dashboard heartbeat fresh;
-- Backend inbox has the message but tmux is not advancing: check the push relay and the idle gate;
-- Claude/Codex was manually restarted inside tmux: use `agentchat down/up` to restore a managed launch;
-- The agent posts to the wrong place: check whether its outbound message references the original backend `reply_to`.
+- Is the agent registered in `hafleet ls`; is the backend `/health` agents count non-zero (zero usually means `HAFLEET_RUNTIME_DIR` points at the wrong data directory);
+- Dispatches stuck in `queued`: read the backend log's `[router-runner]` lines. `agent token is unavailable` = `HAFLEET_HOMEDIR` disagrees with the agent home; a model 400 = `/thread model` named a model incompatible with the agent's framework;
+- A dispatch lands in `outcome_unknown`: the runner died after work may have started (model error, killed process). The session fail-closes until an operator adjudicates via `POST /api/router/dispatches/:id/outcome-inspection` → `resolve-outcome` (action `continue` with a recovery instruction), after which the turn re-runs automatically;
+- The agent says it is in plan mode: expected — chat turns are read-only; write access goes through the task flow or `/thread mode auto`.
 
 ## Thread Replies Fall Into the Main Timeline
 
@@ -65,14 +64,14 @@ If the project room has E2EE enabled, the current agent group outbound path does
 
 Confirm from the entry point downward:
 
-1. If tmux shows the runtime's own local permission selection box, first determine whether this is the waiting UI taken over by agent-chat; the criterion is whether a pending approval actually appears in the backend;
+1. The only criterion is whether a pending approval actually appears in the backend (runner approvals travel over the MCP approval channel into the backend; there is no local tmux prompt any more);
 2. Was Claude started by the launcher with auto + Ask rules; is the Codex hook trusted and its hash matching;
 3. Did the approval store find a unique `(room, agent)→owner`; otherwise it is `owner_binding_missing/ambiguous`;
 4. Has the owner joined the approval room; otherwise it is `owner_invite_pending`;
-5. Did the bridge send `com.agentchat.approval.request.v1`; is there a queued UTD in E2EE;
+5. Did the bridge send `com.hafleet.approval.request.v1`; is there a queued UTD in E2EE;
 6. Has Robrix2 synced, decrypted, and rendered the custom event.
 
-Do not substitute a chat-text "approve" for the card, and do not select Yes inside tmux to skip Matrix-side acceptance.
+Do not substitute a chat-text "approve" for the card, and do not bypass Matrix-side acceptance by any local means.
 
 ## Clicked Approve, but the Runtime Still Shows Expired/Denied
 
@@ -84,9 +83,10 @@ Check the final rejection code in the backend audit and the bridge's verdict log
 
 | What you want to know | Authoritative / primary evidence |
 |------------|---------------|
-| Is the agent process online | managed process/tmux + backend heartbeat |
+| Is the agent available | `hafleet ls` registration + backend `/health` (idle agents having zero processes is normal under thread-session mode) |
 | Did the message reach the backend | backend message/inbox |
 | Where the workflow stands | workflow state + durable task (if any) + Thread; there is currently no single authoritative source |
+| A turn's execution state | the router's dispatch records (queued/started/completed/outcome_unknown) |
 | Who can approve | bridge owner binding + the original Matrix invite sender |
 | Approval outcome | backend approval store/audit |
 | Is the code done | Git commit/worktree + actual test results |

--- a/book/en/src/part2/threads.md
+++ b/book/en/src/part2/threads.md
@@ -2,7 +2,7 @@
 
 > **Scope**: This chapter establishes HAgency's most important collaboration habit — tasks live in Threads, and the main timeline keeps only the cover; it also gives the routing rule for "what goes in a Thread, what goes on the main timeline, and what goes to a DM". Prerequisite: Chapter 5.2.
 
-A board room quickly ends up with several things happening at once. If every bit of progress scrolled by on the main timeline, the room would become unreadable within a day. HAgency's convention: **one Thread per task** — process details go into the thread, and the main timeline keeps the task's "cover". This is a collaboration convention; whether a message actually returns to the Thread still depends on backend reply context.
+A board room quickly ends up with several things happening at once. If every bit of progress scrolled by on the main timeline, the room would become unreadable within a day. HAgency's convention: **one Thread per task** — process details go into the thread, and the main timeline keeps the task's "cover". Under thread-session mode this is more than a collaboration convention: on the backend, each Thread is an isolated agent session (see below).
 
 The complete journey of a message from your Thread, to the Agent, and back into the same Thread:
 
@@ -12,17 +12,39 @@ sequenceDiagram
     participant M as Matrix (Palpo)
     participant B as agent-chat bridge
     participant BE as backend :8090
-    participant A as Agent (tmux)
+    participant R as one-shot runner
 
-    H->>M: @wf_coordinator how's it going? (m.thread relation)
+    H->>M: @wf_coordinator how is it going? (m.thread relation)
     M->>B: room event
-    B->>BE: converted to an agent-chat message (thread context recorded)
-    BE->>A: notification advances tmux
-    A->>BE: structured reply with reply_to
-    BE->>B: outbound message
-    B->>M: rebuilds m.thread + m.in_reply_to from trusted matrixContext
-    M->>H: reply appears inside the Thread
+    B->>BE: converted to a backend message (thread context recorded)
+    BE->>BE: routed to this (agent, thread)'s isolated session
+    BE->>R: spawn a runner, feed it this thread's rebuilt context
+    R->>BE: reply (a runner cannot choose its own reply target)
+    BE->>B: outbound message (reply outbox; the target is derived by the backend)
+    B->>M: rebuild m.thread + m.in_reply_to
+    M->>H: the reply appears inside the Thread
 ```
+
+## One isolated session per Thread
+
+A Thread is not just a collapsed strand in the UI — on the backend, **every (agent, thread) pair is a persistent, isolated session**:
+
+- **Context isolation**: constraints, code words, and preferences stated in Thread A never leak into Thread B. Ask the same agent the same question in two threads and each answer draws only on that thread's own history.
+- **Processes are day labourers**: agents have no resident process. Each turn the backend spawns a one-shot runner (`claude -p` / `codex app-server`), feeds it this thread's context rebuilt from the database, and the runner exits after answering. A thread's "memory" lives in SQLite — restart the backend, ask again, and the agent still remembers what this thread discussed.
+- **Parallel, not queued**: while Thread A runs a long task, Thread B's question is handled by another runner in parallel.
+- **Reply targeting is a transport guarantee**: replies leave through the backend's reply outbox, and the thread attribution is derived by the backend from session records — the model cannot misdirect its own reply.
+- **What stays shared is identity**: the agent's name, Matrix puppet, working directory, and long-term memory remain one — like a human assistant who stays focused inside each strand but remembers who they are.
+
+### Configuring a session in-thread: `/thread` directives
+
+An operator (an account in `MATRIX_OPERATOR_MXIDS`) can adjust **this one thread's** session from inside it:
+
+```text
+/thread model claude-haiku-4-5   # switch this thread's model (default restores)
+/thread mode auto                # grant this thread write access (plan revokes)
+```
+
+Directive messages never enter the conversation context; the agent answers with a confirmation notice. Three caveats: nothing else may follow the directive on the same message (you get a usage hint otherwise); `mode auto` is an audited write grant — every later turn in that thread may write the workspace (concurrent writes stay serialized by the workspace lease); and the model must match the agent's framework — in a thread with several agents the directive applies to **all** of their sessions, and naming a Claude model for a Codex agent fails at runtime.
 
 ## Dispatch Goes into a Thread
 
@@ -40,7 +62,7 @@ Open the Thread (it becomes its own tab, `[Thread] robrix2-board`), and you can 
 
 In the screenshot alex sends just one line — `@wf_coordinator how's it going?` — and the coordinator gives structured status: who took the task, when the task went active, whether the branch has new commits, what the process looks like next, and a promise to post proactive updates.
 
-Proactive reporting is currently a **workflow skill convention, not a transport guarantee**. If the Agent is busy, the push relay does not advance, the session is interrupted, or a `post()` lacks `reply_to`, updates may not appear or may fall back onto the main timeline. Humans should still use `/status`, the Project Board, the dashboard's task/heartbeat, and Git status as fallbacks.
+Reply targeting is a transport guarantee (see the session model above); the **cadence of proactive reporting**, however, is still a workflow-skill convention — an agent busy with a long task may go quiet for a while. Humans should still use `/status`, the Project Board, the dashboard's task/heartbeat, and Git status as fallbacks.
 
 ## How Thread Continuity Actually Works
 

--- a/book/zh/src/part2/deploy-cloud.md
+++ b/book/zh/src/part2/deploy-cloud.md
@@ -36,4 +36,4 @@
 
 选择标准不是品牌，而是四个可验证条件：允许所需账号 provisioning、Client-Server API 稳定、限流能承受 bridge 轮询、你接受非加密项目数据的存储位置。跨 homeserver 协作还要求双方正确配置公网 DNS、TLS 与 Matrix federation。
 
-若把 dashboard 暴露到公网，应放在 HTTPS 反向代理后，设置 `AGENT_CHAT_WEB_URL`，并继续把 backend API 保持在 loopback，除非你明确部署了额外的访问控制。
+若把 dashboard 暴露到公网，应放在 HTTPS 反向代理后，设置 `HAFLEET_WEB_URL`，并继续把 backend API 保持在 loopback，除非你明确部署了额外的访问控制。

--- a/book/zh/src/part2/deploy-local.md
+++ b/book/zh/src/part2/deploy-local.md
@@ -13,17 +13,19 @@ flowchart LR
     end
     subgraph local["本机进程"]
         ROBRIX["Robrix2（cargo run）"]
-        BE["agent-chat backend :8090"]
+        BE["HAFleet backend :8090"]
         DASH["dashboard :8084"]
         BRIDGE["bridge-matrix.js"]
-        TMUX["tmux: Claude Code / Codex"]
+        RUNNER["一次性 runner<br/>claude -p / codex app-server"]
     end
     ROBRIX -->|登录 http://127.0.0.1:8128| PALPO
     BRIDGE <--> PALPO
     BRIDGE <--> BE
     BE --- DASH
-    BE <-->|MCP + 通知| TMUX
+    BE -->|每轮孵化，答完即退| RUNNER
 ```
+
+> agent-chat 项目现已更名为 **HAFleet**，CLI 与环境变量前缀随之从 `agentchat`/`AGENTCHAT_*` 变为 `hafleet`/`HAFLEET_*`。本章按 thread-session runner 模式（推荐、也是本书验证过的模式）撰写：Agent 没有常驻进程，每轮对话由 backend 孵化一次性 runner，空闲时零进程。旧的 tmux 常驻会话模式仍作为回退路径保留在代码中（关闭 `HAFLEET_THREAD_SESSIONS` 即回退），但不再推荐部署。
 
 ## 1. 启动 Palpo（Matrix homeserver）
 
@@ -49,13 +51,13 @@ docker compose logs -f palpo
 
 也可以不用 Docker，按 [Palpo 仓库](https://github.com/palpo-im/palpo) 的说明用 `cargo` 构建运行；agent-chat 只要求「一个可用的 Matrix 服务器」。
 
-## 2. 配置并启动 agent-chat
+## 2. 配置并启动 HAFleet
 
-前置要求：**Node.js 22+**、**tmux**，以及至少一个编码运行时（Claude Code 或 Codex CLI）。
+前置要求：**Node.js 22+**，以及至少一个编码运行时（Claude Code 或 Codex CLI）。thread-session 模式下 tmux 不再是必需项（仅首次注册 Agent 时临时用到，见下文）。
 
 ```bash
-git clone https://github.com/ZhangHanDong/agent-chat.git
-cd agent-chat
+git clone https://github.com/hagency-org/HAFleet.git
+cd HAFleet
 npm install
 cp .env.example .env
 ```
@@ -80,12 +82,19 @@ MATRIX_AGENT_PASSWORD_SECRET=<另一个随机长 secret>
 MATRIX_BRIDGE_SECRET=<backend 与 bridge 共享 secret>
 
 MATRIX_TRUST_MODE=enforce
-MATRIX_TRUSTED_INVITER_MXIDS=@alex:127.0.0.1:8128
+# 注意:除了人类 operator,还必须列入桥机器人自己——它要替 Agent 木偶发房间邀请
+MATRIX_TRUSTED_INVITER_MXIDS=@alex:127.0.0.1:8128,@agent-bridge-alexlocal:127.0.0.1:8128
 MATRIX_OPERATOR_MXIDS=@alex:127.0.0.1:8128
 MATRIX_DEFAULT_WAKE=off
+
+# thread-session runner 模式(推荐):每个 Matrix thread 独立会话,一次性 runner
+HAFLEET_THREAD_SESSIONS=1
+HAFLEET_ROUTER_TASK_CUTOVER=1
 ```
 
-不要只写 display name 或 `alex`；安全边界使用完整 MXID。`MATRIX_OPERATOR_MXIDS` / `MATRIX_ADMIN_MXIDS` 不能都留空，因为管理命令 ACL 为兼容旧部署存在 `no_acl` 回退（这两项在 `.env.example` 里没有现成条目，需自行新增）。关闭 homeserver 注册时，还要预创建桥账号和每个 `@ac_*` 账号，或配置服务器支持的 registration token。
+> `HAFLEET_ROUTER_TASK_CUTOVER=1` 首次启动时会把 `tasks.json` 单向迁入 SQLite(自动留 `.bak`),之后任务库以 SQLite 为准;`HAFLEET_THREAD_SESSIONS` 依赖它。两个变量 backend 与 bridge 都要读到。
+
+不要只写 display name 或 `alex`；安全边界使用完整 MXID。**`MATRIX_TRUSTED_INVITER_MXIDS` 漏掉桥机器人是最常见的部署错误**——症状是 bridge 日志刷 `UNTRUSTED reason=untrusted_inviter`、Agent 木偶进不了房。`MATRIX_OPERATOR_MXIDS` / `MATRIX_ADMIN_MXIDS` 不能都留空，因为管理命令 ACL 为兼容旧部署存在 `no_acl` 回退（这两项在 `.env.example` 里没有现成条目，需自行新增）。关闭 homeserver 注册时，还要预创建桥账号和每个 `@ac_*` 账号，或配置服务器支持的 registration token。
 
 ### Linux：正式安装路径
 
@@ -99,17 +108,19 @@ systemctl --user status agent-chat-v2 agent-chat agent-chat-push-relay bridge-ma
 
 ### macOS：开发运行路径
 
-macOS 目前没有等价的完整安装器。先清除所有 `<...>` 占位符，并对含 shell 特殊字符的值正确加引号；然后在四个终端中从同一环境分别运行：
+macOS 目前没有等价的完整安装器。推荐用仓库自带的本地 supervisor 一条命令拉起全部四个服务（backend `:8090`、dashboard `:8084`、本地通知 relay、Matrix bridge），它会在子进程退出时自动重启：
 
 ```bash
 set -a; source .env; set +a
-node backend-v2.js
-node server.js
-PUSH_RELAY_MODE=local node push-relay.js
-node bridge-matrix.js
+node services/hafleet-services.mjs run --profile services/services-local.json
 ```
 
-上面四条分别是 backend `:8090`、dashboard `:8084`、本地通知 relay 和 Matrix bridge；每条都必须继承同一份环境。已有本地 supervisor/LaunchAgent 配置时可以使用 `bin/agentchat service restart --profile local`，但 clone + `npm install` 本身不会在 macOS 创建这些服务。
+**两个容易踩的路径变量**（我们在真实升级中都踩过）：
+
+- `HAFLEET_RUNTIME_DIR`——数据目录（`data/` 所在处）。supervisor 的 `--runtime` 参数只影响它自己的状态文件，**子进程完全依赖这个环境变量**；不设时 backend 会在代码目录下新建一个空 `data/`，表现为「服务健康但 agents: 0、消息石沉大海」。代码和数据同目录时可不设。
+- `HAFLEET_HOMEDIR`——Agent 家目录（token、状态、工作区所在处），默认 `~/.hafleet`。从旧版 agent-chat 升级、Agent 还住在 `~/.agentchat` 时必须显式指回去，否则 runner 起不来，日志报 `agent token is unavailable`。
+
+也可以像旧文档那样在四个终端里分别手工启动四个进程，但每个终端都必须 source 同一份 `.env` 并带上上述变量。
 
 **验证基础服务**：
 
@@ -118,20 +129,22 @@ curl --noproxy '*' http://127.0.0.1:8090/health   # backend 健康检查
 open http://127.0.0.1:8084                        # 本地监控面板
 ```
 
-### 给 Agent 绑定本地项目并启动
+### 注册 Agent 并绑定本地项目
 
-推荐先声明项目边界，再启动运行时：
+推荐先声明项目边界，再做一次性注册：
 
 ```bash
-bin/agentchat project add wf_coordinator /absolute/path/to/my-project --mode symlink
-bin/agentchat project list wf_coordinator
-bin/agentchat up wf_coordinator /absolute/path/to/my-project claude
-bin/agentchat ls
+bin/hafleet project add wf_coordinator /absolute/path/to/my-project --mode symlink
+bin/hafleet project list wf_coordinator
+bin/hafleet up wf_coordinator /absolute/path/to/my-project claude   # 一次性注册
+bin/hafleet ls
 ```
 
-`symlink` 会让 Agent 直接写源仓库；`copy` 是隔离副本，不会把修改直接写回源目录。只把需要的项目路径加入 Agent，避免把整个工作目录或 home 暴露进去。模型可在启动时用 `--model <model>` 选择，变更模型需要重启该运行时；Robrix2 里的自然语言按任务选模型目前还没有接通。
+`symlink` 会让 Agent 直接写源仓库；`copy` 是隔离副本，不会把修改直接写回源目录。只把需要的项目路径加入 Agent，避免把整个工作目录或 home 暴露进去。
 
-受管启动会注册 `@ac_<name>` 木偶账号、接入 MCP，并固定运行时权限策略：Claude Code 使用 `--permission-mode auto` 与审批 channel，Codex 使用 `workspace-write` + `on-request` hook。Codex 第一次 `up` 必须在本地 TTY 输入一次 `TRUST`；不要手工改 trust state，也不要在 tmux 里直接重开一个未带受管参数的 CLI。
+`up` 完成的是**注册**：创建 `@ac_<name>` 木偶账号、铸 token、写入工作区与 MCP 配置。thread-session 模式下这些是 runner 的全部依赖——注册完成后 tmux 面板即可 `bin/hafleet down` 停掉，Matrix 消息此后由 backend 按轮孵化一次性 runner 处理，不需要任何常驻运行时。Codex Agent 第一次 `up` 必须在本地 TTY 输入一次 `TRUST`；不要手工改 trust state。
+
+**每轮 runner 的权限策略由 backend 固定**：普通聊天回合 Claude 跑 `--permission-mode plan`（只读）、Codex 跑 `read-only` sandbox；只有绑定任务（或 operator 显式 `/thread mode auto` 授权，见第 5.3 章）的回合才拿到写权限，且并发写由工作区租约序列化。模型默认取 Agent 配置，房间内可用 `/thread model <name>` 按 thread 覆盖——注意模型要与 Agent 框架匹配（给 Codex Agent 指定 Claude 模型会在运行时报错）。
 
 ## 3. 启动 Robrix2
 
@@ -151,7 +164,7 @@ cargo run --features agent_chat
 1. **创建 backend group**：
 
    ```bash
-   bin/agentchat cli create-group robrix2-board wf_coordinator
+   bin/hafleet cli create-group robrix2-board wf_coordinator
    ```
 
    **当前 bootstrap 限制**：bridge 观察到新 group 后会自动创建同名 Matrix 房并让 Agent 加入；目前没有 “backend group only / no room” 开关。自动房里的 Agent 邀请者是 bridge，不会建立人类 owner。正式发布应先补这个模式或受校验的 owner-claim 流程。
@@ -193,10 +206,13 @@ cargo run --features agent_chat
 | Robrix2 登录失败 | Palpo 容器日志；homeserver 地址是否带对端口 |
 | bridge 无法启动 | `API_TOKEN`、`MATRIX_BRIDGE_SECRET`、bot 密码与 Agent 密码 secret 是否非空；backend/bridge 是否读取同一 `.env` |
 | **桥对房间消息完全无反应** | 确认 trust mode 为 enforce、trusted inviter 是邀请桥的完整 MXID；看 bridge trust 日志 |
-| `!bindroom` 回复 Group not found | 先 `agentchat cli create-group` 创建 group |
+| `!bindroom` 回复 Group not found | 先 `hafleet cli create-group` 创建 group |
 | `!bindroom` 没有权限 | 发送者不在 `MATRIX_OPERATOR_MXIDS` 里 |
-| @Agent 没反应 | Agent 是否真的在房间；`agentchat ls` 是否在线；bridge 是否收到了 explicit mention；push relay 是否健康 |
+| @Agent 没反应 | Agent 是否真的在房间；`hafleet ls` 是否注册；bridge 是否收到了 explicit mention；push relay 是否健康 |
 | `/` 面板里没有 workflow 命令 | 是否 `--features agent_chat` 构建 + 打开了 Preferences 开关；房间里是否有 `*_coordinator` |
-| 审批立即拒绝 / 卡片不出现 | 是否存在唯一 owner binding；审批房邀请是否接受；运行时是否受管启动；backend 是否创建 pending record |
+| 审批立即拒绝 / 卡片不出现 | 是否存在唯一 owner binding；审批房邀请是否接受；runner 是否由 backend 正常孵化(看 backend 日志 `[router-runner]`)；backend 是否创建 pending record |
+| 服务健康但 agents: 0、消息无反应 | `HAFLEET_RUNTIME_DIR` 未指向真实数据目录,backend 对着空 `data/` 在跑 |
+| runner 全部失败:`agent token is unavailable` | `HAFLEET_HOMEDIR` 与 Agent 实际家目录不一致(旧部署在 `~/.agentchat`) |
+| Agent 回复说自己在 plan mode 写不了文件 | 预期行为:聊天回合只读;要写权限用任务流或 `/thread mode auto` |
 
 完整分层定位见[运行验收与故障排查](operations.md)。下一步：[团队协作实战](collab-overview.md)。

--- a/book/zh/src/part2/operations.md
+++ b/book/zh/src/part2/operations.md
@@ -1,6 +1,6 @@
 # 运行验收与故障排查
 
-> **定位**：本章给出从 Matrix 入站到 tmux、再到审批回传的分层检查表。适用于“Agent 不回复、Thread 跑偏、卡片不出现、点击后仍过期”等问题。
+> **定位**：本章给出从 Matrix 入站、经 thread-session 路由与一次性 runner、再到审批回传的分层检查表。适用于“Agent 不回复、Thread 跑偏、卡片不出现、点击后仍过期”等问题。
 
 ## 发布前验收清单
 
@@ -8,10 +8,10 @@
 
 | 项目 | 需要记录 |
 |------|---------|
-| 版本 | Robrix2 commit、agent-chat commit、homeserver 版本与日期 |
+| 版本 | Robrix2 commit、HAFleet commit、homeserver 版本与日期 |
 | 账号 | human/bridge/每个 `@ac_*` 的完整 MXID |
 | 绑定 | room→group；每个 `(room, agent)→owner`；可选 group→project |
-| 运行时 | agent 名称、Claude/Codex、model、managed marker、project path/mode |
+| 运行时 | agent 名称、Claude/Codex、model、project path/mode、thread-session 开关状态 |
 | 房间 | 非加密项目房；每个 `(agent, owner)` 的 E2EE approval room |
 | workflow | skill 版本、四个角色命名、worktree/commit SHA |
 
@@ -36,20 +36,19 @@
 Matrix event
   → explicit mention / trusted room
   → bridge ingestion
-  → backend message
-  → push relay notification
-  → managed tmux
-  → Agent check_inbox
-  → backend post/reply
-  → Matrix puppet send
+  → backend 消息 → thread-session 路由(每 (Agent, Thread) 一个会话)
+  → dispatch 入队(queued → leased → started → completed)
+  → 孵化一次性 runner
+  → runner 回复 → reply outbox
+  → bridge 领取出站 → Matrix puppet send
 ```
 
 - 房间里是否真的 @ 了完整目标；`MATRIX_DEFAULT_WAKE` 是否为 `off`；
 - Agent 和 companion bridge 是否都 joined；邀请轮询默认可能约 60 秒；
-- `agentchat ls` 是否 online，dashboard heartbeat 是否新鲜；
-- backend inbox 已有消息但 tmux 没推进：查 push relay 与 idle gate；
-- tmux 内手工重开过 Claude/Codex：用 `agentchat down/up` 恢复受管启动；
-- Agent 发到错误位置：查其出站是否引用了原 backend `reply_to`。
+- `hafleet ls` 是否已注册；backend `/health` 的 agents 数是否非零（为 0 通常是 `HAFLEET_RUNTIME_DIR` 指错了数据目录）；
+- dispatch 一直停在 `queued`：看 backend 日志的 `[router-runner]` 行。`agent token is unavailable` = `HAFLEET_HOMEDIR` 与 Agent 家目录不符；模型 400 = `/thread model` 指定了与框架不兼容的模型；
+- dispatch 落入 `outcome_unknown`：runner 在可能已开始工作后异常终止（如模型报错、进程被杀），该会话 fail-closed 锁定，需要 operator 走 `POST /api/router/dispatches/:id/outcome-inspection` → `resolve-outcome`（action `continue` 附恢复说明）裁决后自动重跑；
+- Agent 回复说自己在 plan mode：预期行为——聊天回合只读，写权限走任务流或 `/thread mode auto`。
 
 ## Thread 回复掉到主时间线
 
@@ -65,14 +64,14 @@ Matrix event
 
 从入口向下确认：
 
-1. tmux 如果显示 runtime 自己的本地权限选择框，先确认这是否为 agent-chat 接管的等待 UI；backend 是否实际出现 pending approval 是判据；
-2. Claude 是否由 launcher 以 auto + Ask rules 启动；Codex hook 是否 trusted、hash 是否匹配；
+1. backend 是否实际出现 pending approval 是唯一判据（runner 的审批经 MCP 审批通道进 backend，不再有本地 tmux 弹框）；
+2. Claude runner 是否带审批 channel 启动（backend 固定注入）；Codex hook 是否 trusted、hash 是否匹配；
 3. approval store 是否找到唯一 `(room, agent)→owner`，否则是 `owner_binding_missing/ambiguous`；
 4. owner 是否已加入 approval room，否则是 `owner_invite_pending`；
-5. bridge 是否发送 `com.agentchat.approval.request.v1`；E2EE 是否有 queued UTD；
+5. bridge 是否发送 `com.hafleet.approval.request.v1`；E2EE 是否有 queued UTD；
 6. Robrix2 是否已同步、解密并渲染 custom event。
 
-不要用聊天文字“批准”代替卡片，不要在 tmux 里选 Yes 绕过 Matrix 验收。
+不要用聊天文字“批准”代替卡片，也不要以任何本地方式绕过 Matrix 验收。
 
 ## 点击批准但运行时仍显示过期/拒绝
 
@@ -84,9 +83,10 @@ Matrix event
 
 | 想知道什么 | 权威/主要证据 |
 |------------|---------------|
-| Agent 进程是否在线 | managed process/tmux + backend heartbeat |
+| Agent 是否可用 | `hafleet ls` 注册状态 + backend `/health`（thread-session 模式下空闲无进程是常态） |
 | 消息是否送达 backend | backend message/inbox |
-| workflow 到哪一步 | workflow state + durable task（若有）+ Thread；当前没有单一权威源 |
+| workflow 到哪一步 | workflow state + durable task + Thread；当前没有单一权威源 |
+| 某轮对话的执行状态 | router 的 dispatch 记录（queued/started/completed/outcome_unknown） |
 | 谁能审批 | bridge owner binding + 原始 Matrix invite sender |
 | 审批结果 | backend approval store/audit |
 | 代码是否完成 | Git commit/worktree + 实际测试结果 |

--- a/book/zh/src/part2/threads.md
+++ b/book/zh/src/part2/threads.md
@@ -2,7 +2,7 @@
 
 > **定位**：本章建立 HAgency 最重要的协作习惯 —— 任务住进 Thread，主时间线只留封面；并给出「什么进 Thread、什么进主时间线、什么走 DM」的分流原则。前置依赖：第 5.2 章。
 
-作战室很快会同时进行多件事。如果所有进度都刷在主时间线，房间会在一天内变得不可读。HAgency 的约定是：**每个任务一条 Thread**，过程细节收进线索，主时间线保留任务「封面」。这是协作约定；消息是否真的回到 Thread 还取决于 backend reply context。
+作战室很快会同时进行多件事。如果所有进度都刷在主时间线，房间会在一天内变得不可读。HAgency 的约定是：**每个任务一条 Thread**，过程细节收进线索，主时间线保留任务「封面」。在 thread-session 模式下这不只是协作约定：每条 Thread 在 backend 侧就是一个隔离的 Agent 会话（见下文）。
 
 一条消息从你的 Thread 出发、到 Agent、再回到同一条 Thread 的完整旅程：
 
@@ -12,17 +12,39 @@ sequenceDiagram
     participant M as Matrix（Palpo）
     participant B as agent-chat 桥
     participant BE as backend :8090
-    participant A as Agent（tmux）
+    participant R as 一次性 runner
 
     H->>M: @wf_coordinator 咋样了？（m.thread 关系）
     M->>B: 房间事件
-    B->>BE: 转为 agent-chat 消息（记录线索上下文）
-    BE->>A: 通知推进 tmux
-    A->>BE: 带 reply_to 的结构化回复
-    BE->>B: 出站消息
-    B->>M: 从可信 matrixContext 重建 m.thread + m.in_reply_to
+    B->>BE: 转为 backend 消息（记录线索上下文）
+    BE->>BE: 路由到该 (Agent, Thread) 的独立会话
+    BE->>R: 孵化 runner，喂入本 Thread 的会话上下文
+    R->>BE: 回复（runner 无法指定落点）
+    BE->>B: 出站消息（reply outbox，落点由 backend 派生）
+    B->>M: 重建 m.thread + m.in_reply_to
     M->>H: Thread 内出现回复
 ```
+
+## 每条 Thread 一个独立会话
+
+Thread 不只是 UI 上的折叠线索——在 backend 里，**每个 (Agent, Thread) 组合就是一个持久的独立会话**：
+
+- **上下文隔离**：Thread A 里说过的约束、代号、偏好绝不会渗入 Thread B。同一个 Agent 在两条 Thread 里被问同一个问题，各自只依据本 Thread 的历史作答。
+- **进程即临时工**：Agent 没有常驻进程。每一轮问答由 backend 孵化一次性 runner（`claude -p` / `codex app-server`），喂入从数据库重建的本 Thread 上下文，答完即销毁。Thread 的"记忆"存在 SQLite 里，backend 重启后追问，Agent 依然记得本 Thread 之前聊过什么。
+- **并行不阻塞**：Thread A 里跑长任务时，Thread B 的提问由另一个 runner 并行处理，互不排队。
+- **回复落点是 transport 保证**：runner 的回复经 backend 的 reply outbox 发出，Thread 归属由 backend 从会话记录派生，模型自己无法把回复投错线索。
+- **共享的是身份**：Agent 的名字、Matrix 木偶、工作目录和长期记忆仍是同一份——它像一个人类助理，在每条线索里保持专注，但记得自己是谁。
+
+### 在 Thread 里配置会话：`/thread` 指令
+
+operator（`MATRIX_OPERATOR_MXIDS` 中的账号）可以在任意 Thread 里发指令调整**这一条 Thread** 的会话：
+
+```text
+/thread model claude-haiku-4-5   # 本 Thread 换模型(default 恢复)
+/thread mode auto                # 授予本 Thread 写权限(plan 收回)
+```
+
+指令消息不进入对话上下文，Agent 会回一条确认通知。注意三点：指令后**不能带其他文字**（会收到用法提示）；`mode auto` 是审计过的写授权，该 Thread 后续每轮都可写工作区（并发写仍被租约序列化）；模型名要与 Agent 框架匹配——Thread 里有多个 Agent 时指令会应用到**所有**参与者的会话，给 Codex Agent 指定 Claude 模型会导致该会话运行时报错。
 
 ## 派单入线索
 
@@ -40,7 +62,7 @@ coordinator 接到任务后，在主时间线发一条派发摘要（派给谁�
 
 截图里 alex 只发了一句 `@wf_coordinator 咋样了？`，coordinator 给出结构化状态：谁接了单、任务 active 的起始时间、分支上有没有新提交、接下来走什么流程，并承诺主动更新。
 
-主动汇报目前是 **workflow skill 约定，不是 transport 保证**。Agent 忙碌、push relay 未推进、会话中断，或 `post()` 没带 `reply_to` 时，都可能没有更新或掉回主时间线。人仍应使用 `/status`、Project Board、dashboard task/heartbeat 与 Git 状态作为兜底。
+回复落在正确 Thread 是 transport 保证（见上节）；但**主动汇报的节奏**仍是 workflow skill 约定——Agent 忙于长任务时可能长时间不更新。人仍应使用 `/status`、Project Board、dashboard task/heartbeat 与 Git 状态作为兜底。
 
 ## Thread 连续性实际如何工作
 


### PR DESCRIPTION
## Summary

Upstream agent-chat is now **HAFleet**, and the thread-session runner mode (one isolated session per Matrix thread, one-shot runners, no resident tmux) has merged (hagency-org/HAFleet#39) and passed live acceptance. Part 2 of the book still taught the retired tmux architecture — following it verbatim would fail (the `bin/agentchat` CLI no longer exists upstream). This PR updates both language editions (`zh` + `en`, 4 chapters each):

- **threads** — delivery diagram redrawn around per-thread sessions and one-shot runners; new section on the session model (context isolation / disposable processes / parallelism / transport-guaranteed reply targeting / shared identity); new section on operator `/thread model|mode` directives including the strict-format and framework-compatibility caveats; corrects the outdated "not a transport guarantee" disclaimer.
- **deploy-local** — `hafleet` CLI + `HAFLEET_*` env names, new clone URL, tmux removed from prerequisites, one-command supervisor launch, the `HAFLEET_THREAD_SESSIONS`/`HAFLEET_ROUTER_TASK_CUTOVER` flags, and the three real-world upgrade traps (bridge bot missing from `MATRIX_TRUSTED_INVITER_MXIDS`, `HAFLEET_RUNTIME_DIR`, `HAFLEET_HOMEDIR`) with matching troubleshooting rows.
- **operations** — layered checklist now follows the dispatch state machine (queued→started→completed / outcome_unknown with operator adjudication); tmux-based criteria removed; `com.hafleet.*` msgtypes.
- **deploy-cloud** — `HAFLEET_WEB_URL` rename.

## Verification

- `bash book/build.sh` builds both editions cleanly
- Every documented step and failure symptom was hit and verified on the live local deployment during the thread-session canary (2026-08-14/15) — including all three deployment traps and the outcome_unknown recovery flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)