### PR TITLE
fix(space): cycle guards, stable sidebar order, best-effort attach semantics

### DIFF
--- a/docs/superpowers/specs/2026-08-18-space-completion-design.md
+++ b/docs/superpowers/specs/2026-08-18-space-completion-design.md
@@ -1,0 +1,80 @@
+# Matrix Space 补齐设计(切片 B 收尾)
+
+> 状态:已批准(2026-08-18)· 范围:纯 Matrix Space 能力,不含 HAFleet Phase 4 绑定
+> 依据:matrix-project-space-roadmap.md + 2026-08-17 三组并行代码核实(全部判定有 file:line 证据)
+
+## 背景与目标
+
+roadmap(基线 2026-08-06)大半 P0 已被 PR #292 补齐。核实后的真实剩余:3 个代码缺陷、
+4 个功能缺失、space 核心逻辑零测试。本设计以两个 PR 交付:
+
+- **PR-1 `fix/space-tree-hardening`**:缺陷修复 + 首批单测(先行,低风险)
+- **PR-2 `feat/space-usability`**:四项功能补齐
+
+非目标:restricted join rule 配置器(有意设计,留 Phase 4 语境)、拖拽排序、父链显示、
+"已离开空间"完整管理页、ProjectRef 绑定。
+
+## PR-1:修复 + 测试
+
+### 1. 树递归环保护(崩溃级)
+`space_lobby.rs` 的 `build_tree_for_space` / `build_filtered_tree` / `subtree_has_match` /
+`build_tree_for_space_ignoring_expansion` 与 `rooms_list.rs::is_room_indirectly_in_space`
+均为纯递归,`m.space.child` 成环协议合法 → 栈溢出。
+
+- 统一加 `visited: HashSet<OwnedRoomId>`。选 visited 而非深度上限:深度上限误伤合法深树,
+  visited 精确且 O(n)。
+- 树构建核心重构为接收显式输入(children 映射、展开集、过滤词)的自由函数,
+  脱离 Makepad Widget 可单测。service 层任务级防护与未读聚合防环已存在,不动。
+
+### 2. 侧边栏顺序稳定
+`spaces_bar.rs` 增量路径顺序稳定,但 `update_displayed_spaces` 两处(搜索清空、过滤回退)
+从 `HashMap.keys()` 重建 `displayed_spaces`,顺序漂移。
+
+- `all_joined_spaces: HashMap` → `IndexMap`(insertion order;`indexmap` 已是项目依赖,
+  不新增依赖)。重建路径顺序 = 插入序 = 增量路径顺序。
+
+### 3. 挂载部分失败语义
+`attach_room_to_space`:`m.space.child` 成功 + `m.space.parent` 失败 → 整体报"失败"且
+UI 不刷新,与服务端状态不一致。
+
+- 照搬 `detach_room_from_space` 已验证的 best-effort 模式:主写入(`m.space.child`)成功
+  即成功,反向写入失败降级 `warning!`;
+- `SpaceChildAction::Added` 无论成败都触发 `refresh_space_children`,UI 收敛到服务端状态。
+
+### 测试(随 PR-1)
+环(A→B→A)、自环、重复边、深树的树构建;未读聚合环/共享房间(补既有逻辑的缺失覆盖);
+IndexMap 重建顺序 = 插入序。
+
+## PR-2:四项功能
+
+### 4. selected Space 持久化
+`AppState` 增 `selected_space_id: Option<OwnedRoomId>`(`serde(default)` 兼容老状态文件)。
+空间列表异步到达后应用恢复;目标空间已退出/不可见 → 安全回退 Home(沿用 room 恢复的
+待恢复暂存模式)。恢复后 `saved_dock_state_per_space` 既有 dock 布局自然生效。
+
+### 5. Space 深链接
+`interactions.rs` 的 `MatrixId::Room` 分支先查 `client.get_room()` room type:
+已加入 space → `NavigationBarAction::GoToSpace` 进 Space Lobby;本地可知是 space 但未加入
+→ join modal 带 `is_space: true`;**本地完全未知的房间维持现有普通流程**(决策 A:
+不发预览请求探测,保守渐进)。
+
+### 6. banned/left/knocked 反馈
+用现有 `enqueue_popup_notification` 做最小可感知反馈:被 ban / 远程离开时弹通知
+"你已不在空间 X";knocked 维持忽略但注释写明原因。**本轮不做重新加入/取消 knock 入口**
+(决策 B,放下轮)。
+
+### 7. 目录页 Spaces 切换
+`directory_screen.rs` 的 `kind` 参数化;页头加 Rooms/Spaces 切换(现有 toggle 样式 +
+RBX token);空态文案区分;`en.json`/`zh-CN.json` 同步。
+
+## 横切约束
+
+- Matrix 写操作一律 `submit_async_request(MatrixRequest::*)`
+- Makepad 2.0 语法(script_mod! / := / +:);禁 `cargo fmt`;UI 色值走 RBX token
+- 两份 task spec 继承 `specs/project.spec.md`,`agent-spec lint --min-score 0.7`
+- PR 推送后等用户实测,不自动合并
+
+## 验收
+
+单测随 PR-1;人工验收覆盖桌面/移动端、双账号权限、与 Element 交叉验证层级。
+详见 `specs/task-space-tree-hardening.spec.md` 与 `specs/task-space-usability.spec.md`。

--- a/specs/task-space-tree-hardening.spec.md
+++ b/specs/task-space-tree-hardening.spec.md
@@ -1,0 +1,122 @@
+spec: task
+name: "Space tree hardening: cycle guards, stable order, attach semantics"
+inherits: project
+tags: [bugfix, space, hierarchy, testing]
+estimate: 1d
+---
+
+## Intent
+
+修复 2026-08-17 核实确认的三个 Space 缺陷并建立首批 space 核心逻辑单测:space_lobby 树递归无环保护(`m.space.child` 成环协议合法,现状会栈溢出)、spaces_bar 在搜索清空/过滤回退路径从 HashMap 重建导致顺序漂移、attach_room_to_space 部分失败被误报为完全失败且 UI 不刷新。设计依据 docs/superpowers/specs/2026-08-18-space-completion-design.md。
+
+## Decisions
+
+- 环保护用 `visited: HashSet<OwnedRoomId>`,不用深度上限(深度上限误伤合法深树);覆盖 space_lobby.rs 四个递归函数(`build_tree_for_space`、`build_filtered_tree`、`subtree_has_match`、`build_tree_for_space_ignoring_expansion`)与 rooms_list.rs 的 `is_room_indirectly_in_space`
+- 树构建核心重构为接收显式输入(children 映射、展开集、过滤词)的自由函数,脱离 Makepad Widget 可单测
+- spaces_bar 的 `all_joined_spaces` 由 `HashMap` 改为 `indexmap::IndexMap`(insertion order;`indexmap` 已是项目依赖,不新增依赖),重建路径顺序与增量路径一致
+- `attach_room_to_space` 采用与 `detach_room_from_space` 相同的 best-effort 模式:`m.space.child` 写成功即主操作成功,`m.space.parent` 失败降级 `warning!` 日志
+- `SpaceChildAction::Added` 无论成败都触发 `refresh_space_children`,UI 收敛到服务端状态
+- service 层任务级防护(space_room_list_tasks 去重)与未读聚合防环(accumulate_space_unread)已实现且正确,不改动
+
+## Boundaries
+
+### Allowed Changes
+- src/home/space_lobby.rs
+- src/home/spaces_bar.rs
+- src/home/rooms_list.rs
+- src/sliding_sync.rs
+- specs/task-space-tree-hardening.spec.md
+- docs/superpowers/specs/2026-08-18-space-completion-design.md
+
+### Forbidden
+- 不新增 cargo 依赖(IndexMap 用既有 indexmap crate)
+- 不改动 space_service_sync.rs 的既有循环防护与订阅逻辑
+- 不修改 UI 视觉样式与 DSL 模板(本任务纯逻辑层)
+- 不运行 cargo fmt
+
+## Out of Scope
+
+- selected Space 持久化、深链接、banned/left/knocked 反馈、目录页切换(task-space-usability)
+- restricted join rule 配置器、拖拽排序、父链显示
+- detach_room_from_space(已是正确的 best-effort 实现)
+
+## Completion Criteria
+
+### Rule: cycle-safety — 层级成环不崩溃
+
+场景: 双节点环不栈溢出(critical)
+  标签: critical
+  测试: space_tree_cycle_two_nodes_terminates
+  假设 children 映射中 space A 含子 B 且 space B 含子 A,两者均在展开集中
+  当 构建 space A 的树
+  那么 构建在有限步内终止且 B 只作为 A 的子节点出现一次
+
+场景: 自环被忽略
+  测试: space_tree_self_loop_ignored
+  假设 children 映射中 space A 含子 A 自身
+  当 构建 space A 的树
+  那么 构建终止且 A 的子节点中不含 A 自身
+
+场景: 重复边去重
+  测试: space_tree_duplicate_edges_deduplicated
+  假设 children 映射中 space A 含两条指向同一子房间 R 的边
+  当 构建 space A 的树
+  那么 R 在树中仅出现一次
+
+场景: 深层合法树不被误伤
+  测试: space_tree_deep_chain_fully_built
+  假设 children 映射为 50 层无环链式嵌套且全部展开
+  当 构建根 space 的树
+  那么 全部 50 层节点均出现在树中
+
+场景: 过滤匹配在环上终止
+  测试: space_tree_filter_terminates_on_cycle
+  假设 children 映射含 A↔B 环
+  当 以任意过滤词执行子树匹配检查
+  那么 检查在有限步内返回
+
+### Rule: stable-order — 侧边栏顺序稳定
+
+场景: 重建顺序等于插入序(critical)
+  标签: critical
+  测试: spaces_bar_rebuild_preserves_insertion_order
+  假设 依次加入 space C、A、B
+  当 从全量集合重建显示列表(模拟搜索清空路径)
+  那么 显示顺序仍为 C、A、B
+
+场景: 搜索后清空不打乱顺序
+  测试: manual_test_spaces_bar_order_survives_search_clear
+  层级: manual
+  审核: human
+  假设 侧边栏有 5 个以上空间
+  当 在搜索框输入过滤词后再清空
+  那么 空间顺序与搜索前一致
+
+### Rule: attach-semantics — 挂载失败语义与服务端一致
+
+场景: 反向写入失败不否定主写入
+  测试: manual_test_attach_partial_failure_reports_success
+  层级: manual
+  审核: human
+  假设 用户对父 space 有 m.space.child 写权限但对子房间无 m.space.parent 写权限
+  当 把该房间挂载进 space
+  那么 UI 显示挂载成功且该房间出现在 space 层级中
+  但是 日志含 m.space.parent 写入失败的 warning
+
+场景: 挂载后 UI 收敛服务端状态
+  测试: manual_test_attach_always_refreshes_children
+  层级: manual
+  审核: human
+  假设 任一挂载操作完成(成功或失败)
+  当 SpaceChildAction::Added 到达 UI
+  那么 space 子项列表触发 refresh_space_children 重新读取服务端状态
+
+场景: 挂载重试幂等
+  测试: manual_test_attach_retry_idempotent
+  层级: manual
+  审核: human
+  假设 某房间已成功挂载进 space
+  当 对同一房间再次执行挂载
+  那么 不产生重复子项且不报错
+
+<!-- lint-ack: error-path — cycle-safety 全组即异常输入路径(环/自环/重复边为非法或极端层级数据);attach 组含权限不足失败路径 -->

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1632,13 +1632,31 @@ impl RoomsList {
     /// Returns whether the given target room or space is indirectly within the given parent space.
     ///
     /// This will recursively search all nested spaces within the given `parent_space`.
+    ///
+    /// Cycle-safe: `m.space.child` relationships can legally form cycles (the Matrix
+    /// spec does not forbid them), so this guards against infinite recursion via a
+    /// `visited` set of subspace IDs already walked, rather than a depth limit
+    /// (which would incorrectly truncate legitimately deep hierarchies).
     fn is_room_indirectly_in_space(&self, parent_space: &OwnedRoomId, target: &OwnedRoomId) -> bool {
+        let mut visited = HashSet::new();
+        visited.insert(parent_space.clone());
+        self.is_room_indirectly_in_space_inner(parent_space, target, &mut visited)
+    }
+
+    fn is_room_indirectly_in_space_inner(
+        &self,
+        parent_space: &OwnedRoomId,
+        target: &OwnedRoomId,
+        visited: &mut HashSet<OwnedRoomId>,
+    ) -> bool {
         if let Some(smv) = self.space_map.get(parent_space) {
             if smv.direct_child_rooms.contains(target) {
                 return true;
             }
             for subspace in smv.direct_subspaces.iter() {
-                if self.is_room_indirectly_in_space(subspace, target) {
+                if visited.insert(subspace.clone())
+                    && self.is_room_indirectly_in_space_inner(subspace, target, visited)
+                {
                     return true;
                 }
             }

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1647,7 +1647,15 @@ impl Widget for SpaceLobbyScreen {
                         ),
                     };
                     enqueue_popup_notification(message, kind, Some(5.0));
-                    if error.is_none() {
+                    // `Added` always refreshes, even on a reported failure: attaching a
+                    // room is best-effort (the primary `m.space.child` write can succeed
+                    // while the advisory `m.space.parent` backlink write fails and gets
+                    // reported as an `error` here), so the UI must reconcile with
+                    // whatever the server actually ended up with rather than trusting a
+                    // partial-failure error to mean nothing changed. `Removed` keeps the
+                    // original success-only refresh, since it has no such partial-failure
+                    // case (detach is already fully best-effort at the request layer).
+                    if was_added || error.is_none() {
                         // The homeserver's hierarchy view is what the tree renders, so
                         // re-fetch that space's children rather than editing it locally.
                         refresh_space_children(cx, space_id);

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1140,6 +1140,7 @@ impl From<SpaceRoom> for SpaceRoomInfo {
 }
 
 /// An entry in the tree to be displayed.
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 enum TreeEntry {
     /// A regular space or room entry.
@@ -1163,6 +1164,355 @@ enum TreeEntry {
         /// Bitmask of which parent levels need continuation lines.
         parent_mask: u32,
     },
+}
+
+// ---------------------------------------------------------------------------------
+// Pure, `&self`/Widget-free tree-building functions.
+//
+// These are deliberately free functions (not methods on `SpaceLobbyScreen`) that
+// take only explicit inputs (the children cache, expansion/loading sets, filter
+// keywords) so they can be unit-tested directly without any Makepad `Cx`/`Widget`
+// machinery. `SpaceLobbyScreen::rebuild_tree_entries` is a thin wrapper around
+// `build_tree_for_space`/`build_filtered_tree`.
+//
+// Cycle-safety: `m.space.child` relationships are legally allowed to form cycles
+// per the Matrix spec, so every function below guards against infinite recursion
+// (and duplicate/self-referential edges) using a `visited: HashSet<OwnedRoomId>`
+// of room IDs already emitted/walked *anywhere* in the current build, rather than
+// a depth limit — a depth limit would incorrectly truncate legitimately deep (but
+// acyclic) space hierarchies.
+// ---------------------------------------------------------------------------------
+
+/// Returns whether the given [`SpaceRoomInfo`] matches the filter keywords.
+fn matches_filter(info: &SpaceRoomInfo, keywords: &str) -> bool {
+    info.name.to_lowercase().contains(keywords)
+        || info.id.as_str().to_lowercase().contains(keywords)
+        || info.canonical_alias.as_ref()
+            .is_some_and(|a| a.as_str().to_lowercase().contains(keywords))
+        || info.topic.as_ref()
+            .is_some_and(|t| t.to_lowercase().contains(keywords))
+}
+
+/// Recursively build the tree of spaces and their expanded children such that they
+/// can be displayed in the SpaceLobbyScreen's PortalList.
+///
+/// Cycle-safe: see the module-level note above.
+fn build_tree_for_space(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    expanded_spaces: &HashSet<OwnedRoomId>,
+    loading_subspaces: &HashSet<OwnedRoomId>,
+    tree_entries: &mut Vec<TreeEntry>,
+    space_id: &OwnedRoomId,
+    level: usize,
+    parent_mask: u32,
+) {
+    let mut visited = HashSet::new();
+    visited.insert(space_id.clone());
+    build_tree_for_space_inner(
+        children_cache,
+        expanded_spaces,
+        loading_subspaces,
+        tree_entries,
+        space_id,
+        level,
+        parent_mask,
+        &mut visited,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_tree_for_space_inner(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    expanded_spaces: &HashSet<OwnedRoomId>,
+    loading_subspaces: &HashSet<OwnedRoomId>,
+    tree_entries: &mut Vec<TreeEntry>,
+    space_id: &OwnedRoomId,
+    level: usize,
+    parent_mask: u32,
+    visited: &mut HashSet<OwnedRoomId>,
+) {
+    let Some(children) = children_cache.get(space_id) else { return };
+
+    // Preserve the SDK's spec-compliant `m.space.child` ordering: the SDK already
+    // sorts children per the spec's "Ordering of children within a space"
+    // (`m.space.child` `order`, then the child event's timestamp, then room ID).
+    // Re-sorting here would silently discard the ordering a space's admins
+    // deliberately set.
+    let sorted_children: Vec<_> = children.iter().collect();
+    let count = sorted_children.len();
+
+    for (i, child) in sorted_children.into_iter().enumerate() {
+        // Cycle/duplicate-edge guard: skip any room ID we've already emitted
+        // anywhere in this tree (whether reached via a genuine `m.space.child`
+        // cycle, a self-loop, or a duplicate edge within the same parent's list).
+        if !visited.insert(child.room_id.clone()) {
+            continue;
+        }
+
+        let is_last = i == count - 1;
+
+        tree_entries.push(TreeEntry::Item {
+            info: SpaceRoomInfo::from(child),
+            parent_space_id: space_id.clone(),
+            level,
+            is_last,
+            parent_mask,
+        });
+
+        // If this is an expanded space, recursively add its children or a loading indicator
+        if child.is_space() && expanded_spaces.contains(&child.room_id) {
+            // Calculate mask for children:
+            // If we are NOT the last child, our level needs a continuation line for our children.
+            // If we ARE the last child, our level does NOT need a line.
+            // Parent levels are preserved.
+            let child_mask = if is_last {
+                parent_mask
+            } else {
+                parent_mask | (1 << level)
+            };
+
+            if children_cache.contains_key(&child.room_id) {
+                build_tree_for_space_inner(
+                    children_cache,
+                    expanded_spaces,
+                    loading_subspaces,
+                    tree_entries,
+                    &child.room_id,
+                    level + 1,
+                    child_mask,
+                    visited,
+                );
+            } else if loading_subspaces.contains(&child.room_id) {
+                // Show loading indicator
+                tree_entries.push(TreeEntry::Loading {
+                    level: level + 1,
+                    parent_mask: child_mask,
+                });
+            }
+        }
+    }
+}
+
+/// Recursively build a filtered tree that includes only entries matching
+/// the keywords, plus any ancestor spaces needed to preserve the hierarchy.
+///
+/// Returns `true` if any matching entry was added within this subtree.
+///
+/// Cycle-safe: see the module-level note above.
+fn build_filtered_tree(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    tree_entries: &mut Vec<TreeEntry>,
+    space_id: &OwnedRoomId,
+    keywords: &str,
+    level: usize,
+    parent_mask: u32,
+) -> bool {
+    let mut visited = HashSet::new();
+    visited.insert(space_id.clone());
+    build_filtered_tree_inner(children_cache, tree_entries, space_id, keywords, level, parent_mask, &mut visited)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_filtered_tree_inner(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    tree_entries: &mut Vec<TreeEntry>,
+    space_id: &OwnedRoomId,
+    keywords: &str,
+    level: usize,
+    parent_mask: u32,
+    visited: &mut HashSet<OwnedRoomId>,
+) -> bool {
+    let Some(children) = children_cache.get(space_id) else { return false };
+
+    // Sort identically to the unfiltered tree: spaces first, then rooms, both alphabetically.
+    // Keep the order the SpaceRoomList gave us: the SDK already sorts children
+    // per the spec's "Ordering of children within a space" — `m.space.child`
+    // `order`, then the child event's timestamp, then room ID. Re-sorting here
+    // (e.g. spaces-first, alphabetical) would silently discard the ordering a
+    // space's admins deliberately set.
+    let sorted_children: Vec<_> = children.iter().collect();
+
+    // First pass: determine which children have matches (self or descendants)
+    // so we can correctly compute `is_last` for tree line drawing.
+    let matched_indices: Vec<usize> = sorted_children.iter().enumerate().filter_map(|(i, child)| {
+        let info = SpaceRoomInfo::from(*child);
+        let self_matches = matches_filter(&info, keywords);
+        let has_matching_descendants = child.is_space()
+            && children_cache.contains_key(&child.room_id)
+            && subtree_has_match(children_cache, &child.room_id, keywords);
+        if self_matches || has_matching_descendants {
+            Some(i)
+        } else {
+            None
+        }
+    }).collect();
+
+    if matched_indices.is_empty() {
+        return false;
+    }
+
+    // Second pass: emit entries for matched children, preserving hierarchy.
+    for (pos, &child_idx) in matched_indices.iter().enumerate() {
+        let child = sorted_children[child_idx];
+
+        // Cycle/duplicate-edge guard, see `build_tree_for_space_inner`.
+        if !visited.insert(child.room_id.clone()) {
+            continue;
+        }
+
+        let is_last = pos == matched_indices.len() - 1;
+        let info = SpaceRoomInfo::from(child);
+        let self_matches = matches_filter(&info, keywords);
+
+        let child_mask = if is_last {
+            parent_mask
+        } else {
+            parent_mask | (1 << level)
+        };
+
+        if child.is_space() && children_cache.contains_key(&child.room_id) {
+            // For spaces: always include if self matches or descendants match.
+            tree_entries.push(TreeEntry::Item {
+                info,
+                parent_space_id: space_id.clone(),
+                level,
+                is_last,
+                parent_mask,
+            });
+            // Recurse into child space: if the space itself matches,
+            // show ALL of its children (unfiltered); otherwise show only
+            // the matching descendants.
+            if self_matches {
+                // Show all children of a matching space (no further filtering).
+                build_tree_for_space_ignoring_expansion(
+                    children_cache,
+                    tree_entries,
+                    &child.room_id,
+                    level + 1,
+                    child_mask,
+                );
+            } else {
+                // Space doesn't match, but some descendant does — recurse with filter.
+                build_filtered_tree_inner(
+                    children_cache,
+                    tree_entries,
+                    &child.room_id,
+                    keywords,
+                    level + 1,
+                    child_mask,
+                    visited,
+                );
+            }
+        } else if self_matches {
+            // Non-space room or space without cached children: include only if it matches.
+            tree_entries.push(TreeEntry::Item {
+                info,
+                parent_space_id: space_id.clone(),
+                level,
+                is_last,
+                parent_mask,
+            });
+        }
+    }
+
+    true
+}
+
+/// Returns `true` if any entry in the subtree rooted at `space_id` matches the keywords.
+///
+/// Cycle-safe: see the module-level note above.
+fn subtree_has_match(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    space_id: &OwnedRoomId,
+    keywords: &str,
+) -> bool {
+    let mut visited = HashSet::new();
+    visited.insert(space_id.clone());
+    subtree_has_match_inner(children_cache, space_id, keywords, &mut visited)
+}
+
+fn subtree_has_match_inner(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    space_id: &OwnedRoomId,
+    keywords: &str,
+    visited: &mut HashSet<OwnedRoomId>,
+) -> bool {
+    let Some(children) = children_cache.get(space_id) else { return false };
+    for child in children.iter() {
+        let info = SpaceRoomInfo::from(child);
+        if matches_filter(&info, keywords) {
+            return true;
+        }
+        if child.is_space()
+            && visited.insert(child.room_id.clone())
+            && subtree_has_match_inner(children_cache, &child.room_id, keywords, visited)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Like [`build_tree_for_space`] but ignores expansion state — shows all children.
+/// Used to display the full contents of a space that itself matched the filter.
+///
+/// Cycle-safe: see the module-level note above.
+fn build_tree_for_space_ignoring_expansion(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    tree_entries: &mut Vec<TreeEntry>,
+    space_id: &OwnedRoomId,
+    level: usize,
+    parent_mask: u32,
+) {
+    let mut visited = HashSet::new();
+    visited.insert(space_id.clone());
+    build_tree_for_space_ignoring_expansion_inner(children_cache, tree_entries, space_id, level, parent_mask, &mut visited);
+}
+
+fn build_tree_for_space_ignoring_expansion_inner(
+    children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
+    tree_entries: &mut Vec<TreeEntry>,
+    space_id: &OwnedRoomId,
+    level: usize,
+    parent_mask: u32,
+    visited: &mut HashSet<OwnedRoomId>,
+) {
+    let Some(children) = children_cache.get(space_id) else { return };
+
+    // Preserve the SDK's spec-compliant `m.space.child` ordering (see above).
+    let sorted_children: Vec<_> = children.iter().collect();
+
+    let count = sorted_children.len();
+    for (i, child) in sorted_children.into_iter().enumerate() {
+        if !visited.insert(child.room_id.clone()) {
+            continue;
+        }
+
+        let is_last = i == count - 1;
+        tree_entries.push(TreeEntry::Item {
+            info: SpaceRoomInfo::from(child),
+            parent_space_id: space_id.clone(),
+            level,
+            is_last,
+            parent_mask,
+        });
+
+        if child.is_space() && children_cache.contains_key(&child.room_id) {
+            let child_mask = if is_last {
+                parent_mask
+            } else {
+                parent_mask | (1 << level)
+            };
+            build_tree_for_space_ignoring_expansion_inner(
+                children_cache,
+                tree_entries,
+                &child.room_id,
+                level + 1,
+                child_mask,
+                visited,
+            );
+        }
+    }
 }
 
 /// The view showing the lobby/homepage for a given space.
@@ -1966,7 +2316,7 @@ impl SpaceLobbyScreen {
 
         if self.filter_keywords.is_empty() {
             // No filter: build tree respecting expansion state.
-            Self::build_tree_for_space(
+            build_tree_for_space(
                 &self.children_cache,
                 &self.expanded_spaces,
                 &self.loading_subspaces,
@@ -1979,7 +2329,7 @@ impl SpaceLobbyScreen {
             // Filter active: build tree showing all matching entries
             // plus their ancestor spaces to preserve hierarchy context.
             let kw = self.filter_keywords.to_lowercase();
-            Self::build_filtered_tree(
+            build_filtered_tree(
                 &self.children_cache,
                 &mut new_tree_entries,
                 &root_space_id,
@@ -1990,240 +2340,6 @@ impl SpaceLobbyScreen {
         }
 
         self.tree_entries = new_tree_entries;
-    }
-
-    /// Returns whether the given [`SpaceRoomInfo`] matches the filter keywords.
-    fn matches_filter(info: &SpaceRoomInfo, keywords: &str) -> bool {
-        info.name.to_lowercase().contains(keywords)
-            || info.id.as_str().to_lowercase().contains(keywords)
-            || info.canonical_alias.as_ref()
-                .is_some_and(|a| a.as_str().to_lowercase().contains(keywords))
-            || info.topic.as_ref()
-                .is_some_and(|t| t.to_lowercase().contains(keywords))
-    }
-
-    /// Recursively build a filtered tree that includes only entries matching
-    /// the keywords, plus any ancestor spaces needed to preserve the hierarchy.
-    ///
-    /// Returns `true` if any matching entry was added within this subtree.
-    fn build_filtered_tree(
-        children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
-        tree_entries: &mut Vec<TreeEntry>,
-        space_id: &OwnedRoomId,
-        keywords: &str,
-        level: usize,
-        parent_mask: u32,
-    ) -> bool {
-        let Some(children) = children_cache.get(space_id) else { return false };
-
-        // Sort identically to the unfiltered tree: spaces first, then rooms, both alphabetically.
-        // Keep the order the SpaceRoomList gave us: the SDK already sorts children
-        // per the spec's "Ordering of children within a space" — `m.space.child`
-        // `order`, then the child event's timestamp, then room ID. Re-sorting here
-        // (e.g. spaces-first, alphabetical) would silently discard the ordering a
-        // space's admins deliberately set.
-        let sorted_children: Vec<_> = children.iter().collect();
-
-        // First pass: determine which children have matches (self or descendants)
-        // so we can correctly compute `is_last` for tree line drawing.
-        let matched_indices: Vec<usize> = sorted_children.iter().enumerate().filter_map(|(i, child)| {
-            let info = SpaceRoomInfo::from(*child);
-            let self_matches = Self::matches_filter(&info, keywords);
-            let has_matching_descendants = child.is_space()
-                && children_cache.contains_key(&child.room_id)
-                && Self::subtree_has_match(children_cache, &child.room_id, keywords);
-            if self_matches || has_matching_descendants {
-                Some(i)
-            } else {
-                None
-            }
-        }).collect();
-
-        if matched_indices.is_empty() {
-            return false;
-        }
-
-        // Second pass: emit entries for matched children, preserving hierarchy.
-        for (pos, &child_idx) in matched_indices.iter().enumerate() {
-            let child = sorted_children[child_idx];
-            let is_last = pos == matched_indices.len() - 1;
-            let info = SpaceRoomInfo::from(child);
-            let self_matches = Self::matches_filter(&info, keywords);
-
-            let child_mask = if is_last {
-                parent_mask
-            } else {
-                parent_mask | (1 << level)
-            };
-
-            if child.is_space() && children_cache.contains_key(&child.room_id) {
-                // For spaces: always include if self matches or descendants match.
-                tree_entries.push(TreeEntry::Item {
-                    info,
-                    parent_space_id: space_id.clone(),
-                    level,
-                    is_last,
-                    parent_mask,
-                });
-                // Recurse into child space: if the space itself matches,
-                // show ALL of its children (unfiltered); otherwise show only
-                // the matching descendants.
-                if self_matches {
-                    // Show all children of a matching space (no further filtering).
-                    Self::build_tree_for_space_ignoring_expansion(
-                        children_cache,
-                        tree_entries,
-                        &child.room_id,
-                        level + 1,
-                        child_mask,
-                    );
-                } else {
-                    // Space doesn't match, but some descendant does — recurse with filter.
-                    Self::build_filtered_tree(
-                        children_cache,
-                        tree_entries,
-                        &child.room_id,
-                        keywords,
-                        level + 1,
-                        child_mask,
-                    );
-                }
-            } else if self_matches {
-                // Non-space room or space without cached children: include only if it matches.
-                tree_entries.push(TreeEntry::Item {
-                    info,
-                    parent_space_id: space_id.clone(),
-                    level,
-                    is_last,
-                    parent_mask,
-                });
-            }
-        }
-
-        true
-    }
-
-    /// Returns `true` if any entry in the subtree rooted at `space_id` matches the keywords.
-    fn subtree_has_match(
-        children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
-        space_id: &OwnedRoomId,
-        keywords: &str,
-    ) -> bool {
-        let Some(children) = children_cache.get(space_id) else { return false };
-        children.iter().any(|child| {
-            let info = SpaceRoomInfo::from(child);
-            Self::matches_filter(&info, keywords)
-                || (child.is_space() && Self::subtree_has_match(children_cache, &child.room_id, keywords))
-        })
-    }
-
-    /// Like [`build_tree_for_space`] but ignores expansion state — shows all children.
-    /// Used to display the full contents of a space that itself matched the filter.
-    fn build_tree_for_space_ignoring_expansion(
-        children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
-        tree_entries: &mut Vec<TreeEntry>,
-        space_id: &OwnedRoomId,
-        level: usize,
-        parent_mask: u32,
-    ) {
-        let Some(children) = children_cache.get(space_id) else { return };
-
-        // Preserve the SDK's spec-compliant `m.space.child` ordering (see above).
-        let sorted_children: Vec<_> = children.iter().collect();
-
-        let count = sorted_children.len();
-        for (i, child) in sorted_children.into_iter().enumerate() {
-            let is_last = i == count - 1;
-            tree_entries.push(TreeEntry::Item {
-                info: SpaceRoomInfo::from(child),
-                parent_space_id: space_id.clone(),
-                level,
-                is_last,
-                parent_mask,
-            });
-
-            if child.is_space() && children_cache.contains_key(&child.room_id) {
-                let child_mask = if is_last {
-                    parent_mask
-                } else {
-                    parent_mask | (1 << level)
-                };
-                Self::build_tree_for_space_ignoring_expansion(
-                    children_cache,
-                    tree_entries,
-                    &child.room_id,
-                    level + 1,
-                    child_mask,
-                );
-            }
-        }
-    }
-
-    /// Recursively build the tree of spaces and their expanded children such that they
-    /// can be displayed in the SpaceLobbyScreen's PortalList.
-    //
-    // Note: this is intentionally *not* a method (it doesn't take &mut self),
-    // in order to make it possible to recursively call it while immutably borrowing
-    // only select fields of `Self`.
-    fn build_tree_for_space(
-        children_cache: &HashMap<OwnedRoomId, Vector<SpaceRoom>>,
-        expanded_spaces: &HashSet<OwnedRoomId>,
-        loading_subspaces: &HashSet<OwnedRoomId>,
-        tree_entries: &mut Vec<TreeEntry>,
-        space_id: &OwnedRoomId,
-        level: usize,
-        parent_mask: u32,
-    ) {
-        let Some(children) = children_cache.get(space_id) else { return };
-
-        // Sort: spaces first, then rooms, both alphabetically
-        // Preserve the SDK's spec-compliant `m.space.child` ordering (see above).
-        let sorted_children: Vec<_> = children.iter().collect();
-
-        
-        let count = sorted_children.len();
-        for (i, child) in sorted_children.into_iter().enumerate() {
-            let is_last = i == count - 1;
-            
-            tree_entries.push(TreeEntry::Item {
-                info: SpaceRoomInfo::from(child),
-                parent_space_id: space_id.clone(),
-                level,
-                is_last,
-                parent_mask,
-            });
-
-            // If this is an expanded space, recursively add its children or a loading indicator
-            if child.is_space() && expanded_spaces.contains(&child.room_id) {
-                // Calculate mask for children:
-                // If we are NOT the last child, our level needs a continuation line for our children.
-                // If we ARE the last child, our level does NOT need a line.
-                // Parent levels are preserved.
-                let child_mask = if is_last {
-                    parent_mask
-                } else {
-                    parent_mask | (1 << level)
-                };
-
-                if children_cache.contains_key(&child.room_id) {
-                    Self::build_tree_for_space(
-                        children_cache,
-                        expanded_spaces,
-                        loading_subspaces,
-                        tree_entries,
-                        &child.room_id,
-                        level + 1,
-                        child_mask,
-                    );
-                } else if loading_subspaces.contains(&child.room_id) {
-                    // Show loading indicator
-                    tree_entries.push(TreeEntry::Loading { 
-                        level: level + 1,
-                        parent_mask: child_mask,
-                    });
-                }
-            }
-        }
     }
 
     /// Saves the current UI state to the cache. Call this when the screen is being hidden.
@@ -2311,5 +2427,140 @@ impl SpaceLobbyScreenRef {
     pub fn save_current_state(&self) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.save_current_state();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_sdk::ruma::owned_room_id;
+
+    /// Builds a minimal [`SpaceRoom`] fixture for use in tree-building tests.
+    ///
+    /// `children_count` should be non-zero for any node that itself has an
+    /// entry in the `children_cache` map (i.e. is a space), so that
+    /// [`SpaceRoomExt::is_space`] reports it correctly.
+    fn space_room(id: &OwnedRoomId, children_count: u64) -> SpaceRoom {
+        SpaceRoom {
+            room_id: id.clone(),
+            canonical_alias: None,
+            name: Some(id.to_string()),
+            display_name: id.to_string(),
+            topic: None,
+            avatar_url: None,
+            room_type: if children_count > 0 { Some(RoomType::Space) } else { None },
+            num_joined_members: 1,
+            join_rule: None,
+            world_readable: None,
+            guest_can_join: false,
+            is_direct: None,
+            children_count,
+            state: Some(RoomState::Joined),
+            heroes: None,
+            via: Vec::new(),
+            suggested: false,
+        }
+    }
+
+    /// Counts how many `TreeEntry::Item`s in `entries` have the given `room_id`.
+    fn count_room(entries: &[TreeEntry], room_id: &OwnedRoomId) -> usize {
+        entries.iter().filter(|e| matches!(e, TreeEntry::Item { info, .. } if &info.id == room_id)).count()
+    }
+
+    #[test]
+    fn space_tree_cycle_two_nodes_terminates() {
+        let a = owned_room_id!("!a:example.com");
+        let b = owned_room_id!("!b:example.com");
+
+        // A contains B, B contains A: a two-node cycle.
+        let mut children_cache = HashMap::new();
+        children_cache.insert(a.clone(), Vector::from(vec![space_room(&b, 1)]));
+        children_cache.insert(b.clone(), Vector::from(vec![space_room(&a, 1)]));
+
+        let mut expanded = HashSet::new();
+        expanded.insert(a.clone());
+        expanded.insert(b.clone());
+
+        let mut entries = Vec::new();
+        // Must terminate in finite steps (this call would previously stack-overflow).
+        build_tree_for_space(&children_cache, &expanded, &HashSet::new(), &mut entries, &a, 0, 0);
+
+        assert_eq!(count_room(&entries, &b), 1, "B must appear exactly once as A's child");
+    }
+
+    #[test]
+    fn space_tree_self_loop_ignored() {
+        let a = owned_room_id!("!a:example.com");
+
+        // A contains itself.
+        let mut children_cache = HashMap::new();
+        children_cache.insert(a.clone(), Vector::from(vec![space_room(&a, 1)]));
+
+        let mut expanded = HashSet::new();
+        expanded.insert(a.clone());
+
+        let mut entries = Vec::new();
+        build_tree_for_space(&children_cache, &expanded, &HashSet::new(), &mut entries, &a, 0, 0);
+
+        assert!(entries.is_empty(), "A must not appear as its own child: {entries:?}");
+    }
+
+    #[test]
+    fn space_tree_duplicate_edges_deduplicated() {
+        let a = owned_room_id!("!a:example.com");
+        let r = owned_room_id!("!r:example.com");
+
+        // A has two edges pointing to the same child room R.
+        let mut children_cache = HashMap::new();
+        children_cache.insert(a.clone(), Vector::from(vec![space_room(&r, 0), space_room(&r, 0)]));
+
+        let mut entries = Vec::new();
+        build_tree_for_space(&children_cache, &HashSet::new(), &HashSet::new(), &mut entries, &a, 0, 0);
+
+        assert_eq!(count_room(&entries, &r), 1, "R must appear exactly once despite the duplicate edge");
+    }
+
+    #[test]
+    fn space_tree_deep_chain_fully_built() {
+        // Build a 50-level-deep chain: root -> s1 -> s2 -> ... -> s50, no cycles.
+        const DEPTH: usize = 50;
+        let ids: Vec<OwnedRoomId> = (0..=DEPTH)
+            .map(|i| OwnedRoomId::try_from(format!("!s{i}:example.com")).unwrap())
+            .collect();
+
+        let mut children_cache = HashMap::new();
+        let mut expanded = HashSet::new();
+        for i in 0..DEPTH {
+            let parent = &ids[i];
+            let child = &ids[i + 1];
+            // Every level but the last has one child, and each such space is expanded.
+            children_cache.insert(parent.clone(), Vector::from(vec![space_room(child, 1)]));
+            expanded.insert(parent.clone());
+        }
+
+        let mut entries = Vec::new();
+        build_tree_for_space(&children_cache, &expanded, &HashSet::new(), &mut entries, &ids[0], 0, 0);
+
+        // All 50 descendant levels (ids[1..=50]) must appear in the tree.
+        for id in &ids[1..=DEPTH] {
+            assert_eq!(count_room(&entries, id), 1, "node {id} missing from the fully-expanded deep chain");
+        }
+        assert_eq!(entries.len(), DEPTH, "expected exactly {DEPTH} entries in the deep chain");
+    }
+
+    #[test]
+    fn space_tree_filter_terminates_on_cycle() {
+        let a = owned_room_id!("!a:example.com");
+        let b = owned_room_id!("!b:example.com");
+
+        // A <-> B cycle.
+        let mut children_cache = HashMap::new();
+        children_cache.insert(a.clone(), Vector::from(vec![space_room(&b, 1)]));
+        children_cache.insert(b.clone(), Vector::from(vec![space_room(&a, 1)]));
+
+        // Must return in finite steps regardless of the keyword or which node we start from.
+        let _ = subtree_has_match(&children_cache, &a, "anything");
+        let _ = subtree_has_match(&children_cache, &b, "anything");
+        let _ = subtree_has_match(&children_cache, &a, "");
     }
 }

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -5,7 +5,7 @@
 //! 1. a narrow vertical strip, when in Desktop (widescreen) mode,
 //! 2. a wide, short horizontal strip, when in Mobile (narrowscreen) mode.
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use crossbeam_queue::SegQueue;
 use makepad_widgets::*;
@@ -548,6 +548,21 @@ pub fn build_space_search_text(
     search_text
 }
 
+/// Rebuilds the flat `displayed_spaces` list from the full `all_joined_spaces` map,
+/// in insertion order.
+///
+/// Used by [`SpacesBar::update_displayed_spaces`] on the search-clear and
+/// filter-empty-result paths. This is a pure, `&self`/Widget-free function (its
+/// only input is the map itself) so it can be unit-tested directly: the whole
+/// point is that its output order must match `all_joined_spaces`'s insertion
+/// order, which only holds because `all_joined_spaces` is an `IndexMap` — the
+/// same order the incremental `adjust_displayed_spaces` path produces.
+pub(crate) fn rebuild_displayed_spaces_from_all(
+    all_joined_spaces: &IndexMap<OwnedRoomId, JoinedSpaceInfo>,
+) -> Vec<OwnedRoomId> {
+    all_joined_spaces.keys().cloned().collect()
+}
+
 
 
 /// The possible updates that should be displayed by the single list of all spaces.
@@ -635,7 +650,14 @@ pub struct SpacesBar {
     #[deref] view: AdaptiveView,
 
     /// The set of all joined spaces, keyed by the space ID.
-    #[rust] all_joined_spaces: HashMap<OwnedRoomId, JoinedSpaceInfo>,
+    ///
+    /// This uses `IndexMap` (rather than `HashMap`) so that its key iteration
+    /// order is deterministic insertion order. `update_displayed_spaces` rebuilds
+    /// `displayed_spaces` by iterating this map's keys on the search-clear and
+    /// filter-empty-result paths, and that rebuilt order must match the order
+    /// produced by the incremental `adjust_displayed_spaces` path — otherwise the
+    /// sidebar's space order drifts every time the user searches then clears.
+    #[rust] all_joined_spaces: IndexMap<OwnedRoomId, JoinedSpaceInfo>,
 
     /// The currently-active filter function for the list of spaces.
     ///
@@ -1095,7 +1117,9 @@ impl SpacesBar {
                 }
 
                 SpacesListUpdate::RemoveSpace { space_id, .. } => {
-                    self.all_joined_spaces.remove(&space_id);
+                    // `shift_remove` (not `swap_remove`) preserves the insertion
+                    // order of the remaining entries.
+                    self.all_joined_spaces.shift_remove(&space_id);
                     adjust_displayed_spaces(true, false, space_id, &mut self.displayed_spaces);
                 }
 
@@ -1126,7 +1150,7 @@ impl SpacesBar {
             // Reset each of the displayed_* lists to show all rooms.
             self.is_filtered = false;
             self.display_filter = RoomDisplayFilter::default();
-            self.displayed_spaces = self.all_joined_spaces.keys().cloned().collect();
+            self.displayed_spaces = rebuild_displayed_spaces_from_all(&self.all_joined_spaces);
             portal_list.set_first_id_and_scroll(0, 0.0);
             self.redraw(cx);
             return;
@@ -1157,7 +1181,7 @@ impl SpacesBar {
         if self.displayed_spaces.is_empty() {
             self.is_filtered = false;
             self.display_filter = RoomDisplayFilter::default();
-            self.displayed_spaces = self.all_joined_spaces.keys().cloned().collect();
+            self.displayed_spaces = rebuild_displayed_spaces_from_all(&self.all_joined_spaces);
         }
 
         portal_list.set_first_id_and_scroll(0, 0.0);
@@ -1183,5 +1207,46 @@ impl SpacesBarRef {
             }
         }
         items
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matrix_sdk::ruma::owned_room_id;
+
+    /// Builds a minimal [`JoinedSpaceInfo`] fixture for insertion-order tests.
+    fn joined_space_info(space_id: &OwnedRoomId) -> JoinedSpaceInfo {
+        JoinedSpaceInfo {
+            space_name_id: RoomNameId::new(RoomDisplayName::Named(space_id.to_string()), space_id.clone()),
+            search_text: space_id.as_str().to_lowercase(),
+            canonical_alias: None,
+            topic: None,
+            space_avatar: FetchedRoomAvatar::default(),
+            num_joined_members: 1,
+            join_rule: None,
+            world_readable: None,
+            guest_can_join: false,
+            children_count: 0,
+        }
+    }
+
+    #[test]
+    fn spaces_bar_rebuild_preserves_insertion_order() {
+        let space_c = owned_room_id!("!c:example.com");
+        let space_a = owned_room_id!("!a:example.com");
+        let space_b = owned_room_id!("!b:example.com");
+
+        // Insert in the order C, A, B (deliberately not alphabetical, to catch
+        // any accidental re-sorting).
+        let mut all_joined_spaces = IndexMap::new();
+        all_joined_spaces.insert(space_c.clone(), joined_space_info(&space_c));
+        all_joined_spaces.insert(space_a.clone(), joined_space_info(&space_a));
+        all_joined_spaces.insert(space_b.clone(), joined_space_info(&space_b));
+
+        // Simulate the search-clear / filter-empty-result rebuild path.
+        let rebuilt = rebuild_displayed_spaces_from_all(&all_joined_spaces);
+
+        assert_eq!(rebuilt, vec![space_c, space_a, space_b]);
     }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6625,23 +6625,45 @@ fn clear_sso_prebuild_failure_flag() {
     let _ = std::fs::remove_file(sso_prebuild_failure_flag_path());
 }
 
+/// Attaches a child room (or subspace) to the given parent space.
+///
+/// Mirrors [`detach_room_from_space`]'s best-effort semantics: the primary
+/// write (`m.space.child` in the parent space) is what actually attaches the
+/// room, so only *its* failure is propagated as an `Err`. The reverse
+/// `m.space.parent` backlink in the child room is advisory — we may lack
+/// permission to write state there even though we could write `m.space.child`
+/// in the parent space (e.g. we're a space admin but not a mod in the child
+/// room) — so a failure there is only logged via [`warning!`], never
+/// propagated. This keeps the reported outcome consistent with what the
+/// server actually did: the attach succeeded.
 async fn attach_room_to_space(client: &Client, child_room: &Room, space_id: &OwnedRoomId) -> Result<()> {
-    let user_id = client.user_id().ok_or_else(|| anyhow!("Current user ID not found"))?;
     let space_room = client.get_room(space_id)
         .ok_or_else(|| anyhow!("Selected space {space_id} was not found"))?;
-    let child_power_levels = child_room.power_levels().await?;
 
     let child_route = room_route_with_fallback(child_room).await;
     space_room
         .send_state_event_for_key(child_room.room_id(), SpaceChildEventContent::new(child_route))
         .await?;
 
-    if child_power_levels.user_can_send_state(user_id, StateEventType::SpaceParent) {
+    // Best-effort: also set the reverse `m.space.parent` link in the child room.
+    // We may not have permission to write state there, and that must not fail
+    // the overall attach — the `m.space.child` write above already succeeded
+    // and is what actually attaches the room to the space.
+    if let Some(user_id) = client.user_id()
+        && let Ok(child_power_levels) = child_room.power_levels().await
+        && child_power_levels.user_can_send_state(user_id, StateEventType::SpaceParent)
+    {
         let mut parent_content = SpaceParentEventContent::new(room_route_with_fallback(&space_room).await);
         parent_content.canonical = true;
-        child_room
+        if let Err(error) = child_room
             .send_state_event_for_key(space_room.room_id(), parent_content)
-            .await?;
+            .await
+        {
+            warning!(
+                "Attached {} to space {space_id}, but failed to set its m.space.parent: {error}",
+                child_room.room_id(),
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Implements `specs/task-space-tree-hardening.spec.md` (design: `docs/superpowers/specs/2026-08-18-space-completion-design.md`). Fixes three confirmed Space defects and adds the first batch of unit tests for the space core logic.

### A — Tree recursion cycle guards (`space_lobby.rs`, `rooms_list.rs`)

`m.space.child` relationships are legally allowed to form cycles per the Matrix spec, but `build_tree_for_space`, `build_filtered_tree`, `subtree_has_match`, `build_tree_for_space_ignoring_expansion`, and `rooms_list.rs::is_room_indirectly_in_space` all recursed with no cycle protection — a stack-overflow crash risk. Added a `visited: HashSet<OwnedRoomId>` guard to each (not a depth limit, which would truncate legitimately deep trees).

The four `space_lobby.rs` tree-building functions were pulled out of `impl SpaceLobbyScreen` into plain module-level free functions that take only explicit inputs (children map, expansion set, filter keywords), so they're directly unit-testable without any Makepad `Cx`/`Widget` machinery. `rebuild_tree_entries` is now a thin wrapper around them.

New tests: `space_tree_cycle_two_nodes_terminates`, `space_tree_self_loop_ignored`, `space_tree_duplicate_edges_deduplicated`, `space_tree_deep_chain_fully_built` (50-level chain), `space_tree_filter_terminates_on_cycle`.

### B — Stable sidebar order (`spaces_bar.rs`)

`all_joined_spaces` was a `HashMap`, so `update_displayed_spaces`'s search-clear and filter-empty-result paths (which rebuild `displayed_spaces` from `all_joined_spaces.keys()`) produced drifting order, inconsistent with the incremental `adjust_displayed_spaces` path. Switched to `indexmap::IndexMap` (already a project dependency — no new deps added), so key iteration order equals insertion order. `RemoveSpace` now uses `shift_remove` (not `swap_remove`) to preserve order.

Extracted the rebuild logic into a pure `rebuild_displayed_spaces_from_all` free function for testability.

New test: `spaces_bar_rebuild_preserves_insertion_order`.

### C — Best-effort attach semantics (`sliding_sync.rs`, `space_lobby.rs`)

`attach_room_to_space` wrote `m.space.child` (the actual attach) and then `m.space.parent` (an advisory backlink) with `?`, so a permission failure on the backlink alone caused the whole attach to be reported as failed even though the room was actually attached server-side. Mirrored `detach_room_from_space`'s existing best-effort pattern: the `m.space.child` write is still propagated as an `Err`; a `m.space.parent` failure is now only logged via `warning!`.

`SpaceChildAction::Added` now triggers `refresh_space_children` regardless of whether an error was reported, so the UI always reconciles with the actual server-side hierarchy. `SpaceChildAction::Removed` keeps its original success-only refresh (detach is already fully best-effort at the request layer).

## Boundaries respected

- No new cargo dependencies (`indexmap` was already a dependency).
- `space_service_sync.rs` untouched.
- No DSL/visual template changes — logic-only.
- No `cargo fmt` run.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test --lib` — 669 passed, 0 failed, 4 ignored (includes all 6 new tests above)
- [ ] Manual: search-then-clear preserves sidebar order (`manual_test_spaces_bar_order_survives_search_clear`)
- [ ] Manual: attach with split permissions (space child-write OK, child parent-write denied) reports success and refreshes (`manual_test_attach_partial_failure_reports_success`, `manual_test_attach_always_refreshes_children`)
- [ ] Manual: repeated attach of the same room is idempotent (`manual_test_attach_retry_idempotent`)

⏳ Awaiting user manual testing before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)