### PR TITLE
docs(specs): make legacy specs parse under agent-spec 1.4.0

### DIFF
--- a/specs/task-dm-routing-membership-filter.spec.md
+++ b/specs/task-dm-routing-membership-filter.spec.md
@@ -1,4 +1,3 @@
----
 spec: task
 name: "DM Reopen After Leave — Hide Stale Empty DMs And Reuse Only Active Candidates"
 inherits: project

--- a/specs/task-mention-list-scrolling.spec.md
+++ b/specs/task-mention-list-scrolling.spec.md
@@ -9,7 +9,6 @@ estimate: 1d
 
 Make the @mention autocomplete popup's user list scrollable so that users can browse all matching members instead of being limited to a hardcoded maximum (10 on desktop, 5 on mobile). In rooms with many members, the current truncation silently hides relevant results. A scrollable list with a fixed maximum height improves discoverability while keeping the popup compact.
 
-## Context
 
 The current `List` widget (in `command_text_input.rs`) is a plain `View` with `flow: Down` — it has no scroll capability. The popup uses `height: Fit` which means it grows unbounded. To prevent this, `DESKTOP_MAX_VISIBLE_ITEMS = 10` and `MOBILE_MAX_VISIBLE_ITEMS = 5` artificially cap the displayed items. The search buffer fetches `max_visible_items * 2` results but only the first half are shown.
 

--- a/specs/task-realtime-translation.spec.md
+++ b/specs/task-realtime-translation.spec.md
@@ -9,7 +9,6 @@ estimate: 2d
 
 Add a real-time translation feature to the chat message input bar. Users can toggle "write-and-translate" mode, select a target language, type in their native language, and see the translation appear in a preview area above the input. Clicking "Apply" replaces the input text with the translation, ready to send.
 
-## Context
 
 The translation feature uses any OpenAI-compatible LLM API (local or cloud) to translate text in real-time as the user types. The system prompt is adapted from the makepad-voice-input (Vox) project's bilingual correction+translation prompt.
 
@@ -83,7 +82,7 @@ The translation feature uses any OpenAI-compatible LLM API (local or cloud) to t
 - Do NOT store translation state in Matrix room events
 - Do NOT run `cargo fmt`
 
-## Supported Languages
+**Supported Languages**
 
 | Code | Name |
 |------|------|
@@ -105,7 +104,7 @@ The translation feature uses any OpenAI-compatible LLM API (local or cloud) to t
 | ms | Bahasa Melayu |
 | tr | Türkçe |
 
-## Known Issues
+**Known Issues**
 
 - Language selector popup positioning uses `abs_pos` in `draw_walk` — position is calculated from button rect, may shift if input bar layout changes
 - Settings → Preferences language dropdown has arrow visual artifact (see issues/002)


### PR DESCRIPTION
## Summary

The agent-spec 1.4.0 "enforcement" release rejects formatting that 1.2.0 tolerated. Three legacy specs failed to parse; this makes all 42 specs parse clean under 1.4.0. Formatting only, no semantic changes.

- `task-dm-routing-membership-filter`: front-matter was wrapped in YAML `---` fences; unwrapped to the bare form the parser expects (8 scenarios now recognized).
- `task-mention-list-scrolling`: dropped the illegal top-level `## Context` header; its paragraphs merge into Intent (5 scenarios recognized).
- `task-realtime-translation`: dropped `## Context` (into Intent), demoted `## Supported Languages` / `## Known Issues` to bold text. Note: this completed legacy spec's `- **Given**` bullet scenarios are not extracted by 1.4.0 (0 scenarios); rewrite to bare DSL if the task is ever reactivated.

## Testing

- `agent-spec parse` passes on all 42 specs under 1.4.0; `task-ruma-lax-syncv5-deser` lint stays at 96%.
- Docs-only change — safe to merge without app testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)