### PR TITLE
fix(build): resolve system font symlinks on non-Debian Linux; absolute link targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -150,42 +150,212 @@ fn link_system_cjk_font(target_os: &str) {
     // SFNS.ttf is San Francisco, the macOS UI face. Single-face (so makepad's
     // hardcoded face index 0 is right) and variable, so one file serves both
     // regular and bold via the `wght` axis.
-    let cjk_candidates: &[&str] = match target_os {
-        "macos" => &[
-            MACOS_PINGFANG,
-            "/System/Library/Fonts/Hiragino Sans GB.ttc",
-            "/System/Library/Fonts/STHeiti Light.ttc",
-        ],
-        "windows" => &["C:/Windows/Fonts/msyh.ttc", "C:/Windows/Fonts/simhei.ttf"],
-        _ => &[
-            "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-            "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
-        ],
-    };
-    let latin_candidates: &[&str] = match target_os {
-        "macos" => &["/System/Library/Fonts/SFNS.ttf", "/System/Library/Fonts/HelveticaNeue.ttc"],
-        "windows" => &["C:/Windows/Fonts/segoeui.ttf", "C:/Windows/Fonts/arial.ttf"],
-        _ => &[
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
-        ],
-    };
+    //
+    // On Linux, font layout under /usr/share/fonts is distro-specific
+    // (Debian: `truetype/<pkg>/`, `opentype/<pkg>/`; Arch: `<pkg>/` or `TTF/`;
+    // Fedora: `<pkg>/`; NixOS: elsewhere entirely), so hardcoded paths alone
+    // are only ever right on one family of distros. Ask fontconfig first —
+    // it is the one thing every desktop Linux agrees on — and keep the
+    // hardcoded paths as a second line for machines without `fc-match`.
+    let mut cjk_candidates: Vec<String> = Vec::new();
+    let mut latin_candidates: Vec<String> = Vec::new();
+    match target_os {
+        "macos" => {
+            cjk_candidates.extend(
+                [
+                    MACOS_PINGFANG,
+                    "/System/Library/Fonts/Hiragino Sans GB.ttc",
+                    "/System/Library/Fonts/STHeiti Light.ttc",
+                ]
+                .map(String::from),
+            );
+            latin_candidates.extend(
+                ["/System/Library/Fonts/SFNS.ttf", "/System/Library/Fonts/HelveticaNeue.ttc"]
+                    .map(String::from),
+            );
+        }
+        "windows" => {
+            cjk_candidates
+                .extend(["C:/Windows/Fonts/msyh.ttc", "C:/Windows/Fonts/simhei.ttf"].map(String::from));
+            latin_candidates
+                .extend(["C:/Windows/Fonts/segoeui.ttf", "C:/Windows/Fonts/arial.ttf"].map(String::from));
+        }
+        // Only the host's own desktop Linux may borrow host fonts. build.rs
+        // runs on the host but `target_os` is the *target*: for android /
+        // ios / ohos cross-builds (CI does Android on Ubuntu) a fontconfig
+        // query here would write the host's font path into the symlink and
+        // either ship a host font in the package or ship a dangling link.
+        // Those targets get an empty candidate list and always take the
+        // bundled fallback.
+        "linux" => {
+            cjk_candidates.extend(fc_match(&["sans-serif:lang=zh-cn", "sans-serif:lang=zh"], Some("zh-cn")));
+            cjk_candidates.extend(
+                [
+                    // Debian / Ubuntu
+                    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+                    "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
+                    // Arch (noto-fonts-cjk, wqy-microhei)
+                    "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+                    "/usr/share/fonts/wenquanyi/wqy-microhei/wqy-microhei.ttc",
+                    // Fedora (google-noto-sans-cjk-fonts)
+                    "/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",
+                    "/usr/share/fonts/google-noto-sans-cjk-fonts/NotoSansCJK-Regular.ttc",
+                ]
+                .map(String::from),
+            );
+            latin_candidates.extend(fc_match(&["sans-serif:lang=en", "sans-serif"], Some("en")));
+            latin_candidates.extend(
+                [
+                    // Debian / Ubuntu
+                    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+                    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+                    "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+                    // Arch (ttf-dejavu, ttf-liberation, noto-fonts)
+                    "/usr/share/fonts/TTF/DejaVuSans.ttf",
+                    "/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+                    "/usr/share/fonts/noto/NotoSans-Regular.ttf",
+                    // Fedora
+                    "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf",
+                    "/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf",
+                    "/usr/share/fonts/google-noto/NotoSans-Regular.ttf",
+                ]
+                .map(String::from),
+            );
+        }
+        _ => {}
+    }
 
     // Makepad's CoreText fallback makes hvgl-only fonts renderable, but only
     // on macOS builds.
     let allow_hvgl = target_os == "macos";
     link_font(
         "resources/fonts/system_cjk.ttc",
-        cjk_candidates,
+        &cjk_candidates,
         "resources/fonts/LXGWWenKaiRegular.ttf",
         allow_hvgl,
     );
     link_font(
         "resources/fonts/system_latin.ttf",
-        latin_candidates,
+        &latin_candidates,
         "resources/fonts/LiberationMono-Regular.ttf",
         allow_hvgl,
     );
+}
+
+/// Ask fontconfig which file it would use for each `pattern`, in order,
+/// then — if `required_lang` is set — every installed font that actually
+/// covers that language (`fc-list :lang=<x>`), best-looking first.
+///
+/// `fc-match` treats `:lang=` as a preference, not a constraint: a user
+/// fontconfig that pins `sans-serif` to one family (Omarchy binds it to
+/// Liberation Sans) makes it return that family for `sans-serif:lang=zh-cn`
+/// too, even though it has no CJK glyphs. So each `fc-match` answer is
+/// checked against its own `%{lang}` coverage and dropped if it lacks
+/// `required_lang`; the `fc-list` sweep then finds a real match by coverage.
+///
+/// Returns whatever resolved (deduplicated, possibly empty) — fontconfig
+/// missing or failing is normal on minimal systems and simply yields nothing,
+/// leaving the hardcoded candidates to try. Only sfnt-looking files are kept
+/// (bitmap / Type1 fonts are useless to makepad); `outline_format_supported`
+/// filters the rest downstream.
+fn fc_match(patterns: &[&str], required_lang: Option<&str>) -> Vec<String> {
+    use std::process::Command;
+
+    fn is_sfnt(file: &str) -> bool {
+        let lower = file.to_ascii_lowercase();
+        lower.ends_with(".ttf") || lower.ends_with(".ttc") || lower.ends_with(".otf")
+    }
+    fn covers(lang_list: &str, lang: Option<&str>) -> bool {
+        match lang {
+            None => true,
+            Some(lang) => lang_list.split('|').any(|l| l.trim().eq_ignore_ascii_case(lang)),
+        }
+    }
+    fn push(out: &mut Vec<String>, file: &str) {
+        if !file.is_empty() && is_sfnt(file) && !out.iter().any(|f| f == file) {
+            out.push(file.to_string());
+        }
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for pattern in patterns {
+        let Ok(output) = Command::new("fc-match")
+            .args(["-f", "%{file}\t%{lang}", pattern])
+            .output()
+        else {
+            return out; // fc-match not installed; fontconfig is unavailable
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut parts = text.trim().splitn(2, '\t');
+        let file = parts.next().unwrap_or("").trim();
+        let langs = parts.next().unwrap_or("");
+        if covers(langs, required_lang) {
+            push(&mut out, file);
+        }
+    }
+
+    // Coverage sweep: every font that really has glyphs for the language.
+    // Prefer well-known UI sans faces in a Regular weight; makepad only
+    // reads face 0 of a collection and has no synthetic bold, so a face that
+    // is Light/Bold-only would render every label in that weight.
+    if let Some(lang) = required_lang {
+        if let Ok(output) = Command::new("fc-list")
+            .args(["-f", "%{file}\t%{family}\t%{style}\n", &format!(":lang={lang}")])
+            .output()
+        {
+            if output.status.success() {
+                let text = String::from_utf8_lossy(&output.stdout);
+                let mut scored: Vec<(u32, String)> = Vec::new();
+                for line in text.lines() {
+                    let mut cols = line.split('\t');
+                    let file = cols.next().unwrap_or("").trim();
+                    let family = cols.next().unwrap_or("").to_ascii_lowercase();
+                    let style = cols.next().unwrap_or("").to_ascii_lowercase();
+                    if !is_sfnt(file) {
+                        continue;
+                    }
+                    let styles: Vec<&str> = style.split(',').map(str::trim).collect();
+                    // "Regular" alone, not "Medium,Regular" (fontconfig's alias
+                    // for a weight's un-styled name).
+                    let regular = styles.contains(&"regular") && styles.len() == 1
+                        || styles == ["regular", "regular"];
+                    if !regular {
+                        continue;
+                    }
+                    let mut score = 0u32;
+                    if family.contains("serif") && !family.contains("sans") {
+                        continue; // serif faces are not a UI font
+                    }
+                    if family.contains("mono") {
+                        continue;
+                    }
+                    if family.contains("noto sans cjk") || family.contains("source han sans") {
+                        score += 30;
+                    }
+                    if family.contains("noto sans") || family.contains("dejavu sans")
+                        || family.contains("liberation sans") || family.contains("wenquanyi")
+                        || family.contains("wqy")
+                    {
+                        score += 20;
+                    }
+                    if family.contains(" sc") || family.contains("simplified") {
+                        score += 5;
+                    }
+                    if !scored.iter().any(|(_, f)| f == file) {
+                        scored.push((score, file.to_string()));
+                    }
+                }
+                scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+                for (_, file) in scored {
+                    push(&mut out, &file);
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Point `link` at the first usable `candidates` entry, else at `fallback`.
@@ -201,29 +371,45 @@ fn link_system_cjk_font(target_os: &str) {
 /// disk, so nothing here redistributes a system font. The link always resolves
 /// to *something*, because the DSL references it unconditionally and makepad
 /// panics on a font face it cannot load.
-fn link_font(link: &str, candidates: &[&str], fallback: &str, allow_hvgl: bool) {
-    use std::path::Path;
+///
+/// The link target is always made absolute. A symlink's target is resolved
+/// relative to the *link's own directory*, so writing the crate-relative
+/// `resources/fonts/X.ttf` verbatim would produce a link that resolves to
+/// `resources/fonts/resources/fonts/X.ttf` — a dangling link, and a blank UI.
+fn link_font(link: &str, candidates: &[String], fallback: &str, allow_hvgl: bool) {
+    use std::path::{Path, PathBuf};
 
-    let link = Path::new(link);
+    let manifest_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into()));
+    let absolute = |p: &Path| -> PathBuf {
+        let p = if p.is_absolute() { p.to_path_buf() } else { manifest_dir.join(p) };
+        // Canonicalize when possible so `read_link == target` below stays
+        // stable across builds; keep the joined path if the file is missing.
+        std::fs::canonicalize(&p).unwrap_or(p)
+    };
+
+    // The link itself must NOT be canonicalized: that follows an existing
+    // symlink and would make `link` the system font path itself.
+    let link = manifest_dir.join(link);
     let target = candidates
         .iter()
-        .map(Path::new)
-        .find(|p| p.exists() && outline_format_supported(p, allow_hvgl))
-        .unwrap_or_else(|| Path::new(fallback));
+        .map(|c| absolute(Path::new(c)))
+        .find(|p| p.is_file() && outline_format_supported(p, allow_hvgl))
+        .unwrap_or_else(|| absolute(Path::new(fallback)));
 
-    if !target.exists() {
+    if !target.is_file() {
         println!("cargo:warning={} not linked: no font found", link.display());
         return;
     }
-    if std::fs::read_link(link).ok().as_deref() == Some(target) {
+    if std::fs::read_link(&link).ok().as_deref() == Some(target.as_path()) {
         return;
     }
-    let _ = std::fs::remove_file(link);
+    let _ = std::fs::remove_file(&link);
 
     #[cfg(unix)]
-    let linked = std::os::unix::fs::symlink(target, link);
+    let linked = std::os::unix::fs::symlink(&target, &link);
     #[cfg(not(unix))]
-    let linked = std::fs::copy(target, link).map(|_| ());
+    let linked = std::fs::copy(&target, &link).map(|_| ());
 
     match linked {
         Ok(()) => println!("cargo:warning=font: {} -> {}", link.display(), target.display()),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,4 +14,4 @@
 # actions-rust-lang/setup-rust-toolchain@v1, which reads this file.
 
 [toolchain]
-channel = "1.94.0"
+channel = "1.97.1"

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -598,28 +598,69 @@ mod cjk_font_tests {
     /// LXGWWenKai everywhere else.
     const CJK_FONT: &str = "resources/fonts/system_cjk.ttc";
 
+    /// Same for the Latin UI face (`system_latin.ttf`).
+    const LATIN_FONT: &str = "resources/fonts/system_latin.ttf";
+
+    /// `path` must exist (following symlinks) and start with a font magic
+    /// `ttf_parser::Face::parse` accepts: a collection (`ttcf`), TrueType
+    /// outlines (0x00010000), or CFF (`OTTO`).
+    fn assert_is_real_font(path: &str) {
+        let p = Path::new(path);
+        assert!(
+            p.exists(),
+            "{path} missing or dangling — build.rs should have linked it; the DSL \
+             references this path and font loading would panic",
+        );
+        let data = std::fs::read(p).expect("font should be readable");
+        assert!(data.len() > 4, "{path} is empty");
+        let magic = &data[..4];
+        assert!(
+            magic == b"ttcf" || magic == b"OTTO" || magic == [0x00, 0x01, 0x00, 0x00],
+            "unrecognised font magic {magic:?} at {path}",
+        );
+    }
+
     /// Font loading in makepad is lazy and panics on a bad face
     /// (`.expect("font face should load")`), so a broken link would not
     /// surface until the first Chinese glyph is drawn — potentially in front
     /// of a user. Check the wiring here instead.
     #[test]
     fn cjk_font_link_resolves_to_a_real_font() {
-        let path = Path::new(CJK_FONT);
-        assert!(
-            path.exists(),
-            "{CJK_FONT} missing — build.rs should have linked it; the DSL \
-             references this path and font loading would panic",
-        );
+        assert_is_real_font(CJK_FONT);
+    }
 
-        let data = std::fs::read(path).expect("CJK font should be readable");
-        assert!(data.len() > 4, "font file is empty");
-        // A collection (`ttcf`), TrueType outlines (0x00010000), or CFF
-        // (`OTTO`) — all of which `ttf_parser::Face::parse` accepts.
-        let magic = &data[..4];
-        assert!(
-            magic == b"ttcf" || magic == b"OTTO" || magic == [0x00, 0x01, 0x00, 0x00],
-            "unrecognised font magic {magic:?} at {CJK_FONT}",
-        );
+    /// The Latin face is used by every label, so a dangling link here is a
+    /// fully blank UI (seen on Arch/Omarchy: build.rs once wrote a
+    /// crate-relative fallback path into the symlink, which then resolved
+    /// relative to `resources/fonts/` and pointed nowhere).
+    #[test]
+    fn latin_font_link_resolves_to_a_real_font() {
+        assert_is_real_font(LATIN_FONT);
+    }
+
+    /// On unix these are symlinks, and their targets must be absolute: a
+    /// relative target is resolved against the link's *own* directory, so
+    /// `resources/fonts/X.ttf` would silently become
+    /// `resources/fonts/resources/fonts/X.ttf`. This is exactly the bug that
+    /// blanked the UI on distros whose system-font paths didn't match the
+    /// hardcoded candidates.
+    #[cfg(unix)]
+    #[test]
+    fn font_symlink_targets_are_absolute() {
+        for link in [CJK_FONT, LATIN_FONT] {
+            let target = std::fs::read_link(link)
+                .unwrap_or_else(|e| panic!("{link} should be a symlink: {e}"));
+            assert!(
+                target.is_absolute(),
+                "{link} -> {} : symlink target must be absolute",
+                target.display(),
+            );
+            assert!(
+                target.is_file(),
+                "{link} -> {} : symlink target does not exist",
+                target.display(),
+            );
+        }
     }
 
     /// On macOS the whole point is that this resolves to a *system* Chinese


### PR DESCRIPTION
## Problem

Since #298, `build.rs` links `resources/fonts/system_latin.ttf` / `system_cjk.ttc` to a system font, falling back to the bundled faces. On Arch/Omarchy (and Fedora, NixOS, any Linux without the Debian `/usr/share/fonts/{truetype,opentype}/…` layout) both candidate lists miss, and the fallback was written into the symlink as the crate-relative path `resources/fonts/X.ttf`. A symlink resolves its target against its **own directory**, so the link pointed at `resources/fonts/resources/fonts/X.ttf` — dangling. Makepad then logged `Failed to load resource: resources/fonts/system_latin.ttf` / `system_cjk.ttc` and the window rendered completely blank.

Before (Omarchy):
```
system_cjk.ttc   -> resources/fonts/LXGWWenKaiRegular.ttf     (dangling)
system_latin.ttf -> resources/fonts/LiberationMono-Regular.ttf (dangling)
```
After:
```
system_cjk.ttc   -> /usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc
system_latin.ttf -> /usr/share/fonts/liberation/LiberationSans-Regular.ttf
```

## Fix (`build.rs`)

- **Absolute link targets.** Every candidate and the fallback are made absolute (`CARGO_MANIFEST_DIR` + `canonicalize`) before symlinking, so the fallback can never dangle again on any distro. The link path itself is deliberately *not* canonicalized (that would follow an existing link).
- **fontconfig-first on Linux.** `fc-match` is queried first, but its answer is validated against the font's own `%{lang}` coverage — `:lang=` is only a preference, and Omarchy's fontconfig pins `sans-serif` to Liberation Sans, which has no CJK glyphs. If that fails, an `fc-list :lang=zh-cn` coverage sweep picks a Regular-weight Sans face (Noto Sans CJK / Source Han Sans preferred). Debian/Arch/Fedora hardcoded paths remain as a second line.
- **Host fonts only for `target_os == "linux"`.** `build.rs` runs on the host but `target_os` is the target; android/ios/ohos cross-builds (CI builds Android on Ubuntu) now always take the bundled fallback instead of linking a host font into the package. (This hazard predates this PR — #298 also used `_ =>`.)

## Tests (`src/shared/styles.rs`)

- `latin_font_link_resolves_to_a_real_font` (new) — `system_latin.ttf` had no coverage.
- `font_symlink_targets_are_absolute` (new, unix) — both link targets must be absolute and exist.
- Existing CJK test refactored to share the helper. All three failed on Arch before this fix.

Also bumps `rust-toolchain.toml` to 1.97.1.

## Verification

- `cargo test --lib cjk_font_tests` → 3 passed
- `cargo run` on Omarchy (Arch, Hyprland/Wayland): both `Failed to load resource: resources/fonts/system_*` log lines gone; UI renders normally (room list, CJK text, icons).
- No makepad changes required — makepad only loads the file the DSL names; locating system fonts is entirely `build.rs`.

Not addressed here (separate task): on mobile targets the bundled fallback is copied into the package under both names, duplicating ~19MB of LXGWWenKai — a pre-existing tradeoff of the #298 approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
