### PR TITLE
fix(build): keep bundled fallback out of cargo-makepad's fonts/ dir; assert APK font manifest in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -284,6 +284,41 @@ jobs:
           --config profile.dev.strip=true \
           --config profile.dev.debug-assertions=false
 
+      # Guard against #303: packagers copy resources/ by value, so the APK must
+      # contain exactly one copy of the bundled OFL CJK font (as system_cjk.ttc)
+      # and never a host system font. Fails the job if the manifest drifts.
+      - name: Check APK ships only bundled fonts
+        run: |
+          set -euo pipefail
+          apk=$(ls target/makepad-android-apk/robrix/apk/*.apk | grep -v unaligned | head -1)
+          echo "APK: $apk ($(stat -c %s "$apk") bytes)"
+          echo "--- font entries ---"
+          unzip -l "$apk" | grep -E 'assets/makepad/robrix/(resources/fonts|fonts)/' | tee fonts.txt
+          fail=0
+          # The bundled CJK fallback must not ship under its own name (it lives
+          # in bundled_fonts/, outside resources/), only as system_cjk.ttc.
+          if grep -q 'LXGWWenKaiRegular.ttf' fonts.txt; then echo "::error::LXGWWenKaiRegular.ttf shipped under its own name (duplicate)"; fail=1; fi
+          # No host system fonts, ever.
+          if grep -qiE 'PingFang|Hiragino|STHeiti|SFNS|HelveticaNeue|msyh|simhei|segoeui|arial|NotoSansCJK|DejaVu|LiberationSans' fonts.txt; then echo "::error::host system font found in APK"; fail=1; fi
+          # system_cjk.ttc must be byte-identical to the bundled LXGWWenKai,
+          # system_latin.ttf to the bundled LiberationMono.
+          mkdir -p apk_fonts && unzip -o -q "$apk" 'assets/makepad/robrix/resources/fonts/system_*' -d apk_fonts
+          for pair in "system_cjk.ttc:bundled_fonts/LXGWWenKaiRegular.ttf" "system_latin.ttf:resources/fonts/LiberationMono-Regular.ttf"; do
+            name=${pair%%:*}; src=${pair#*:}
+            got=$(sha256sum "apk_fonts/assets/makepad/robrix/resources/fonts/$name" | cut -d' ' -f1)
+            want=$(sha256sum "$src" | cut -d' ' -f1)
+            if [ "$got" = "$want" ]; then echo "OK  $name == $src"; else echo "::error::$name differs from $src"; fail=1; fi
+          done
+          exit $fail
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: robrix-android-debug-apk
+          path: target/makepad-android-apk/robrix/apk/*.apk
+          retention-days: 7
+          if-no-files-found: error
+
   build_android_on_windows:
     name: Build Android (Windows Host)
     runs-on: windows-2022

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -290,7 +290,10 @@ jobs:
       - name: Check APK ships only bundled fonts
         run: |
           set -euo pipefail
-          apk=$(ls target/makepad-android-apk/robrix/apk/*.apk | grep -v unaligned | head -1)
+          # cargo-makepad writes to <target>/android/makepad-android-apk/<crate>/apk/
+          # (or <CARGO_TARGET_DIR>/makepad-android-apk/... when that var is set).
+          apk=$(find target -path '*/makepad-android-apk/robrix/apk/*.apk' ! -name '*.unaligned.apk' | head -1)
+          [ -n "$apk" ] || { echo "::error::no APK found under target/"; find target -name '*.apk' -maxdepth 6; exit 1; }
           echo "APK: $apk ($(stat -c %s "$apk") bytes)"
           echo "--- font entries ---"
           unzip -l "$apk" | grep -E 'assets/makepad/robrix/(resources/fonts|fonts)/' | tee fonts.txt
@@ -315,7 +318,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: robrix-android-debug-apk
-          path: target/makepad-android-apk/robrix/apk/*.apk
+          path: target/**/makepad-android-apk/robrix/apk/*.apk
           retention-days: 7
           if-no-files-found: error
 

--- a/build.rs
+++ b/build.rs
@@ -153,12 +153,15 @@ const BUNDLED_FONTS_ENV: &str = "ROBRIX_BUNDLED_FONTS";
 /// faces, so a distributable ships exactly one copy of each and nothing
 /// proprietary. `cargo run` from a checkout keeps using the system fonts.
 ///
-/// The bundled CJK fallback lives in `fonts/bundled/`, *outside* `resources/`,
+/// The bundled CJK fallback lives in `bundled_fonts/`, *outside* `resources/`,
 /// precisely so that packagers do not ship it a second time under its own
-/// name next to the materialised `system_cjk.ttc`.
+/// name next to the materialised `system_cjk.ttc`. The directory is
+/// deliberately not called `fonts/`: cargo-makepad also packages a crate's
+/// top-level `fonts/` dir (`add_font_assets_dir_to_apk` / apple
+/// `add_font_assets_dir`), which would reintroduce the duplicate.
 fn link_system_cjk_font(target_os: &str) {
     println!("cargo:rerun-if-changed=resources/fonts");
-    println!("cargo:rerun-if-changed=fonts/bundled");
+    println!("cargo:rerun-if-changed=bundled_fonts");
     println!("cargo:rerun-if-env-changed={BUNDLED_FONTS_ENV}");
 
     let bundled_only = std::env::var_os(BUNDLED_FONTS_ENV)
@@ -265,7 +268,7 @@ fn link_system_cjk_font(target_os: &str) {
     link_font(
         "resources/fonts/system_cjk.ttc",
         &cjk_candidates,
-        "fonts/bundled/LXGWWenKaiRegular.ttf",
+        "bundled_fonts/LXGWWenKaiRegular.ttf",
         allow_hvgl,
     );
     link_font(

--- a/docs/ux-audit-and-performance-2026-08.md
+++ b/docs/ux-audit-and-performance-2026-08.md
@@ -189,7 +189,7 @@ makepad panics on a font face it cannot load.
 `resources/` by value, dereferencing these links, so they must be built with
 `ROBRIX_BUNDLED_FONTS=1`: host fonts are then never considered and both links
 resolve to the bundled OFL faces (LiberationMono, and LXGWWenKai from
-`fonts/bundled/` — kept outside `resources/` so it is not shipped twice).
+`bundled_fonts/` — kept outside `resources/` so it is not shipped twice).
 CI and `packaging/build-macos-dmg.sh` set it. See issue #303.
 
 **`styles.rs`** declares `APP_FONT_REGULAR` / `APP_FONT_BOLD`;

--- a/issues/012-packaged-builds-redistribute-system-fonts-and-duplicate-lxgw.md
+++ b/issues/012-packaged-builds-redistribute-system-fonts-and-duplicate-lxgw.md
@@ -63,7 +63,7 @@ packager copies that tree by value. Symlinks are an adequate mechanism for
 ## Implemented resolution (no makepad change)
 
 1. **The bundled CJK fallback was moved out of `resources/`** to
-   `fonts/bundled/LXGWWenKaiRegular.ttf`, and `build.rs` now points its fallback
+   `bundled_fonts/LXGWWenKaiRegular.ttf`, and `build.rs` now points its fallback
    there. Only the resolved `system_cjk.ttc` is packaged → fixes B
    (38 MB → 19 MB). The new directory is covered by `cargo:rerun-if-changed`.
    `LiberationMono-Regular.ttf` stays.

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -596,10 +596,10 @@ mod cjk_font_tests {
     /// The single path the DSL's `chinese` font members point at. `build.rs`
     /// links it to a system CJK font where one is found (PingFang on macOS,
     /// YaHei on Windows, fontconfig's answer on Linux), or to the bundled
-    /// LXGWWenKai in `fonts/bundled/` otherwise — and always to the bundled
+    /// LXGWWenKai in `bundled_fonts/` otherwise — and always to the bundled
     /// face when `ROBRIX_BUNDLED_FONTS=1` was set at build time.
     const CJK_FONT: &str = "resources/fonts/system_cjk.ttc";
-    const CJK_BUNDLED: &str = "fonts/bundled/LXGWWenKaiRegular.ttf";
+    const CJK_BUNDLED: &str = "bundled_fonts/LXGWWenKaiRegular.ttf";
     const LATIN_BUNDLED: &str = "resources/fonts/LiberationMono-Regular.ttf";
 
     /// Same for the Latin UI face (`system_latin.ttf`).


### PR DESCRIPTION
Follow-up to #304 (merged) / #303.

## Problem

#304 moved the bundled CJK fallback to `fonts/bundled/LXGWWenKaiRegular.ttf` so packagers would ship it only once, as the materialised `system_cjk.ttc`. But cargo-makepad **also packages a crate's top-level `fonts/` directory** — Android `add_font_assets_dir_to_apk` and Apple `add_font_assets_dir` (`tools/cargo_makepad/src/android/compile.rs:1683`, `apple/compile.rs:1097`), recursively, skipping a file only when `resources/<same relative path>` exists. So with #304 as merged, every APK/IPA gets `assets/makepad/robrix/fonts/bundled/LXGWWenKaiRegular.ttf` **plus** `resources/fonts/system_cjk.ttc` — the very 19 MB duplicate #304 set out to remove, just at a different path. My pre-merge emulation only enumerated `resources/`, so it missed this.

## Fix

- Rename the directory to **`bundled_fonts/`**, which no packager touches (`build.rs` docs now say why it must not be called `fonts/`); update `build.rs` fallback path + `rerun-if-changed`, tests, docs, issue note.
- **CI guard** on the Linux-host Android job (`builds.yml`): after the build, list the APK's font entries and **fail** if `LXGWWenKaiRegular.ttf` ships under its own name, if any host system font name appears (PingFang / Hiragino / SFNS / msyh / segoeui / NotoSansCJK / DejaVu / LiberationSans …), or if `system_cjk.ttc` / `system_latin.ttf` are not byte-identical (sha256) to `bundled_fonts/LXGWWenKaiRegular.ttf` / `resources/fonts/LiberationMono-Regular.ttf`. Upload the APK as an artifact (7 days) for manual inspection. This is the real-artifact check #304's description deferred to CI.

## Verification (local, Arch)

- `ROBRIX_BUNDLED_FONTS=1 cargo build` → `system_cjk.ttc → <repo>/bundled_fonts/LXGWWenKaiRegular.ttf`, `system_latin.ttf → LiberationMono`; `cjk_font_tests` 4/4
- normal `cargo build` → system fonts restored; 4/4
- Packager view (`resources/` deref + no `fonts/` dir): LXGW appears exactly once (19,073,964 B) as `system_cjk.ttc`
- The APK assertion step runs on this PR — see the "Check APK ships only bundled fonts" step of *Build Android (Linux Host)*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
